### PR TITLE
feat: Raids - roster sync, auto-link, overlords, signup alerts, weekly reports

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,6 +17,18 @@ All commands are Discord slash commands registered to a single guild.
 | `/setup set_channel` | Assign a Discord channel to a bot purpose | Yes | No |
 | `/setup set_role` | Assign a Discord role to a bot purpose | Yes | No |
 | `/setup get_config` | View current channel/role configuration | Yes | No |
+| `/raiders get_raiders` | List all tracked raiders | Yes | No |
+| `/raiders get_ignored_characters` | List all ignored characters | Yes | No |
+| `/raiders ignore_character` | Add a character to the ignore list (removes from raiders) | Yes | No |
+| `/raiders remove_ignore_character` | Remove a character from the ignore list | Yes | No |
+| `/raiders sync_raiders` | Manually trigger a Raider.io roster sync | Yes | No |
+| `/raiders check_missing_users` | Find raiders without a linked Discord user and run auto-match | Yes | No |
+| `/raiders update_raider_user` | Manually link a raider character to a Discord user | Yes | No |
+| `/raiders previous_highest_mythicplus` | Generate last week's highest M+ run report as a file | Yes | No |
+| `/raiders previous_great_vault` | Generate last week's Great Vault eligibility report as a file | Yes | No |
+| `/raiders add_overlord` | Add an overlord (officer with special permissions) | Yes | No |
+| `/raiders get_overlords` | List all configured overlords | Yes | No |
+| `/raiders remove_overlord` | Remove an overlord | Yes | No |
 
 ## Notes
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -6,11 +6,12 @@ Used for guild roster, M+ rankings, and raid progression data.
 
 Base URL: `https://raider.io/api/v1`
 
-| Endpoint | Description | Status |
-|---|---|---|
-| `GET /guilds/profile` | Guild profile with roster | Placeholder |
-| `GET /mythic-plus/runs` | M+ run history for a character | Placeholder |
-| `GET /raiding/progression` | Raid progression tiers | Placeholder |
+| Endpoint | Function | Description | Status |
+|---|---|---|---|
+| `GET /guilds/profile?fields=members` | `getGuildRoster()` | Fetches full guild roster; filters to rank 0, 1, 3, 4, 5, 7 | Implemented |
+| `GET /raiding/raid-rankings` | `getRaidRankings(raidSlug)` | World/region Mythic raid rankings for a given raid tier | Implemented |
+| `GET /raiding/static-data` | `getRaidStaticData(expansionId)` | Raid and encounter metadata for a given expansion | Implemented |
+| `GET /characters/profile?fields=mythic_plus_previous_weekly_highest_level_runs` | `getWeeklyMythicPlusRuns(region, realm, name)` | Previous week's highest M+ key run for a character | Implemented |
 
 Authentication: none required for public endpoints. Guild IDs configured via `RAIDERIO_GUILD_IDS`.
 
@@ -20,11 +21,11 @@ Used for raid sign-ups, attendance, and historical raid data.
 
 Base URL: `https://wowaudit.com/v1`
 
-| Endpoint | Description | Status |
-|---|---|---|
-| `GET /raids` | Upcoming and historical raids | Placeholder |
-| `GET /raids/:id` | Raid detail with sign-ups | Placeholder |
-| `GET /characters` | Guild roster with audit data | Placeholder |
+| Endpoint | Function | Description | Status |
+|---|---|---|---|
+| `GET /period` | `getCurrentPeriod()` (internal) | Returns the current WoW Audit period number; used internally by `getHistoricalData()` | Implemented |
+| `GET /raids?include_past=false` | `getUpcomingRaids()` | Lists upcoming raids with sign-up details (character name, realm, class, status) | Implemented |
+| `GET /historical_data?period=<n>` | `getHistoricalData()` | Fetches historical raid data for the previous period; used for Great Vault report generation | Implemented |
 
 Authentication: Bearer token via `WOWAUDIT_API_SECRET`.
 
@@ -43,4 +44,4 @@ Authentication: OAuth2 client credentials via `WARCRAFTLOGS_CLIENT_ID` / `WARCRA
 
 ---
 
-Service wrappers live in `src/services/`. Each service exports typed async functions consumed by scheduler jobs and command handlers. Actual endpoint implementations will be documented here as they are built.
+Service wrappers live in `src/services/`. Each service exports typed async functions consumed by scheduler jobs and command handlers.

--- a/src/commands/raiders.ts
+++ b/src/commands/raiders.ts
@@ -1,0 +1,403 @@
+import {
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  MessageFlags,
+  PermissionFlagsBits,
+  AttachmentBuilder,
+} from 'discord.js';
+import { getDatabase } from '../database/db.js';
+import { requireOfficer, createEmbed, audit } from '../utils.js';
+import { syncRaiders } from '../functions/raids/syncRaiders.js';
+import { autoMatchRaiders } from '../functions/raids/autoMatchRaiders.js';
+import { sendAlertForRaidersWithNoUser } from '../functions/raids/sendAlertForRaidersWithNoUser.js';
+import { updateRaiderDiscordUser } from '../functions/raids/updateRaiderDiscordUser.js';
+import { ignoreCharacter } from '../functions/raids/ignoreCharacter.js';
+import { addOverlord, removeOverlord, getOverlords } from '../functions/raids/overlords.js';
+import {
+  generateMythicPlusReport,
+  generateGreatVaultReport,
+} from '../functions/raids/alertHighestMythicPlusDone.js';
+import { getHistoricalData } from '../services/wowaudit.js';
+import type { RaiderRow, IgnoredCharacterRow } from '../types/index.js';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('raiders')
+    .setDescription('Manage raiders')
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+    .addSubcommand((sub) =>
+      sub.setName('get_raiders').setDescription('List all raiders'),
+    )
+    .addSubcommand((sub) =>
+      sub.setName('get_ignored_characters').setDescription('List all ignored characters'),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('ignore_character')
+        .setDescription('Ignore a character from raider tracking')
+        .addStringOption((opt) =>
+          opt.setName('character_name').setDescription('Character name').setRequired(true),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('remove_ignore_character')
+        .setDescription('Remove a character from the ignore list')
+        .addStringOption((opt) =>
+          opt.setName('character_name').setDescription('Character name').setRequired(true),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub.setName('sync_raiders').setDescription('Manually trigger a raider sync'),
+    )
+    .addSubcommand((sub) =>
+      sub.setName('check_missing_users').setDescription('Check for raiders without linked Discord users'),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('update_raider_user')
+        .setDescription('Link a raider to a Discord user')
+        .addStringOption((opt) =>
+          opt.setName('character_name').setDescription('Character name').setRequired(true),
+        )
+        .addUserOption((opt) =>
+          opt.setName('user').setDescription('Discord user').setRequired(true),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub.setName('previous_highest_mythicplus').setDescription('Generate previous week M+ report'),
+    )
+    .addSubcommand((sub) =>
+      sub.setName('previous_great_vault').setDescription('Generate previous week Great Vault report'),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('add_overlord')
+        .setDescription('Add an overlord')
+        .addStringOption((opt) =>
+          opt.setName('name').setDescription('Overlord name').setRequired(true),
+        )
+        .addUserOption((opt) =>
+          opt.setName('user').setDescription('Discord user').setRequired(true),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub.setName('get_overlords').setDescription('List all overlords'),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('remove_overlord')
+        .setDescription('Remove an overlord')
+        .addStringOption((opt) =>
+          opt.setName('name').setDescription('Overlord name').setRequired(true),
+        ),
+    ),
+  async execute(interaction: ChatInputCommandInteraction) {
+    const subcommand = interaction.options.getSubcommand();
+
+    // get_raiders is viewable by any admin (no officer check)
+    if (subcommand !== 'get_raiders') {
+      if (!(await requireOfficer(interaction))) return;
+    }
+
+    const db = getDatabase();
+
+    switch (subcommand) {
+      case 'get_raiders': {
+        const raiders = db
+          .prepare('SELECT * FROM raiders ORDER BY character_name')
+          .all() as RaiderRow[];
+
+        if (raiders.length === 0) {
+          await interaction.reply({
+            content: 'No raiders found.',
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        // Build pages of raider listings
+        const lines = raiders.map(
+          (r) =>
+            `**${r.character_name}** (${r.realm}) - ${r.class ?? 'Unknown'} | ${r.discord_user_id ? `<@${r.discord_user_id}>` : 'Unlinked'}`,
+        );
+
+        const pages: string[] = [];
+        let current = '';
+        for (const line of lines) {
+          if ((current + '\n' + line).length > 2000) {
+            pages.push(current);
+            current = line;
+          } else {
+            current = current ? current + '\n' + line : line;
+          }
+        }
+        if (current) pages.push(current);
+
+        // Send first page as embed
+        const embed = createEmbed(`Raiders (${raiders.length} total)`).setDescription(
+          pages[0],
+        );
+
+        if (pages.length > 1) {
+          embed.setFooter({ text: `Page 1/${pages.length} | SeriouslyCasualBot` });
+        }
+
+        await interaction.reply({ embeds: [embed] });
+
+        // Send remaining pages as follow-ups
+        for (let i = 1; i < pages.length; i++) {
+          const pageEmbed = createEmbed().setDescription(pages[i]).setFooter({
+            text: `Page ${i + 1}/${pages.length} | SeriouslyCasualBot`,
+          });
+          await interaction.followUp({ embeds: [pageEmbed] });
+        }
+        break;
+      }
+
+      case 'get_ignored_characters': {
+        const ignored = db
+          .prepare('SELECT * FROM ignored_characters ORDER BY character_name')
+          .all() as IgnoredCharacterRow[];
+
+        const list =
+          ignored.length > 0
+            ? ignored.map((ic) => `- ${ic.character_name}`).join('\n')
+            : 'No ignored characters.';
+
+        await interaction.reply({
+          content: `**Ignored Characters:**\n${list}`,
+          flags: MessageFlags.Ephemeral,
+        });
+        break;
+      }
+
+      case 'ignore_character': {
+        const characterName = interaction.options.getString('character_name', true);
+        const success = ignoreCharacter(characterName);
+
+        if (success) {
+          await audit(interaction.user, 'ignored character', characterName);
+          await interaction.reply({
+            content: `Ignored **${characterName}** and removed from raiders.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        } else {
+          await interaction.reply({
+            content: `Failed to ignore **${characterName}**.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+        break;
+      }
+
+      case 'remove_ignore_character': {
+        const characterName = interaction.options.getString('character_name', true);
+        const result = db
+          .prepare('DELETE FROM ignored_characters WHERE character_name = ?')
+          .run(characterName);
+
+        if (result.changes > 0) {
+          await audit(interaction.user, 'removed ignore for character', characterName);
+          await interaction.reply({
+            content: `Removed **${characterName}** from the ignore list.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        } else {
+          await interaction.reply({
+            content: `**${characterName}** was not in the ignore list.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+        break;
+      }
+
+      case 'sync_raiders': {
+        await interaction.reply({
+          content: 'Syncing raiders...',
+          flags: MessageFlags.Ephemeral,
+        });
+
+        try {
+          await syncRaiders(interaction.client);
+          await interaction.editReply({ content: 'Raider sync complete.' });
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error(String(error));
+          await interaction.editReply({
+            content: `Sync failed: ${err.message}`,
+          });
+        }
+        break;
+      }
+
+      case 'check_missing_users': {
+        const unlinked = db
+          .prepare('SELECT * FROM raiders WHERE discord_user_id IS NULL')
+          .all() as RaiderRow[];
+
+        if (unlinked.length === 0) {
+          await interaction.reply({
+            content: 'All raiders are linked to Discord users.',
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        const guild = interaction.guild;
+        if (!guild) {
+          await interaction.reply({
+            content: 'This command must be used in a guild.',
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        await interaction.reply({
+          content: `Found ${unlinked.length} unlinked raiders. Running auto-match...`,
+          flags: MessageFlags.Ephemeral,
+        });
+
+        const matches = await autoMatchRaiders(guild, unlinked);
+        await sendAlertForRaidersWithNoUser(interaction.client, unlinked, matches);
+
+        await interaction.editReply({
+          content: `Found ${unlinked.length} unlinked raiders. Auto-matched ${matches.length}. Alerts sent to raider-setup channel.`,
+        });
+        break;
+      }
+
+      case 'update_raider_user': {
+        const characterName = interaction.options.getString('character_name', true);
+        const user = interaction.options.getUser('user', true);
+
+        const success = await updateRaiderDiscordUser(
+          interaction.client,
+          characterName,
+          user.id,
+        );
+
+        if (success) {
+          await audit(interaction.user, 'linked raider', `${characterName} -> ${user.tag}`);
+          await interaction.reply({
+            content: `Linked **${characterName}** to ${user}.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        } else {
+          await interaction.reply({
+            content: `Failed to link **${characterName}**. Raider may not exist.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+        break;
+      }
+
+      case 'previous_highest_mythicplus': {
+        await interaction.reply({ content: 'Generating M+ report...' });
+
+        try {
+          const raiders = db
+            .prepare('SELECT * FROM raiders ORDER BY character_name')
+            .all() as RaiderRow[];
+
+          const content = await generateMythicPlusReport(raiders);
+          const dateStr = new Date().toISOString().split('T')[0];
+          const file = new AttachmentBuilder(Buffer.from(content), {
+            name: `highest_mythicplus_${dateStr}.txt`,
+          });
+
+          await interaction.editReply({
+            content: `**M+ Report** - ${dateStr}`,
+            files: [file],
+          });
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error(String(error));
+          await interaction.editReply({
+            content: `Failed to generate M+ report: ${err.message}`,
+          });
+        }
+        break;
+      }
+
+      case 'previous_great_vault': {
+        await interaction.reply({ content: 'Generating Great Vault report...' });
+
+        try {
+          const raiders = db
+            .prepare('SELECT * FROM raiders ORDER BY character_name')
+            .all() as RaiderRow[];
+
+          const historicalData = await getHistoricalData();
+          const content = await generateGreatVaultReport(raiders, historicalData);
+          const dateStr = new Date().toISOString().split('T')[0];
+          const file = new AttachmentBuilder(Buffer.from(content), {
+            name: `great_vaults_${dateStr}.txt`,
+          });
+
+          await interaction.editReply({
+            content: `**Great Vault Report** - ${dateStr}`,
+            files: [file],
+          });
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error(String(error));
+          await interaction.editReply({
+            content: `Failed to generate Great Vault report: ${err.message}`,
+          });
+        }
+        break;
+      }
+
+      case 'add_overlord': {
+        const name = interaction.options.getString('name', true);
+        const user = interaction.options.getUser('user', true);
+
+        try {
+          addOverlord(name, user.id);
+          await audit(interaction.user, 'added overlord', `${name} (${user.tag})`);
+          await interaction.reply({
+            content: `Added overlord **${name}** (${user}).`,
+            flags: MessageFlags.Ephemeral,
+          });
+        } catch {
+          await interaction.reply({
+            content: `Failed to add overlord **${name}**. They may already exist.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+        break;
+      }
+
+      case 'get_overlords': {
+        const overlords = getOverlords();
+        const list =
+          overlords.length > 0
+            ? overlords.map((o) => `- **${o.name}**: <@${o.user_id}>`).join('\n')
+            : 'No overlords configured.';
+
+        await interaction.reply({
+          content: `**Overlords:**\n${list}`,
+          flags: MessageFlags.Ephemeral,
+        });
+        break;
+      }
+
+      case 'remove_overlord': {
+        const name = interaction.options.getString('name', true);
+
+        try {
+          removeOverlord(name);
+          await audit(interaction.user, 'removed overlord', name);
+          await interaction.reply({
+            content: `Removed overlord **${name}**.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        } catch {
+          await interaction.reply({
+            content: `Failed to remove overlord **${name}**.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+        break;
+      }
+    }
+  },
+};

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,6 +1,12 @@
 import { type Interaction, MessageFlags } from 'discord.js';
 import type { BotClient } from '../types/index.js';
 import { logger } from '../services/logger.js';
+import { updateRaiderDiscordUser } from '../functions/raids/updateRaiderDiscordUser.js';
+import { ignoreCharacter } from '../functions/raids/ignoreCharacter.js';
+import { sendAlertForRaidersWithNoUser } from '../functions/raids/sendAlertForRaidersWithNoUser.js';
+import { audit } from '../services/auditLog.js';
+import { getDatabase } from '../database/db.js';
+import type { RaiderRow } from '../types/index.js';
 
 export default {
   name: 'interactionCreate',
@@ -31,6 +37,145 @@ export default {
       }
     }
 
-    // Button, modal, and select menu handlers will be added by domain slices
+    // Button handlers
+    if (interaction.isButton()) {
+      const customId = interaction.customId;
+
+      try {
+        // raider:confirm_link:{characterName}:{userId}
+        if (customId.startsWith('raider:confirm_link:')) {
+          const parts = customId.split(':');
+          const characterName = parts[2];
+          const userId = parts[3];
+
+          const success = await updateRaiderDiscordUser(
+            interaction.client,
+            characterName,
+            userId,
+          );
+
+          if (success) {
+            await audit(interaction.user, 'confirmed raider link', `${characterName} -> <@${userId}>`);
+            await interaction.update({
+              content: `Linked **${characterName}** to <@${userId}>!`,
+              components: [],
+            });
+          } else {
+            await interaction.reply({
+              content: `Failed to link **${characterName}**.`,
+              flags: MessageFlags.Ephemeral,
+            });
+          }
+        }
+
+        // raider:reject_link:{characterName}
+        if (customId.startsWith('raider:reject_link:')) {
+          const characterName = customId.split(':')[2];
+
+          try {
+            await interaction.message.delete();
+          } catch {
+            // Message may already be deleted
+          }
+
+          // Post standard missing user alert (unmatched style)
+          const db = getDatabase();
+          const raider = db
+            .prepare('SELECT * FROM raiders WHERE character_name = ?')
+            .get(characterName) as RaiderRow | undefined;
+
+          if (raider) {
+            // Clear the old message_id since we deleted it
+            db.prepare('UPDATE raiders SET message_id = NULL WHERE character_name = ?').run(characterName);
+            await sendAlertForRaidersWithNoUser(interaction.client, [raider], []);
+          }
+        }
+
+        // raider:ignore:{characterName}
+        if (customId.startsWith('raider:ignore:')) {
+          const characterName = customId.split(':')[2];
+          const success = ignoreCharacter(characterName);
+
+          if (success) {
+            await audit(interaction.user, 'ignored character via button', characterName);
+
+            try {
+              await interaction.message.delete();
+            } catch {
+              // Message may already be deleted
+            }
+
+            await interaction.reply({
+              content: `Ignored **${characterName}** and removed from raiders.`,
+              flags: MessageFlags.Ephemeral,
+            });
+          } else {
+            await interaction.reply({
+              content: `Failed to ignore **${characterName}**.`,
+              flags: MessageFlags.Ephemeral,
+            });
+          }
+        }
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        logger.error('interaction', `Button handler failed (${customId}): ${err.message}`, err);
+
+        const reply = { content: 'An error occurred handling this button.', flags: MessageFlags.Ephemeral } as const;
+        if (interaction.replied || interaction.deferred) {
+          await interaction.followUp(reply).catch(() => {});
+        } else {
+          await interaction.reply(reply).catch(() => {});
+        }
+      }
+    }
+
+    // User select menu handlers
+    if (interaction.isUserSelectMenu()) {
+      const customId = interaction.customId;
+
+      try {
+        // raider:select_user:{characterName}
+        if (customId.startsWith('raider:select_user:')) {
+          const characterName = customId.split(':')[2];
+          const selectedUserId = interaction.values[0];
+
+          const success = await updateRaiderDiscordUser(
+            interaction.client,
+            characterName,
+            selectedUserId,
+          );
+
+          if (success) {
+            await audit(interaction.user, 'linked raider via select', `${characterName} -> <@${selectedUserId}>`);
+
+            try {
+              await interaction.message.delete();
+            } catch {
+              // Message may already be deleted
+            }
+
+            await interaction.reply({
+              content: `Linked **${characterName}** to <@${selectedUserId}>.`,
+              flags: MessageFlags.Ephemeral,
+            });
+          } else {
+            await interaction.reply({
+              content: `Failed to link **${characterName}**.`,
+              flags: MessageFlags.Ephemeral,
+            });
+          }
+        }
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        logger.error('interaction', `Select menu handler failed (${customId}): ${err.message}`, err);
+
+        const reply = { content: 'An error occurred handling this selection.', flags: MessageFlags.Ephemeral } as const;
+        if (interaction.replied || interaction.deferred) {
+          await interaction.followUp(reply).catch(() => {});
+        } else {
+          await interaction.reply(reply).catch(() => {});
+        }
+      }
+    }
   },
 };

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -2,6 +2,10 @@ import type { Client } from 'discord.js';
 import { logger } from '../services/logger.js';
 import { Scheduler } from '../scheduler/scheduler.js';
 import { deployCommands } from '../deploy-commands.js';
+import { syncRaiders } from '../functions/raids/syncRaiders.js';
+import { alertSignups } from '../functions/raids/alertSignups.js';
+import { alertHighestMythicPlusDone } from '../functions/raids/alertHighestMythicPlusDone.js';
+import { refreshLinkingMessages } from '../functions/raids/refreshLinkingMessages.js';
 
 export const scheduler = new Scheduler();
 
@@ -20,7 +24,31 @@ export default {
       logger.error('bot', `Failed to register commands: ${err.message}`, err);
     }
 
-    // Scheduled tasks will be registered by domain slices
+    // Register scheduled tasks
+    scheduler.registerInterval({
+      name: 'syncRaiders',
+      intervalMs: 600_000,
+      handler: () => syncRaiders(client),
+    });
+
+    scheduler.registerInterval({
+      name: 'refreshLinkingMessages',
+      intervalMs: 600_000,
+      handler: () => refreshLinkingMessages(client),
+    });
+
+    scheduler.registerCron({
+      name: 'alertSignups',
+      expression: '0 19 * * 1,2,5,6',
+      handler: () => alertSignups(client),
+    });
+
+    scheduler.registerCron({
+      name: 'weeklyReports',
+      expression: '0 12 * * 3',
+      handler: () => alertHighestMythicPlusDone(client),
+    });
+
     scheduler.start();
 
     logger.info('bot', 'Startup complete');

--- a/src/functions/raids/alertHighestMythicPlusDone.ts
+++ b/src/functions/raids/alertHighestMythicPlusDone.ts
@@ -1,0 +1,215 @@
+import { type Client, type TextChannel, ChannelType, AttachmentBuilder } from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { getHistoricalData, type WowAuditHistoricalEntry } from '../../services/wowaudit.js';
+import { getWeeklyMythicPlusRuns } from '../../services/raiderio.js';
+import { logger } from '../../services/logger.js';
+import { config } from '../../config.js';
+import type { ConfigRow, RaiderRow } from '../../types/index.js';
+
+async function getWeeklyCheckChannel(client: Client): Promise<TextChannel | null> {
+  const db = getDatabase();
+
+  const row = db
+    .prepare('SELECT value FROM config WHERE key = ?')
+    .get('weekly_check_channel_id') as ConfigRow | undefined;
+
+  if (row) {
+    try {
+      const channel = await client.channels.fetch(row.value);
+      if (channel && channel.type === ChannelType.GuildText) {
+        return channel as TextChannel;
+      }
+    } catch {
+      logger.warn('WeeklyReports', 'Configured weekly-check channel not found, will auto-create');
+    }
+  }
+
+  // Auto-create the channel
+  try {
+    const guild = await client.guilds.fetch(config.guildId);
+    const channel = await guild.channels.create({
+      name: 'weekly-check',
+      type: ChannelType.GuildText,
+      topic: 'Weekly M+ and Great Vault reports',
+    });
+
+    db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(
+      'weekly_check_channel_id',
+      channel.id,
+    );
+
+    logger.info('WeeklyReports', `Auto-created weekly-check channel: #${channel.name}`);
+    return channel;
+  } catch (error) {
+    logger.error('WeeklyReports', 'Failed to auto-create weekly-check channel', error as Error);
+    return null;
+  }
+}
+
+export async function generateMythicPlusReport(raiders: RaiderRow[]): Promise<string> {
+  const lines: string[] = [];
+  lines.push('Weekly Highest M+ Runs');
+  lines.push('='.repeat(40));
+  lines.push('');
+
+  for (const raider of raiders) {
+    try {
+      const runs = await getWeeklyMythicPlusRuns(
+        raider.region || 'eu',
+        raider.realm || 'silvermoon',
+        raider.character_name,
+      );
+
+      if (runs.length === 0) {
+        lines.push(`${raider.character_name}: None`);
+      } else {
+        const levels = runs.map((r) => r.mythic_level).join(', ');
+        lines.push(`${raider.character_name}: [${levels}]`);
+      }
+    } catch {
+      lines.push(`${raider.character_name}: Error`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function extractVaultOption(
+  data: Record<string, unknown> | undefined,
+  category: string,
+  option: string,
+): string {
+  if (!data) return '-';
+
+  const vaultOptions = data.vault_options as Record<string, unknown> | undefined;
+  if (!vaultOptions) return '-';
+
+  const categoryData = vaultOptions[category] as Record<string, unknown> | undefined;
+  if (!categoryData) return '-';
+
+  const optionData = categoryData[option] as Record<string, unknown> | undefined;
+  if (!optionData) return '-';
+
+  const level = optionData.level ?? optionData.ilvl ?? optionData.item_level ?? '-';
+  return String(level);
+}
+
+export async function generateGreatVaultReport(
+  raiders: RaiderRow[],
+  historicalData: WowAuditHistoricalEntry[],
+): Promise<string> {
+  const lines: string[] = [];
+
+  // Build lookup from historical data
+  const histMap = new Map<string, WowAuditHistoricalEntry>();
+  for (const entry of historicalData) {
+    histMap.set(entry.character.name.toLowerCase(), entry);
+  }
+
+  // Find max name length for alignment
+  const maxNameLen = Math.max(14, ...raiders.map((r) => r.character_name.length));
+
+  const header =
+    'Character Name'.padEnd(maxNameLen + 2) +
+    'Raid'.padEnd(20) +
+    'Dungeon'.padEnd(20) +
+    'World'.padEnd(20);
+
+  lines.push('Weekly Great Vault Report');
+  lines.push('='.repeat(header.length));
+  lines.push('');
+  lines.push(header);
+  lines.push('-'.repeat(header.length));
+
+  for (const raider of raiders) {
+    const entry = histMap.get(raider.character_name.toLowerCase());
+    const data = entry?.data as Record<string, unknown> | undefined;
+
+    const raidOpts = [
+      extractVaultOption(data, 'raids', 'option_1'),
+      extractVaultOption(data, 'raids', 'option_2'),
+      extractVaultOption(data, 'raids', 'option_3'),
+    ].join('/');
+
+    const dungeonOpts = [
+      extractVaultOption(data, 'dungeons', 'option_1'),
+      extractVaultOption(data, 'dungeons', 'option_2'),
+      extractVaultOption(data, 'dungeons', 'option_3'),
+    ].join('/');
+
+    const worldOpts = [
+      extractVaultOption(data, 'world', 'option_1'),
+      extractVaultOption(data, 'world', 'option_2'),
+      extractVaultOption(data, 'world', 'option_3'),
+    ].join('/');
+
+    const line =
+      raider.character_name.padEnd(maxNameLen + 2) +
+      raidOpts.padEnd(20) +
+      dungeonOpts.padEnd(20) +
+      worldOpts.padEnd(20);
+
+    lines.push(line);
+  }
+
+  return lines.join('\n');
+}
+
+export async function alertHighestMythicPlusDone(client: Client): Promise<void> {
+  const db = getDatabase();
+  const raiders = db
+    .prepare('SELECT * FROM raiders ORDER BY character_name')
+    .all() as RaiderRow[];
+
+  if (raiders.length === 0) {
+    logger.info('WeeklyReports', 'No raiders in database, skipping weekly reports');
+    return;
+  }
+
+  const dateStr = new Date().toISOString().split('T')[0];
+
+  // Generate M+ report
+  let mplusContent: string;
+  try {
+    mplusContent = await generateMythicPlusReport(raiders);
+  } catch (error) {
+    logger.error('WeeklyReports', 'Failed to generate M+ report', error as Error);
+    mplusContent = 'Error generating M+ report';
+  }
+
+  // Generate Great Vault report
+  let vaultContent: string;
+  try {
+    const historicalData = await getHistoricalData();
+    vaultContent = await generateGreatVaultReport(raiders, historicalData);
+  } catch (error) {
+    logger.error('WeeklyReports', 'Failed to generate Great Vault report', error as Error);
+    vaultContent = 'Error generating Great Vault report';
+  }
+
+  // Create file attachments
+  const mplusFile = new AttachmentBuilder(Buffer.from(mplusContent), {
+    name: `highest_mythicplus_${dateStr}.txt`,
+  });
+
+  const vaultFile = new AttachmentBuilder(Buffer.from(vaultContent), {
+    name: `great_vaults_${dateStr}.txt`,
+  });
+
+  // Get the weekly-check channel
+  const channel = await getWeeklyCheckChannel(client);
+  if (!channel) {
+    logger.error('WeeklyReports', 'Could not get weekly-check channel');
+    return;
+  }
+
+  try {
+    await channel.send({
+      content: `**Weekly Reports** - ${dateStr}`,
+      files: [mplusFile, vaultFile],
+    });
+    logger.info('WeeklyReports', `Sent weekly reports for ${dateStr}`);
+  } catch (error) {
+    logger.error('WeeklyReports', 'Failed to send weekly reports', error as Error);
+  }
+}

--- a/src/functions/raids/alertSignups.ts
+++ b/src/functions/raids/alertSignups.ts
@@ -1,0 +1,159 @@
+import { type Client, type TextChannel, ChannelType } from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { getUpcomingRaids } from '../../services/wowaudit.js';
+import { logger } from '../../services/logger.js';
+import { config } from '../../config.js';
+import type { ConfigRow, RaiderRow, SettingRow, SignupMessageRow } from '../../types/index.js';
+
+interface DayConfig {
+  settingKey: string;
+  raidDay: string;
+  twoDayReminder: boolean;
+}
+
+const DAY_MAP: Record<number, DayConfig> = {
+  1: { settingKey: 'alertSignup_Wednesday_48', raidDay: 'Wednesday', twoDayReminder: true },
+  2: { settingKey: 'alertSignup_Wednesday', raidDay: 'Wednesday', twoDayReminder: false },
+  5: { settingKey: 'alertSignup_Sunday_48', raidDay: 'Sunday', twoDayReminder: true },
+  6: { settingKey: 'alertSignup_Sunday', raidDay: 'Sunday', twoDayReminder: false },
+};
+
+async function getRaidersLoungeChannel(client: Client): Promise<TextChannel | null> {
+  const db = getDatabase();
+
+  const row = db
+    .prepare('SELECT value FROM config WHERE key = ?')
+    .get('raiders_lounge_channel_id') as ConfigRow | undefined;
+
+  if (row) {
+    try {
+      const channel = await client.channels.fetch(row.value);
+      if (channel && channel.type === ChannelType.GuildText) {
+        return channel as TextChannel;
+      }
+    } catch {
+      logger.warn('AlertSignups', 'Configured raiders-lounge channel not found, will auto-create');
+    }
+  }
+
+  // Auto-create the channel
+  try {
+    const guild = await client.guilds.fetch(config.guildId);
+    const channel = await guild.channels.create({
+      name: 'raiders-lounge',
+      type: ChannelType.GuildText,
+      topic: 'Raider signup alerts and discussion',
+    });
+
+    db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(
+      'raiders_lounge_channel_id',
+      channel.id,
+    );
+
+    logger.info('AlertSignups', `Auto-created raiders-lounge channel: #${channel.name}`);
+    return channel;
+  } catch (error) {
+    logger.error('AlertSignups', 'Failed to auto-create raiders-lounge channel', error as Error);
+    return null;
+  }
+}
+
+export async function alertSignups(client: Client): Promise<void> {
+  const dayOfWeek = new Date().getDay();
+  const dayConfig = DAY_MAP[dayOfWeek];
+
+  if (!dayConfig) {
+    logger.debug('AlertSignups', `No signup alert configured for day ${dayOfWeek}`);
+    return;
+  }
+
+  const db = getDatabase();
+
+  // Check if this alert setting is enabled
+  const settingRow = db
+    .prepare('SELECT value FROM settings WHERE key = ?')
+    .get(dayConfig.settingKey) as SettingRow | undefined;
+
+  if (!settingRow || settingRow.value === 0) {
+    logger.debug('AlertSignups', `Setting ${dayConfig.settingKey} is disabled, skipping`);
+    return;
+  }
+
+  // Fetch upcoming raids from WoW Audit
+  let raids;
+  try {
+    raids = await getUpcomingRaids();
+  } catch (error) {
+    logger.error('AlertSignups', 'Failed to fetch upcoming raids from WoW Audit', error as Error);
+    return;
+  }
+
+  // Find the next Mythic raid with status 'Planned'
+  const nextRaid = raids.find(
+    (r) => r.title.toLowerCase().includes('mythic') && r.note?.toLowerCase() !== 'cancelled',
+  );
+
+  if (!nextRaid) {
+    logger.debug('AlertSignups', 'No upcoming Mythic raid found');
+    return;
+  }
+
+  // Find unsigned raiders (status = 'Unknown')
+  const unsignedCharacters = nextRaid.signups
+    .filter((s) => s.status === 'Unknown')
+    .map((s) => s.character.name.toLowerCase());
+
+  if (unsignedCharacters.length === 0) {
+    // Everyone has signed up!
+    const channel = await getRaidersLoungeChannel(client);
+    if (channel) {
+      await channel.send('Everyone has signed for the next raid!');
+    }
+    logger.info('AlertSignups', 'All raiders have signed up for the next raid');
+    return;
+  }
+
+  // Resolve Discord user IDs for unsigned raiders
+  const raiders = db.prepare('SELECT * FROM raiders').all() as RaiderRow[];
+  const raiderMap = new Map(raiders.map((r) => [r.character_name.toLowerCase(), r]));
+
+  const mentions: string[] = [];
+  for (const charName of unsignedCharacters) {
+    const raider = raiderMap.get(charName);
+    if (raider?.discord_user_id) {
+      mentions.push(`<@${raider.discord_user_id}>`);
+    } else {
+      mentions.push(`**${charName}**`);
+    }
+  }
+
+  // Pick a random signup message
+  const messageRow = db
+    .prepare('SELECT message FROM signup_messages ORDER BY RANDOM() LIMIT 1')
+    .get() as SignupMessageRow | undefined;
+
+  const randomMessage = messageRow?.message ?? 'Sign up for the next raid!';
+
+  // Build the alert message
+  let content = `${randomMessage}\n\nThe following raiders have not signed up for **${dayConfig.raidDay}**:\n${mentions.join(', ')}`;
+
+  // For 48-hour reminders, add relative timestamp
+  if (dayConfig.twoDayReminder) {
+    const raidDate = new Date(nextRaid.date);
+    const unixTimestamp = Math.floor(raidDate.getTime() / 1000);
+    content += `\n\nRaid starts <t:${unixTimestamp}:R>`;
+  }
+
+  const channel = await getRaidersLoungeChannel(client);
+  if (!channel) {
+    logger.error('AlertSignups', 'Could not get raiders-lounge channel');
+    return;
+  }
+
+  try {
+    await channel.send(content);
+    logger.info('AlertSignups', `Sent signup alert for ${dayConfig.raidDay} (${unsignedCharacters.length} unsigned)`);
+  } catch (error) {
+    logger.error('AlertSignups', 'Failed to send signup alert', error as Error);
+  }
+}

--- a/src/functions/raids/autoMatchRaiders.ts
+++ b/src/functions/raids/autoMatchRaiders.ts
@@ -1,0 +1,56 @@
+import type { Guild, GuildMember } from 'discord.js';
+import { logger } from '../../services/logger.js';
+import type { RaiderRow } from '../../types/index.js';
+
+export interface AutoMatch {
+  raider: RaiderRow;
+  suggestedUser: GuildMember;
+}
+
+export async function autoMatchRaiders(
+  guild: Guild,
+  unlinkedRaiders: RaiderRow[],
+): Promise<AutoMatch[]> {
+  if (unlinkedRaiders.length === 0) return [];
+
+  let members;
+  try {
+    members = await guild.members.fetch();
+  } catch (error) {
+    logger.error('AutoMatch', 'Failed to fetch guild members', error as Error);
+    return [];
+  }
+
+  const matches: AutoMatch[] = [];
+
+  for (const raider of unlinkedRaiders) {
+    const charName = raider.character_name.trim().toLowerCase();
+    const matchingMembers: GuildMember[] = [];
+
+    for (const [, member] of members) {
+      const displayName = member.displayName.trim().toLowerCase();
+      const globalDisplayName = member.user.displayName.trim().toLowerCase();
+      const username = member.user.username.trim().toLowerCase();
+
+      if (
+        charName === displayName ||
+        charName === globalDisplayName ||
+        charName === username
+      ) {
+        matchingMembers.push(member);
+      }
+    }
+
+    if (matchingMembers.length === 1) {
+      matches.push({ raider, suggestedUser: matchingMembers[0] });
+    } else if (matchingMembers.length > 1) {
+      logger.debug(
+        'AutoMatch',
+        `Ambiguous match for "${raider.character_name}": ${matchingMembers.length} members matched, skipping`,
+      );
+    }
+  }
+
+  logger.info('AutoMatch', `Found ${matches.length} auto-matches out of ${unlinkedRaiders.length} unlinked raiders`);
+  return matches;
+}

--- a/src/functions/raids/ignoreCharacter.ts
+++ b/src/functions/raids/ignoreCharacter.ts
@@ -1,0 +1,21 @@
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+
+export function ignoreCharacter(characterName: string): boolean {
+  const db = getDatabase();
+
+  try {
+    db.transaction(() => {
+      db.prepare('INSERT OR IGNORE INTO ignored_characters (character_name) VALUES (?)').run(
+        characterName,
+      );
+      db.prepare('DELETE FROM raiders WHERE character_name = ?').run(characterName);
+    })();
+
+    logger.info('IgnoreCharacter', `Ignored and removed raider "${characterName}"`);
+    return true;
+  } catch (error) {
+    logger.error('IgnoreCharacter', `Failed to ignore "${characterName}"`, error as Error);
+    return false;
+  }
+}

--- a/src/functions/raids/overlords.ts
+++ b/src/functions/raids/overlords.ts
@@ -1,0 +1,39 @@
+import type { ThreadChannel } from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import type { OverlordRow } from '../../types/index.js';
+
+export function addOverlord(name: string, userId: string): void {
+  const db = getDatabase();
+  db.prepare('INSERT INTO overlords (name, user_id) VALUES (?, ?)').run(name, userId);
+  logger.info('Overlords', `Added overlord "${name}" (${userId})`);
+}
+
+export function removeOverlord(name: string): void {
+  const db = getDatabase();
+  db.prepare('DELETE FROM overlords WHERE name = ?').run(name);
+  logger.info('Overlords', `Removed overlord "${name}"`);
+}
+
+export function getOverlords(): OverlordRow[] {
+  const db = getDatabase();
+  return db.prepare('SELECT * FROM overlords').all() as OverlordRow[];
+}
+
+export async function addOverlordsToThread(thread: ThreadChannel): Promise<void> {
+  const overlords = getOverlords();
+
+  for (const overlord of overlords) {
+    try {
+      await thread.members.add(overlord.user_id);
+    } catch (error) {
+      logger.error(
+        'Overlords',
+        `Failed to add overlord "${overlord.name}" (${overlord.user_id}) to thread ${thread.id}`,
+        error as Error,
+      );
+    }
+  }
+
+  logger.info('Overlords', `Added ${overlords.length} overlords to thread ${thread.id}`);
+}

--- a/src/functions/raids/refreshLinkingMessages.ts
+++ b/src/functions/raids/refreshLinkingMessages.ts
@@ -1,0 +1,114 @@
+import {
+  type Client,
+  type TextChannel,
+  type Message,
+  ChannelType,
+  ActionRowBuilder,
+  UserSelectMenuBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import type { RaiderRow, ConfigRow } from '../../types/index.js';
+
+export async function refreshLinkingMessages(client: Client): Promise<void> {
+  const db = getDatabase();
+
+  const configRow = db
+    .prepare('SELECT value FROM config WHERE key = ?')
+    .get('raider_setup_channel_id') as ConfigRow | undefined;
+
+  if (!configRow) {
+    logger.debug('RefreshLinks', 'No raider-setup channel configured, skipping refresh');
+    return;
+  }
+
+  let channel: TextChannel;
+  try {
+    const fetched = await client.channels.fetch(configRow.value);
+    if (!fetched || fetched.type !== ChannelType.GuildText) {
+      logger.warn('RefreshLinks', 'Raider-setup channel is not a text channel');
+      return;
+    }
+    channel = fetched as TextChannel;
+  } catch {
+    logger.warn('RefreshLinks', 'Could not fetch raider-setup channel');
+    return;
+  }
+
+  // Get all raiders that still have linking messages (not yet linked)
+  const raidersWithMessages = db
+    .prepare('SELECT * FROM raiders WHERE message_id IS NOT NULL AND discord_user_id IS NULL')
+    .all() as RaiderRow[];
+
+  if (raidersWithMessages.length === 0) {
+    logger.debug('RefreshLinks', 'No linking messages to refresh');
+    return;
+  }
+
+  // Fetch the last 20 messages from the channel
+  let recentMessages: Map<string, Message>;
+  try {
+    const fetched = await channel.messages.fetch({ limit: 20 });
+    recentMessages = new Map(fetched.map((m) => [m.id, m]));
+  } catch (error) {
+    logger.error('RefreshLinks', 'Failed to fetch recent messages', error as Error);
+    return;
+  }
+
+  let refreshed = 0;
+
+  for (const raider of raidersWithMessages) {
+    if (!raider.message_id) continue;
+
+    // Skip if the message is already among the last 20
+    if (recentMessages.has(raider.message_id)) continue;
+
+    try {
+      // Try to delete the old message
+      try {
+        const oldMessage = await channel.messages.fetch(raider.message_id);
+        await oldMessage.delete();
+      } catch {
+        // Message may already be deleted, that's fine
+      }
+
+      // Repost with standard linking components (user select + ignore button)
+      const userSelect = new UserSelectMenuBuilder()
+        .setCustomId(`raider:select_user:${raider.character_name}`)
+        .setPlaceholder('Select a user...');
+
+      const selectRow = new ActionRowBuilder<UserSelectMenuBuilder>().addComponents(userSelect);
+
+      const ignoreButton = new ButtonBuilder()
+        .setCustomId(`raider:ignore:${raider.character_name}`)
+        .setLabel('Ignore')
+        .setStyle(ButtonStyle.Danger);
+
+      const buttonRow = new ActionRowBuilder<ButtonBuilder>().addComponents(ignoreButton);
+
+      const newMessage = await channel.send({
+        content: `**${raider.character_name}**`,
+        components: [selectRow, buttonRow],
+      });
+
+      db.prepare('UPDATE raiders SET message_id = ? WHERE character_name = ?').run(
+        newMessage.id,
+        raider.character_name,
+      );
+
+      refreshed++;
+    } catch (error) {
+      logger.error(
+        'RefreshLinks',
+        `Failed to refresh message for "${raider.character_name}"`,
+        error as Error,
+      );
+    }
+  }
+
+  if (refreshed > 0) {
+    logger.info('RefreshLinks', `Refreshed ${refreshed} linking messages`);
+  }
+}

--- a/src/functions/raids/sendAlertForRaidersWithNoUser.ts
+++ b/src/functions/raids/sendAlertForRaidersWithNoUser.ts
@@ -1,0 +1,153 @@
+import {
+  type Client,
+  type TextChannel,
+  ChannelType,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  UserSelectMenuBuilder,
+} from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import { config } from '../../config.js';
+import type { RaiderRow, ConfigRow } from '../../types/index.js';
+import type { AutoMatch } from './autoMatchRaiders.js';
+
+async function getRaiderSetupChannel(client: Client): Promise<TextChannel | null> {
+  const db = getDatabase();
+
+  const row = db
+    .prepare('SELECT value FROM config WHERE key = ?')
+    .get('raider_setup_channel_id') as ConfigRow | undefined;
+
+  if (row) {
+    try {
+      const channel = await client.channels.fetch(row.value);
+      if (channel && channel.type === ChannelType.GuildText) {
+        return channel as TextChannel;
+      }
+    } catch {
+      logger.warn('RaiderAlerts', 'Configured raider-setup channel not found, will auto-create');
+    }
+  }
+
+  // Auto-create the channel
+  try {
+    const guild = await client.guilds.fetch(config.guildId);
+    const channel = await guild.channels.create({
+      name: 'raider-setup',
+      type: ChannelType.GuildText,
+      topic: 'Raider-Discord user linking setup',
+    });
+
+    db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(
+      'raider_setup_channel_id',
+      channel.id,
+    );
+
+    logger.info('RaiderAlerts', `Auto-created raider-setup channel: #${channel.name}`);
+    return channel;
+  } catch (error) {
+    logger.error('RaiderAlerts', 'Failed to auto-create raider-setup channel', error as Error);
+    return null;
+  }
+}
+
+export async function sendAlertForRaidersWithNoUser(
+  client: Client,
+  newUnlinkedRaiders: RaiderRow[],
+  autoMatches: AutoMatch[],
+): Promise<void> {
+  const channel = await getRaiderSetupChannel(client);
+  if (!channel) return;
+
+  const db = getDatabase();
+  const autoMatchMap = new Map(
+    autoMatches.map((m) => [m.raider.character_name.toLowerCase(), m]),
+  );
+
+  // Send messages for auto-matched raiders
+  for (const match of autoMatches) {
+    const { raider, suggestedUser } = match;
+
+    try {
+      const confirmButton = new ButtonBuilder()
+        .setCustomId(`raider:confirm_link:${raider.character_name}:${suggestedUser.id}`)
+        .setLabel('Confirm')
+        .setStyle(ButtonStyle.Success);
+
+      const rejectButton = new ButtonBuilder()
+        .setCustomId(`raider:reject_link:${raider.character_name}`)
+        .setLabel('Reject')
+        .setStyle(ButtonStyle.Danger);
+
+      const buttonRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        confirmButton,
+        rejectButton,
+      );
+
+      const userSelect = new UserSelectMenuBuilder()
+        .setCustomId(`raider:select_user:${raider.character_name}`)
+        .setPlaceholder('Select a different user...');
+
+      const selectRow = new ActionRowBuilder<UserSelectMenuBuilder>().addComponents(userSelect);
+
+      const message = await channel.send({
+        content: `Link **${raider.character_name}** to ${suggestedUser}?`,
+        components: [buttonRow, selectRow],
+      });
+
+      db.prepare('UPDATE raiders SET message_id = ? WHERE character_name = ?').run(
+        message.id,
+        raider.character_name,
+      );
+    } catch (error) {
+      logger.error(
+        'RaiderAlerts',
+        `Failed to send auto-match alert for "${raider.character_name}"`,
+        error as Error,
+      );
+    }
+  }
+
+  // Send messages for unmatched raiders
+  for (const raider of newUnlinkedRaiders) {
+    if (autoMatchMap.has(raider.character_name.toLowerCase())) continue;
+
+    try {
+      const userSelect = new UserSelectMenuBuilder()
+        .setCustomId(`raider:select_user:${raider.character_name}`)
+        .setPlaceholder('Select a user...');
+
+      const selectRow = new ActionRowBuilder<UserSelectMenuBuilder>().addComponents(userSelect);
+
+      const ignoreButton = new ButtonBuilder()
+        .setCustomId(`raider:ignore:${raider.character_name}`)
+        .setLabel('Ignore')
+        .setStyle(ButtonStyle.Danger);
+
+      const buttonRow = new ActionRowBuilder<ButtonBuilder>().addComponents(ignoreButton);
+
+      const message = await channel.send({
+        content: `**${raider.character_name}**`,
+        components: [selectRow, buttonRow],
+      });
+
+      db.prepare('UPDATE raiders SET message_id = ? WHERE character_name = ?').run(
+        message.id,
+        raider.character_name,
+      );
+    } catch (error) {
+      logger.error(
+        'RaiderAlerts',
+        `Failed to send unmatched alert for "${raider.character_name}"`,
+        error as Error,
+      );
+    }
+  }
+
+  logger.info(
+    'RaiderAlerts',
+    `Sent ${autoMatches.length} auto-match alerts and ${newUnlinkedRaiders.length - autoMatches.length} unmatched alerts`,
+  );
+}

--- a/src/functions/raids/syncRaiders.ts
+++ b/src/functions/raids/syncRaiders.ts
@@ -1,0 +1,109 @@
+import type { Client } from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { getGuildRoster } from '../../services/raiderio.js';
+import { logger } from '../../services/logger.js';
+import type { RaiderRow, RaiderIdentityMapRow, IgnoredCharacterRow } from '../../types/index.js';
+
+const GRACE_PERIOD_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export async function syncRaiders(_client: Client): Promise<void> {
+  const db = getDatabase();
+
+  let apiMembers;
+  try {
+    apiMembers = await getGuildRoster();
+  } catch (error) {
+    logger.error('SyncRaiders', 'Failed to fetch guild roster from Raider.io', error as Error);
+    return;
+  }
+
+  const dbRaiders = db.prepare('SELECT * FROM raiders').all() as RaiderRow[];
+  const ignoredCharacters = db
+    .prepare('SELECT character_name FROM ignored_characters')
+    .all() as IgnoredCharacterRow[];
+
+  const ignoredSet = new Set(ignoredCharacters.map((ic) => ic.character_name.toLowerCase()));
+
+  // Filter API roster: exclude ignored characters
+  const filteredMembers = apiMembers.filter(
+    (m) => !ignoredSet.has(m.character.name.toLowerCase()),
+  );
+
+  const apiNameSet = new Set(filteredMembers.map((m) => m.character.name.toLowerCase()));
+  const dbRaiderMap = new Map(dbRaiders.map((r) => [r.character_name.toLowerCase(), r]));
+
+  let added = 0;
+  let markedMissing = 0;
+  let returned = 0;
+  let alreadyMissing = 0;
+
+  const transaction = db.transaction(() => {
+    const now = new Date().toISOString();
+
+    // 1. Handle raiders no longer in API
+    for (const raider of dbRaiders) {
+      if (!apiNameSet.has(raider.character_name.toLowerCase())) {
+        if (raider.missing_since === null) {
+          // First time missing: set missing_since
+          db.prepare('UPDATE raiders SET missing_since = ? WHERE id = ?').run(now, raider.id);
+          markedMissing++;
+        } else {
+          const missingSinceDate = new Date(raider.missing_since).getTime();
+          const elapsed = Date.now() - missingSinceDate;
+
+          if (elapsed >= GRACE_PERIOD_MS) {
+            logger.warn(
+              'SyncRaiders',
+              `Raider "${raider.character_name}" has been missing for over 24 hours (since ${raider.missing_since})`,
+            );
+            alreadyMissing++;
+          }
+          // If < 24 hours, do nothing (grace period)
+        }
+      }
+    }
+
+    // 2. Handle raiders back in API: clear missing_since
+    for (const raider of dbRaiders) {
+      if (apiNameSet.has(raider.character_name.toLowerCase()) && raider.missing_since !== null) {
+        db.prepare('UPDATE raiders SET missing_since = NULL WHERE id = ?').run(raider.id);
+        returned++;
+      }
+    }
+
+    // 3. Handle new raiders from API
+    const identityMap = db
+      .prepare('SELECT character_name, discord_user_id FROM raider_identity_map')
+      .all() as RaiderIdentityMapRow[];
+    const identityLookup = new Map(
+      identityMap.map((im) => [im.character_name.toLowerCase(), im.discord_user_id]),
+    );
+
+    for (const member of filteredMembers) {
+      const lowerName = member.character.name.toLowerCase();
+      if (!dbRaiderMap.has(lowerName)) {
+        const discordUserId = identityLookup.get(lowerName) ?? null;
+
+        db.prepare(
+          `INSERT INTO raiders (character_name, realm, region, rank, class, discord_user_id)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+        ).run(
+          member.character.name,
+          member.character.realm,
+          member.character.region,
+          member.rank,
+          member.character.class,
+          discordUserId,
+        );
+        added++;
+      }
+    }
+  });
+
+  transaction();
+
+  logger.info(
+    'SyncRaiders',
+    `Sync complete: ${added} added, ${returned} returned, ${markedMissing} newly missing, ${alreadyMissing} still missing (>24h)`,
+  );
+}

--- a/src/functions/raids/updateRaiderDiscordUser.ts
+++ b/src/functions/raids/updateRaiderDiscordUser.ts
@@ -1,0 +1,63 @@
+import { type Client, type TextChannel, ChannelType } from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import type { RaiderRow, ConfigRow } from '../../types/index.js';
+
+export async function updateRaiderDiscordUser(
+  client: Client,
+  characterName: string,
+  userId: string,
+): Promise<boolean> {
+  const db = getDatabase();
+
+  try {
+    const raider = db
+      .prepare('SELECT * FROM raiders WHERE character_name = ?')
+      .get(characterName) as RaiderRow | undefined;
+
+    if (!raider) {
+      logger.warn('UpdateRaider', `Raider "${characterName}" not found in database`);
+      return false;
+    }
+
+    db.transaction(() => {
+      // Update the raider's discord_user_id
+      db.prepare('UPDATE raiders SET discord_user_id = ?, message_id = NULL WHERE character_name = ?').run(
+        userId,
+        characterName,
+      );
+
+      // Upsert into raider_identity_map
+      db.prepare(
+        'INSERT OR REPLACE INTO raider_identity_map (character_name, discord_user_id) VALUES (?, ?)',
+      ).run(characterName, userId);
+    })();
+
+    // Delete the linking message if it existed
+    if (raider.message_id) {
+      try {
+        const configRow = db
+          .prepare('SELECT value FROM config WHERE key = ?')
+          .get('raider_setup_channel_id') as ConfigRow | undefined;
+
+        if (configRow) {
+          const channel = await client.channels.fetch(configRow.value);
+          if (channel && channel.type === ChannelType.GuildText) {
+            const textChannel = channel as TextChannel;
+            const message = await textChannel.messages.fetch(raider.message_id);
+            await message.delete();
+          }
+        }
+      } catch {
+        // Message may already be deleted, that's fine
+        logger.debug('UpdateRaider', `Could not delete linking message for "${characterName}"`);
+      }
+    }
+
+    logger.info('UpdateRaider', `Linked "${characterName}" to user ${userId}`);
+    return true;
+  } catch (error) {
+    logger.error('UpdateRaider', `Failed to update raider "${characterName}"`, error as Error);
+    return false;
+  }
+}

--- a/src/services/raiderio.ts
+++ b/src/services/raiderio.ts
@@ -1,0 +1,100 @@
+import { config } from '../config.js';
+
+const BASE_URL = 'https://raider.io/api/v1';
+const ROSTER_RANKS = [0, 1, 3, 4, 5, 7];
+
+export interface RaiderIoMember {
+  rank: number;
+  character: {
+    name: string;
+    realm: string;
+    region: string;
+    class: string;
+  };
+}
+
+export interface RaidRanking {
+  rank: number;
+  guild: {
+    name: string;
+    realm: string;
+    region: string;
+  };
+  encountersDefeated: number;
+  encountersTotal: number;
+}
+
+export interface RaidStaticData {
+  raids: Array<{
+    id: number;
+    slug: string;
+    name: string;
+    expansion_id: number;
+    encounters: Array<{
+      id: number;
+      slug: string;
+      name: string;
+    }>;
+  }>;
+}
+
+export interface MythicPlusRun {
+  dungeon: string;
+  short_name: string;
+  mythic_level: number;
+  num_keystone_upgrades: number;
+  score: number;
+}
+
+export async function getGuildRoster(): Promise<RaiderIoMember[]> {
+  const url = `${BASE_URL}/guilds/profile?region=eu&realm=silvermoon&name=seriouslycasual&fields=members`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Raider.io API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as { members: RaiderIoMember[] };
+  return data.members.filter((m) => ROSTER_RANKS.includes(m.rank));
+}
+
+export async function getRaidRankings(raidSlug: string): Promise<RaidRanking[]> {
+  const url = `${BASE_URL}/raiding/raid-rankings?raid=${raidSlug}&difficulty=mythic&region=world&guilds=${config.raiderIoGuildIds}&limit=50`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Raider.io API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as { raidRankings: RaidRanking[] };
+  return data.raidRankings;
+}
+
+export async function getRaidStaticData(expansionId: number): Promise<RaidStaticData> {
+  const url = `${BASE_URL}/raiding/static-data?expansion_id=${expansionId}`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Raider.io API error: ${response.status} ${response.statusText}`);
+  }
+
+  return (await response.json()) as RaidStaticData;
+}
+
+export async function getWeeklyMythicPlusRuns(
+  region: string,
+  realm: string,
+  name: string,
+): Promise<MythicPlusRun[]> {
+  const url = `${BASE_URL}/characters/profile?region=${region}&realm=${realm}&name=${encodeURIComponent(name)}&fields=mythic_plus_previous_weekly_highest_level_runs`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Raider.io API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as {
+    mythic_plus_previous_weekly_highest_level_runs: MythicPlusRun[];
+  };
+  return data.mythic_plus_previous_weekly_highest_level_runs;
+}

--- a/src/services/wowaudit.ts
+++ b/src/services/wowaudit.ts
@@ -1,0 +1,66 @@
+import { config } from '../config.js';
+
+const BASE_URL = 'https://wowaudit.com/v1';
+
+function headers(): Record<string, string> {
+  return {
+    accept: 'application/json',
+    Authorization: config.wowAuditApiSecret,
+  };
+}
+
+export interface WowAuditRaid {
+  id: number;
+  date: string;
+  title: string;
+  note: string;
+  signups: Array<{
+    character: {
+      name: string;
+      realm: string;
+      class_name: string;
+    };
+    status: string;
+  }>;
+}
+
+export interface WowAuditHistoricalEntry {
+  character: {
+    name: string;
+    realm: string;
+  };
+  data: Record<string, unknown>;
+}
+
+async function getCurrentPeriod(): Promise<number> {
+  const response = await fetch(`${BASE_URL}/period`, { headers: headers() });
+  if (!response.ok) {
+    throw new Error(`WoW Audit API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as { current_period: number };
+  return data.current_period;
+}
+
+export async function getUpcomingRaids(): Promise<WowAuditRaid[]> {
+  const response = await fetch(`${BASE_URL}/raids?include_past=false`, { headers: headers() });
+  if (!response.ok) {
+    throw new Error(`WoW Audit API error: ${response.status} ${response.statusText}`);
+  }
+
+  return (await response.json()) as WowAuditRaid[];
+}
+
+export async function getHistoricalData(): Promise<WowAuditHistoricalEntry[]> {
+  const currentPeriod = await getCurrentPeriod();
+  const previousPeriod = currentPeriod - 1;
+
+  const response = await fetch(`${BASE_URL}/historical_data?period=${previousPeriod}`, {
+    headers: headers(),
+  });
+  if (!response.ok) {
+    throw new Error(`WoW Audit API error: ${response.status} ${response.statusText}`);
+  }
+
+  return (await response.json()) as WowAuditHistoricalEntry[];
+}

--- a/tests/integration/raids-flow.test.ts
+++ b/tests/integration/raids-flow.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { initDatabase, closeDatabase, getDatabase } from '../../src/database/db.js';
+import type { Client } from 'discord.js';
+import type { RaiderIoMember } from '../../src/services/raiderio.js';
+
+// Mock the Raider.io service
+vi.mock('../../src/services/raiderio.js', () => ({
+  getGuildRoster: vi.fn(),
+}));
+
+// Mock the logger so sync doesn't crash without a real Discord client
+vi.mock('../../src/services/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock config (required by raiderio import chain)
+vi.mock('../../src/config.js', () => ({
+  config: {
+    raiderIoGuildIds: 'test-guild-id',
+  },
+}));
+
+import { syncRaiders } from '../../src/functions/raids/syncRaiders.js';
+import { getGuildRoster } from '../../src/services/raiderio.js';
+
+const mockClient = {} as Client;
+const mockedGetGuildRoster = vi.mocked(getGuildRoster);
+
+function makeMember(
+  name: string,
+  rank = 3,
+  realm = 'silvermoon',
+  region = 'eu',
+  charClass = 'Warrior',
+): RaiderIoMember {
+  return {
+    rank,
+    character: { name, realm, region, class: charClass },
+  };
+}
+
+describe('raids roster sync flow (integration)', () => {
+  beforeEach(() => {
+    closeDatabase();
+    initDatabase(':memory:');
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  it('should add new raiders from API', async () => {
+    mockedGetGuildRoster.mockResolvedValue([
+      makeMember('Testchar', 3, 'silvermoon', 'eu', 'Paladin'),
+      makeMember('Anotherchar', 4, 'silvermoon', 'eu', 'Druid'),
+    ]);
+
+    await syncRaiders(mockClient);
+
+    const db = getDatabase();
+    const raiders = db
+      .prepare('SELECT character_name, realm, region, rank, class FROM raiders ORDER BY character_name')
+      .all() as Array<{
+        character_name: string;
+        realm: string;
+        region: string;
+        rank: number;
+        class: string;
+      }>;
+
+    expect(raiders).toHaveLength(2);
+    const names = raiders.map((r) => r.character_name);
+    expect(names).toContain('Testchar');
+    expect(names).toContain('Anotherchar');
+
+    const testchar = raiders.find((r) => r.character_name === 'Testchar')!;
+    expect(testchar.realm).toBe('silvermoon');
+    expect(testchar.region).toBe('eu');
+    expect(testchar.rank).toBe(3);
+    expect(testchar.class).toBe('Paladin');
+  });
+
+  it('should set missing_since for raiders not in API', async () => {
+    const db = getDatabase();
+    db.prepare(
+      'INSERT INTO raiders (character_name, realm, region) VALUES (?, ?, ?)',
+    ).run('GoneMember', 'silvermoon', 'eu');
+
+    // API returns empty — GoneMember is no longer in the roster
+    mockedGetGuildRoster.mockResolvedValue([]);
+
+    await syncRaiders(mockClient);
+
+    const raider = db
+      .prepare('SELECT missing_since FROM raiders WHERE character_name = ?')
+      .get('GoneMember') as { missing_since: string | null };
+
+    expect(raider.missing_since).not.toBeNull();
+    // Should be a valid ISO timestamp
+    expect(new Date(raider.missing_since!).getTime()).not.toBeNaN();
+  });
+
+  it('should clear missing_since when raider returns', async () => {
+    const db = getDatabase();
+    const missingSince = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(); // 2 hours ago
+    db.prepare(
+      'INSERT INTO raiders (character_name, realm, region, missing_since) VALUES (?, ?, ?, ?)',
+    ).run('ReturnedMember', 'silvermoon', 'eu', missingSince);
+
+    // Raider is back in the API response
+    mockedGetGuildRoster.mockResolvedValue([makeMember('ReturnedMember')]);
+
+    await syncRaiders(mockClient);
+
+    const raider = db
+      .prepare('SELECT missing_since FROM raiders WHERE character_name = ?')
+      .get('ReturnedMember') as { missing_since: string | null };
+
+    expect(raider.missing_since).toBeNull();
+  });
+
+  it('should auto-link from identity map', async () => {
+    const db = getDatabase();
+    db.prepare(
+      'INSERT INTO raider_identity_map (character_name, discord_user_id) VALUES (?, ?)',
+    ).run('Linkedchar', '111222333444555666');
+
+    mockedGetGuildRoster.mockResolvedValue([makeMember('Linkedchar')]);
+
+    await syncRaiders(mockClient);
+
+    const raider = db
+      .prepare('SELECT discord_user_id FROM raiders WHERE character_name = ?')
+      .get('Linkedchar') as { discord_user_id: string | null };
+
+    expect(raider.discord_user_id).toBe('111222333444555666');
+  });
+
+  it('should not add ignored characters', async () => {
+    const db = getDatabase();
+    db.prepare('INSERT INTO ignored_characters (character_name) VALUES (?)').run('Ignoredchar');
+
+    mockedGetGuildRoster.mockResolvedValue([
+      makeMember('Ignoredchar'),
+      makeMember('Regularchar'),
+    ]);
+
+    await syncRaiders(mockClient);
+
+    const raiders = db
+      .prepare('SELECT character_name FROM raiders')
+      .all() as Array<{ character_name: string }>;
+
+    const names = raiders.map((r) => r.character_name);
+    expect(names).not.toContain('Ignoredchar');
+    expect(names).toContain('Regularchar');
+    expect(raiders).toHaveLength(1);
+  });
+});

--- a/tests/unit/autoMatchRaiders.test.ts
+++ b/tests/unit/autoMatchRaiders.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest';
+import { autoMatchRaiders } from '../../src/functions/raids/autoMatchRaiders.js';
+import type { RaiderRow } from '../../src/types/index.js';
+import type { Guild, GuildMember, Collection, User } from 'discord.js';
+
+function createMockMember(
+  displayName: string,
+  globalDisplayName: string,
+  username: string,
+  id = '123456789',
+): GuildMember {
+  return {
+    displayName,
+    id,
+    user: {
+      displayName: globalDisplayName,
+      username,
+      id,
+    } as User,
+  } as GuildMember;
+}
+
+function createMockGuild(members: GuildMember[]): Guild {
+  const membersMap = new Map(members.map((m, i) => [String(i), m]));
+  return {
+    members: {
+      fetch: vi.fn().mockResolvedValue(membersMap),
+    },
+  } as unknown as Guild;
+}
+
+function createRaider(characterName: string): RaiderRow {
+  return {
+    id: 1,
+    character_name: characterName,
+    realm: 'silvermoon',
+    region: 'eu',
+    rank: null,
+    class: null,
+    discord_user_id: null,
+    message_id: null,
+    missing_since: null,
+  };
+}
+
+describe('autoMatchRaiders', () => {
+  it('should match on exact displayName', async () => {
+    const member = createMockMember('Thrall', 'SomeGlobal', 'someuser');
+    const guild = createMockGuild([member]);
+    const raider = createRaider('Thrall');
+
+    const result = await autoMatchRaiders(guild, [raider]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].raider.character_name).toBe('Thrall');
+    expect(result[0].suggestedUser).toBe(member);
+  });
+
+  it('should match case-insensitively', async () => {
+    const member = createMockMember('THRALL', 'SomeGlobal', 'someuser');
+    const guild = createMockGuild([member]);
+    const raider = createRaider('thrall');
+
+    const result = await autoMatchRaiders(guild, [raider]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].raider.character_name).toBe('thrall');
+    expect(result[0].suggestedUser).toBe(member);
+  });
+
+  it('should return empty when no match found', async () => {
+    const member = createMockMember('Jaina', 'JainaGlobal', 'jainauser');
+    const guild = createMockGuild([member]);
+    const raider = createRaider('Thrall');
+
+    const result = await autoMatchRaiders(guild, [raider]);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('should skip ambiguous matches (multiple members match same name)', async () => {
+    const member1 = createMockMember('Thrall', 'SomeGlobal1', 'user1', '111');
+    const member2 = createMockMember('Thrall', 'SomeGlobal2', 'user2', '222');
+    const guild = createMockGuild([member1, member2]);
+    const raider = createRaider('Thrall');
+
+    const result = await autoMatchRaiders(guild, [raider]);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('should return empty for empty unlinked raiders array', async () => {
+    const guild = createMockGuild([]);
+
+    const result = await autoMatchRaiders(guild, []);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('should match on user.displayName (global display name)', async () => {
+    const member = createMockMember('ServerNick', 'Thrall', 'someuser');
+    const guild = createMockGuild([member]);
+    const raider = createRaider('Thrall');
+
+    const result = await autoMatchRaiders(guild, [raider]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].suggestedUser).toBe(member);
+  });
+
+  it('should match on user.username', async () => {
+    const member = createMockMember('ServerNick', 'SomeGlobal', 'thrall');
+    const guild = createMockGuild([member]);
+    const raider = createRaider('Thrall');
+
+    const result = await autoMatchRaiders(guild, [raider]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].suggestedUser).toBe(member);
+  });
+});

--- a/tests/unit/raiderio.test.ts
+++ b/tests/unit/raiderio.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock config before importing the module under test
+vi.mock('../../src/config.js', () => ({
+  config: {
+    raiderIoGuildIds: 'test-guild-id',
+  },
+}));
+
+import { getGuildRoster, getRaidRankings, getRaidStaticData, getWeeklyMythicPlusRuns } from '../../src/services/raiderio.js';
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('getGuildRoster', () => {
+  it('should return only members with allowed ranks [0,1,3,4,5,7]', async () => {
+    const mockMembers = [
+      { rank: 0, character: { name: 'GuildMaster', realm: 'silvermoon', region: 'eu', class: 'Warrior' } },
+      { rank: 1, character: { name: 'Officer1', realm: 'silvermoon', region: 'eu', class: 'Mage' } },
+      { rank: 2, character: { name: 'ShouldBeExcluded', realm: 'silvermoon', region: 'eu', class: 'Rogue' } },
+      { rank: 3, character: { name: 'Raider1', realm: 'silvermoon', region: 'eu', class: 'Paladin' } },
+      { rank: 4, character: { name: 'Raider2', realm: 'silvermoon', region: 'eu', class: 'Priest' } },
+      { rank: 5, character: { name: 'Trial1', realm: 'silvermoon', region: 'eu', class: 'Druid' } },
+      { rank: 6, character: { name: 'AlsoExcluded', realm: 'silvermoon', region: 'eu', class: 'Hunter' } },
+      { rank: 7, character: { name: 'Social1', realm: 'silvermoon', region: 'eu', class: 'Warlock' } },
+      { rank: 8, character: { name: 'ExcludedToo', realm: 'silvermoon', region: 'eu', class: 'Monk' } },
+    ];
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ members: mockMembers }),
+    });
+
+    const result = await getGuildRoster();
+
+    expect(result).toHaveLength(6);
+    const names = result.map((m) => m.character.name);
+    expect(names).toContain('GuildMaster');
+    expect(names).toContain('Officer1');
+    expect(names).toContain('Raider1');
+    expect(names).toContain('Raider2');
+    expect(names).toContain('Trial1');
+    expect(names).toContain('Social1');
+    expect(names).not.toContain('ShouldBeExcluded');
+    expect(names).not.toContain('AlsoExcluded');
+    expect(names).not.toContain('ExcludedToo');
+  });
+
+  it('should throw on non-OK response', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    });
+
+    await expect(getGuildRoster()).rejects.toThrow('Raider.io API error: 500 Internal Server Error');
+  });
+
+  it('should call the correct URL', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ members: [] }),
+    });
+
+    await getGuildRoster();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://raider.io/api/v1/guilds/profile?region=eu&realm=silvermoon&name=seriouslycasual&fields=members',
+    );
+  });
+});
+
+describe('getRaidRankings', () => {
+  it('should fetch rankings for a given raid slug', async () => {
+    const mockRankings = [
+      { rank: 1, guild: { name: 'Test', realm: 'silvermoon', region: 'eu' }, encountersDefeated: 8, encountersTotal: 8 },
+    ];
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ raidRankings: mockRankings }),
+    });
+
+    const result = await getRaidRankings('nerubar-palace');
+
+    expect(result).toEqual(mockRankings);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('raid=nerubar-palace'),
+    );
+  });
+
+  it('should throw on non-OK response', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    });
+
+    await expect(getRaidRankings('invalid')).rejects.toThrow('Raider.io API error: 404 Not Found');
+  });
+});
+
+describe('getRaidStaticData', () => {
+  it('should fetch static data for an expansion', async () => {
+    const mockData = {
+      raids: [{ id: 1, slug: 'test-raid', name: 'Test Raid', expansion_id: 10, encounters: [] }],
+    };
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    });
+
+    const result = await getRaidStaticData(10);
+
+    expect(result).toEqual(mockData);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('expansion_id=10'),
+    );
+  });
+});
+
+describe('getWeeklyMythicPlusRuns', () => {
+  it('should fetch M+ runs for a character', async () => {
+    const mockRuns = [
+      { dungeon: 'The Stonevault', short_name: 'SV', mythic_level: 12, num_keystone_upgrades: 2, score: 150 },
+    ];
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ mythic_plus_previous_weekly_highest_level_runs: mockRuns }),
+    });
+
+    const result = await getWeeklyMythicPlusRuns('eu', 'silvermoon', 'Testchar');
+
+    expect(result).toEqual(mockRuns);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('name=Testchar'),
+    );
+  });
+
+  it('should encode character names with special characters', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ mythic_plus_previous_weekly_highest_level_runs: [] }),
+    });
+
+    await getWeeklyMythicPlusRuns('eu', 'silvermoon', 'Tëst Chàr');
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`name=${encodeURIComponent('Tëst Chàr')}`),
+    );
+  });
+});

--- a/tests/unit/syncRaiders.test.ts
+++ b/tests/unit/syncRaiders.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { initDatabase, closeDatabase, getDatabase } from '../../src/database/db.js';
+import type { Client } from 'discord.js';
+import type { RaiderIoMember } from '../../src/services/raiderio.js';
+
+// Mock the raiderio service
+vi.mock('../../src/services/raiderio.js', () => ({
+  getGuildRoster: vi.fn(),
+}));
+
+// Mock the logger
+vi.mock('../../src/services/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock config (needed by raiderio import chain)
+vi.mock('../../src/config.js', () => ({
+  config: {
+    raiderIoGuildIds: 'test-guild-id',
+  },
+}));
+
+import { syncRaiders } from '../../src/functions/raids/syncRaiders.js';
+import { getGuildRoster } from '../../src/services/raiderio.js';
+import { logger } from '../../src/services/logger.js';
+
+const mockClient = {} as Client;
+const mockedGetGuildRoster = vi.mocked(getGuildRoster);
+
+function makeMember(name: string, rank = 3, realm = 'silvermoon', region = 'eu', charClass = 'Warrior'): RaiderIoMember {
+  return {
+    rank,
+    character: { name, realm, region, class: charClass },
+  };
+}
+
+beforeEach(() => {
+  closeDatabase();
+  initDatabase(':memory:');
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  closeDatabase();
+});
+
+describe('syncRaiders', () => {
+  it('should add new raiders when they appear in API but not in DB', async () => {
+    mockedGetGuildRoster.mockResolvedValue([
+      makeMember('Newchar', 3, 'silvermoon', 'eu', 'Mage'),
+    ]);
+
+    await syncRaiders(mockClient);
+
+    const db = getDatabase();
+    const raiders = db.prepare('SELECT * FROM raiders').all() as Array<{
+      character_name: string;
+      realm: string;
+      region: string;
+      rank: number;
+      class: string;
+      discord_user_id: string | null;
+    }>;
+
+    expect(raiders).toHaveLength(1);
+    expect(raiders[0].character_name).toBe('Newchar');
+    expect(raiders[0].realm).toBe('silvermoon');
+    expect(raiders[0].region).toBe('eu');
+    expect(raiders[0].rank).toBe(3);
+    expect(raiders[0].class).toBe('Mage');
+    expect(raiders[0].discord_user_id).toBeNull();
+  });
+
+  it('should set missing_since when a raider disappears from API', async () => {
+    const db = getDatabase();
+    db.prepare(
+      'INSERT INTO raiders (character_name, realm, region) VALUES (?, ?, ?)',
+    ).run('OldRaider', 'silvermoon', 'eu');
+
+    // API returns empty (OldRaider not in API anymore)
+    mockedGetGuildRoster.mockResolvedValue([]);
+
+    await syncRaiders(mockClient);
+
+    const raider = db.prepare('SELECT * FROM raiders WHERE character_name = ?').get('OldRaider') as {
+      missing_since: string | null;
+    };
+
+    expect(raider.missing_since).not.toBeNull();
+  });
+
+  it('should clear missing_since when a raider returns to API', async () => {
+    const db = getDatabase();
+    db.prepare(
+      'INSERT INTO raiders (character_name, realm, region, missing_since) VALUES (?, ?, ?, ?)',
+    ).run('ReturnedRaider', 'silvermoon', 'eu', new Date().toISOString());
+
+    mockedGetGuildRoster.mockResolvedValue([
+      makeMember('ReturnedRaider'),
+    ]);
+
+    await syncRaiders(mockClient);
+
+    const raider = db.prepare('SELECT * FROM raiders WHERE character_name = ?').get('ReturnedRaider') as {
+      missing_since: string | null;
+    };
+
+    expect(raider.missing_since).toBeNull();
+  });
+
+  it('should exclude ignored characters from sync', async () => {
+    const db = getDatabase();
+    db.prepare('INSERT INTO ignored_characters (character_name) VALUES (?)').run('IgnoredAlt');
+
+    mockedGetGuildRoster.mockResolvedValue([
+      makeMember('IgnoredAlt'),
+      makeMember('ValidRaider'),
+    ]);
+
+    await syncRaiders(mockClient);
+
+    const raiders = db.prepare('SELECT * FROM raiders').all() as Array<{ character_name: string }>;
+
+    expect(raiders).toHaveLength(1);
+    expect(raiders[0].character_name).toBe('ValidRaider');
+  });
+
+  it('should auto-populate discord_user_id from identity map', async () => {
+    const db = getDatabase();
+    db.prepare(
+      'INSERT INTO raider_identity_map (character_name, discord_user_id) VALUES (?, ?)',
+    ).run('MappedChar', '123456789');
+
+    mockedGetGuildRoster.mockResolvedValue([
+      makeMember('MappedChar'),
+    ]);
+
+    await syncRaiders(mockClient);
+
+    const raider = db.prepare('SELECT * FROM raiders WHERE character_name = ?').get('MappedChar') as {
+      discord_user_id: string | null;
+    };
+
+    expect(raider.discord_user_id).toBe('123456789');
+  });
+
+  it('should handle case-insensitive matching for ignored characters', async () => {
+    const db = getDatabase();
+    db.prepare('INSERT INTO ignored_characters (character_name) VALUES (?)').run('ignoredchar');
+
+    mockedGetGuildRoster.mockResolvedValue([
+      makeMember('IgnoredChar'), // Different case than DB
+      makeMember('ValidRaider'),
+    ]);
+
+    await syncRaiders(mockClient);
+
+    const raiders = db.prepare('SELECT * FROM raiders').all() as Array<{ character_name: string }>;
+
+    expect(raiders).toHaveLength(1);
+    expect(raiders[0].character_name).toBe('ValidRaider');
+  });
+
+  it('should not duplicate existing raiders', async () => {
+    const db = getDatabase();
+    db.prepare(
+      'INSERT INTO raiders (character_name, realm, region) VALUES (?, ?, ?)',
+    ).run('ExistingRaider', 'silvermoon', 'eu');
+
+    mockedGetGuildRoster.mockResolvedValue([
+      makeMember('ExistingRaider'),
+    ]);
+
+    await syncRaiders(mockClient);
+
+    const raiders = db.prepare('SELECT * FROM raiders').all() as Array<{ character_name: string }>;
+
+    expect(raiders).toHaveLength(1);
+  });
+
+  it('should warn when a raider has been missing for over 24 hours', async () => {
+    const db = getDatabase();
+    const oldDate = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(); // 25 hours ago
+    db.prepare(
+      'INSERT INTO raiders (character_name, realm, region, missing_since) VALUES (?, ?, ?, ?)',
+    ).run('LongGoneRaider', 'silvermoon', 'eu', oldDate);
+
+    mockedGetGuildRoster.mockResolvedValue([]);
+
+    await syncRaiders(mockClient);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'SyncRaiders',
+      expect.stringContaining('LongGoneRaider'),
+    );
+  });
+
+  it('should not warn when a raider is missing for less than 24 hours', async () => {
+    const db = getDatabase();
+    const recentDate = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(); // 2 hours ago
+    db.prepare(
+      'INSERT INTO raiders (character_name, realm, region, missing_since) VALUES (?, ?, ?, ?)',
+    ).run('RecentlyGoneRaider', 'silvermoon', 'eu', recentDate);
+
+    mockedGetGuildRoster.mockResolvedValue([]);
+
+    await syncRaiders(mockClient);
+
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      'SyncRaiders',
+      expect.stringContaining('RecentlyGoneRaider'),
+    );
+  });
+
+  it('should log sync summary', async () => {
+    mockedGetGuildRoster.mockResolvedValue([
+      makeMember('NewRaider'),
+    ]);
+
+    await syncRaiders(mockClient);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'SyncRaiders',
+      expect.stringContaining('Sync complete'),
+    );
+  });
+
+  it('should handle API failure gracefully', async () => {
+    mockedGetGuildRoster.mockRejectedValue(new Error('Network error'));
+
+    await syncRaiders(mockClient);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'SyncRaiders',
+      'Failed to fetch guild roster from Raider.io',
+      expect.any(Error),
+    );
+  });
+
+  it('should handle case-insensitive identity map lookup', async () => {
+    const db = getDatabase();
+    db.prepare(
+      'INSERT INTO raider_identity_map (character_name, discord_user_id) VALUES (?, ?)',
+    ).run('mappedchar', '987654321');
+
+    mockedGetGuildRoster.mockResolvedValue([
+      makeMember('MappedChar'), // Different case
+    ]);
+
+    await syncRaiders(mockClient);
+
+    const raider = db.prepare('SELECT * FROM raiders WHERE character_name = ?').get('MappedChar') as {
+      discord_user_id: string | null;
+    };
+
+    expect(raider.discord_user_id).toBe('987654321');
+  });
+});

--- a/tests/unit/wowaudit.test.ts
+++ b/tests/unit/wowaudit.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('../../src/config.js', () => ({
+  config: {
+    wowAuditApiSecret: 'test-api-secret',
+  },
+}));
+
+import { getUpcomingRaids, getHistoricalData } from '../../src/services/wowaudit.js';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('getUpcomingRaids', () => {
+  it('should fetch upcoming raids with correct headers', async () => {
+    const mockRaids = [
+      { id: 1, date: '2026-04-20', title: 'Raid Night', note: '', signups: [] },
+    ];
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockRaids,
+    });
+
+    const result = await getUpcomingRaids();
+
+    expect(result).toEqual(mockRaids);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://wowaudit.com/v1/raids?include_past=false',
+      {
+        headers: {
+          accept: 'application/json',
+          Authorization: 'test-api-secret',
+        },
+      },
+    );
+  });
+
+  it('should throw on non-OK response', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+    });
+
+    await expect(getUpcomingRaids()).rejects.toThrow('WoW Audit API error: 401 Unauthorized');
+  });
+});
+
+describe('getHistoricalData', () => {
+  it('should fetch historical data for the previous period', async () => {
+    const mockHistorical = [
+      { character: { name: 'Testchar', realm: 'silvermoon' }, data: { ilvl: 620 } },
+    ];
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        // getCurrentPeriod call
+        ok: true,
+        json: async () => ({ current_period: 42 }),
+      })
+      .mockResolvedValueOnce({
+        // getHistoricalData call
+        ok: true,
+        json: async () => mockHistorical,
+      });
+
+    const result = await getHistoricalData();
+
+    expect(result).toEqual(mockHistorical);
+
+    // First call: getCurrentPeriod
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://wowaudit.com/v1/period',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'test-api-secret' }),
+      }),
+    );
+
+    // Second call: historical data with previous period (42 - 1 = 41)
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://wowaudit.com/v1/historical_data?period=41',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'test-api-secret' }),
+      }),
+    );
+  });
+
+  it('should throw if getCurrentPeriod fails', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    });
+
+    await expect(getHistoricalData()).rejects.toThrow('WoW Audit API error: 500 Internal Server Error');
+  });
+
+  it('should throw if historical data request fails', async () => {
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ current_period: 42 }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+    await expect(getHistoricalData()).rejects.toThrow('WoW Audit API error: 404 Not Found');
+  });
+});


### PR DESCRIPTION
## Summary

Complete Raids domain implementation with roster sync, raider management, and scheduled alerts.

### What's included (11 commits):

- **Raider.io service** - 4 endpoints: guild roster, raid rankings, static data, M+ runs
- **WoW Audit service** - 2 endpoints: upcoming raids, historical data
- **Roster sync** - 10-minute interval, grace period (24h before flagging missing raiders), identity map auto-linking
- **Auto-link suggestions** - Match Discord display names to character names, confirm/reject buttons
- **Missing user alerts** - Select menu + ignore button in raider-setup channel
- **Message refresh** - Stale linking messages reposted at bottom of channel
- **Overlord management** - Add/remove/list officers, add to threads
- **Signup alerts** - Cron 7PM Mon/Tue/Fri/Sat, random messages, settings toggle
- **Weekly reports** - M+ and Great Vault as .txt attachments, Wednesday noon
- **/raiders command** - 12 subcommands with button/select menu interaction handlers
- **Scheduled tasks** - 2 intervals (sync, refresh) + 2 crons (signups, reports)

### Test coverage:

- 57 tests across 10 test files
- Unit tests: Raider.io service, WoW Audit service, roster sync, auto-match
- Integration test: full roster sync flow (add, remove, grace period, identity map, ignore)

### Chrome verified:

- `/raiders get_raiders` - shows 0 raiders initially, 29 after sync
- `/raiders sync_raiders` - pulls live data from Raider.io, populates DB
- All 12 subcommands visible in autocomplete

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` - all 57 tests pass
- [ ] `/raiders sync_raiders` pulls live roster from Raider.io
- [ ] `/raiders get_raiders` shows synced raiders with realms and classes
- [ ] `/raiders get_overlords` returns empty list
- [ ] `/raiders add_overlord` adds an officer
- [ ] Auto-link suggestions appear for matching Discord names

🤖 Generated with [Claude Code](https://claude.com/claude-code)