### PR TITLE
feat: Guild Info - embeds, achievements image, /guildinfo command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -29,6 +29,8 @@ All commands are Discord slash commands registered to a single guild.
 | `/raiders add_overlord` | Add an overlord (officer with special permissions) | Yes | No |
 | `/raiders get_overlords` | List all configured overlords | Yes | No |
 | `/raiders remove_overlord` | Remove an overlord | Yes | No |
+| `/guildinfo` | Full refresh of all guild info embeds (About Us, Schedule, Recruitment, Achievements) | Yes | No |
+| `/updateachievements` | Refresh the achievements embed only | Yes | No |
 
 ## Notes
 

--- a/src/commands/guildinfo.ts
+++ b/src/commands/guildinfo.ts
@@ -1,0 +1,36 @@
+import {
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  MessageFlags,
+  PermissionFlagsBits,
+} from 'discord.js';
+import { requireOfficer, audit } from '../utils.js';
+import { clearGuildInfo } from '../functions/guild-info/clearGuildInfo.js';
+import { updateAboutUs } from '../functions/guild-info/updateAboutUs.js';
+import { updateSchedule } from '../functions/guild-info/updateSchedule.js';
+import { updateRecruitment } from '../functions/guild-info/updateRecruitment.js';
+import { updateAchievements } from '../functions/guild-info/updateAchievements.js';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('guildinfo')
+    .setDescription('Full refresh of all guild info embeds')
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+
+  async execute(interaction: ChatInputCommandInteraction) {
+    if (!(await requireOfficer(interaction))) return;
+
+    await interaction.reply({ content: 'Updating Guild Info...', flags: MessageFlags.Ephemeral });
+
+    const client = interaction.client;
+
+    await clearGuildInfo(client);
+    await updateAboutUs(client);
+    await updateSchedule(client);
+    await updateRecruitment(client);
+    await updateAchievements(client);
+
+    await audit(interaction.user, 'refreshed guild info', 'all embeds');
+    await interaction.editReply({ content: 'Guild Info updated.' });
+  },
+};

--- a/src/commands/updateachievements.ts
+++ b/src/commands/updateachievements.ts
@@ -1,0 +1,26 @@
+import {
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  MessageFlags,
+  PermissionFlagsBits,
+} from 'discord.js';
+import { requireOfficer, audit } from '../utils.js';
+import { updateAchievements } from '../functions/guild-info/updateAchievements.js';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('updateachievements')
+    .setDescription('Refresh achievements embed only')
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+
+  async execute(interaction: ChatInputCommandInteraction) {
+    if (!(await requireOfficer(interaction))) return;
+
+    await interaction.reply({ content: 'Updating achievements...', flags: MessageFlags.Ephemeral });
+
+    await updateAchievements(interaction.client);
+
+    await audit(interaction.user, 'refreshed achievements', 'achievements embed');
+    await interaction.editReply({ content: 'Achievements updated.' });
+  },
+};

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -6,6 +6,7 @@ import { syncRaiders } from '../functions/raids/syncRaiders.js';
 import { alertSignups } from '../functions/raids/alertSignups.js';
 import { alertHighestMythicPlusDone } from '../functions/raids/alertHighestMythicPlusDone.js';
 import { refreshLinkingMessages } from '../functions/raids/refreshLinkingMessages.js';
+import { updateAchievements } from '../functions/guild-info/updateAchievements.js';
 
 export const scheduler = new Scheduler();
 
@@ -47,6 +48,12 @@ export default {
       name: 'weeklyReports',
       expression: '0 12 * * 3',
       handler: () => alertHighestMythicPlusDone(client),
+    });
+
+    scheduler.registerInterval({
+      name: 'updateAchievements',
+      intervalMs: 1_800_000,
+      handler: () => updateAchievements(client),
     });
 
     scheduler.start();

--- a/src/functions/guild-info/clearGuildInfo.ts
+++ b/src/functions/guild-info/clearGuildInfo.ts
@@ -1,0 +1,104 @@
+import { type Client, type Message, ChannelType, type TextChannel } from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import { asSendable } from '../../utils.js';
+import { config } from '../../config.js';
+import type { ConfigRow } from '../../types/index.js';
+
+/**
+ * Delete all messages in the guild info channel and clear the guild_info_messages table.
+ */
+export async function clearGuildInfo(client: Client): Promise<void> {
+  const channel = await getOrCreateGuildInfoChannel(client);
+  if (!channel) {
+    logger.warn('guild-info', 'Could not resolve guild info channel');
+    return;
+  }
+
+  // Fetch all messages (up to 100 at a time)
+  let fetched;
+  const allMessages: Message[] = [];
+
+  do {
+    fetched = await channel.messages.fetch({
+      limit: 100,
+      ...(allMessages.length > 0 ? { before: allMessages[allMessages.length - 1].id } : {}),
+    });
+    allMessages.push(...fetched.values());
+  } while (fetched.size === 100);
+
+  if (allMessages.length === 0) {
+    logger.debug('guild-info', 'No messages to clear in guild info channel');
+  } else {
+    // Split into messages < 14 days old (bulk deletable) and older ones
+    const twoWeeksAgo = Date.now() - 14 * 24 * 60 * 60 * 1000;
+    const recent = allMessages.filter((m) => m.createdTimestamp > twoWeeksAgo);
+    const old = allMessages.filter((m) => m.createdTimestamp <= twoWeeksAgo);
+
+    // Bulk delete recent messages (in chunks of 100)
+    for (let i = 0; i < recent.length; i += 100) {
+      const chunk = recent.slice(i, i + 100);
+      if (chunk.length === 1) {
+        await chunk[0].delete();
+      } else if (chunk.length > 1) {
+        await channel.bulkDelete(chunk);
+      }
+    }
+
+    // Delete old messages individually
+    for (const message of old) {
+      try {
+        await message.delete();
+      } catch (error) {
+        logger.warn('guild-info', `Failed to delete old message ${message.id}`);
+      }
+    }
+
+    logger.info('guild-info', `Cleared ${allMessages.length} messages from guild info channel`);
+  }
+
+  // Clear guild_info_messages table
+  const db = getDatabase();
+  db.prepare('DELETE FROM guild_info_messages').run();
+}
+
+/**
+ * Get the guild info channel from config, or create one if it doesn't exist.
+ */
+export async function getOrCreateGuildInfoChannel(client: Client): Promise<TextChannel | null> {
+  const db = getDatabase();
+  const row = db.prepare('SELECT value FROM config WHERE key = ?').get('guild_info_channel_id') as ConfigRow | undefined;
+
+  if (row) {
+    const channel = await client.channels.fetch(row.value).catch(() => null);
+    const sendable = asSendable(channel);
+    if (sendable) return sendable;
+    logger.warn('guild-info', `Configured guild info channel ${row.value} not found, creating new one`);
+  }
+
+  // Auto-create the channel
+  const guild = await client.guilds.fetch(config.guildId).catch(() => null);
+  if (!guild) {
+    logger.error('guild-info', 'Could not fetch guild to create guild info channel');
+    return null;
+  }
+
+  try {
+    const newChannel = await guild.channels.create({
+      name: 'guild-info',
+      type: ChannelType.GuildText,
+    });
+
+    db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(
+      'guild_info_channel_id',
+      newChannel.id,
+    );
+
+    logger.info('guild-info', `Created guild info channel #${newChannel.name} (${newChannel.id})`);
+    return newChannel;
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    logger.error('guild-info', `Failed to create guild info channel: ${err.message}`, err);
+    return null;
+  }
+}

--- a/src/functions/guild-info/updateAboutUs.ts
+++ b/src/functions/guild-info/updateAboutUs.ts
@@ -1,0 +1,73 @@
+import {
+  type Client,
+  EmbedBuilder,
+  Colors,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import { getOrCreateGuildInfoChannel } from './clearGuildInfo.js';
+import type { GuildInfoContentRow, GuildInfoLinkRow } from '../../types/index.js';
+
+/**
+ * Post the About Us embed with link buttons to the guild info channel.
+ */
+export async function updateAboutUs(client: Client): Promise<void> {
+  const channel = await getOrCreateGuildInfoChannel(client);
+  if (!channel) {
+    logger.warn('guild-info', 'Could not resolve guild info channel for About Us');
+    return;
+  }
+
+  const db = getDatabase();
+
+  // Get about us content
+  const aboutUs = db.prepare('SELECT * FROM guild_info_content WHERE key = ?').get('aboutus') as GuildInfoContentRow | undefined;
+  if (!aboutUs) {
+    logger.warn('guild-info', 'No aboutus content found in guild_info_content');
+    return;
+  }
+
+  // Get link buttons
+  const links = db.prepare('SELECT * FROM guild_info_links ORDER BY id').all() as GuildInfoLinkRow[];
+
+  // Build embed
+  const embed = new EmbedBuilder()
+    .setColor(Colors.Green)
+    .setTitle(aboutUs.title ?? 'About Us')
+    .setDescription(aboutUs.content);
+
+  // Build action row with link buttons
+  const messagePayload: { embeds: EmbedBuilder[]; components?: ActionRowBuilder<ButtonBuilder>[] } = {
+    embeds: [embed],
+  };
+
+  if (links.length > 0) {
+    const row = new ActionRowBuilder<ButtonBuilder>();
+    for (const link of links) {
+      const button = new ButtonBuilder()
+        .setLabel(link.label)
+        .setStyle(ButtonStyle.Link)
+        .setURL(link.url);
+
+      if (link.emoji_id) {
+        button.setEmoji(link.emoji_id);
+      }
+
+      row.addComponents(button);
+    }
+    messagePayload.components = [row];
+  }
+
+  const message = await channel.send(messagePayload);
+
+  // Store message ID
+  db.prepare('INSERT OR REPLACE INTO guild_info_messages (key, message_id) VALUES (?, ?)').run(
+    'aboutus',
+    message.id,
+  );
+
+  logger.info('guild-info', 'Posted About Us embed');
+}

--- a/src/functions/guild-info/updateAchievements.ts
+++ b/src/functions/guild-info/updateAchievements.ts
@@ -1,0 +1,335 @@
+import { type Client, AttachmentBuilder, EmbedBuilder, Colors } from 'discord.js';
+import { createCanvas } from '@napi-rs/canvas';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import { getOrCreateGuildInfoChannel } from './clearGuildInfo.js';
+import { getRaidStaticData, getRaidRankings } from '../../services/raiderio.js';
+import type { AchievementsManualRow, GuildInfoContentRow, GuildInfoMessageRow } from '../../types/index.js';
+
+// ─── Types ──────────────────────────────────────────────────────
+
+interface AchievementRow {
+  raid: string;
+  progress: string;
+  result: string;
+  isCE: boolean;
+}
+
+interface AchievementSection {
+  expansionLabel: string | null;
+  rows: AchievementRow[];
+}
+
+interface RaidStaticRaid {
+  id: number;
+  slug: string;
+  name: string;
+  short_name?: string;
+  expansion_id: number;
+  encounters: Array<{
+    id: number;
+    slug: string;
+    name: string;
+  }>;
+  starts?: Record<string, string>;
+  ends?: Record<string, string | null>;
+}
+
+interface RaidRankingEntry {
+  rank: number;
+  guild: {
+    name: string;
+    realm: string;
+    region: string;
+  };
+  encountersDefeated: number;
+  encountersTotal: number;
+  encounter_defeated?: Array<{
+    slug: string;
+    lastDefeated: string;
+    firstDefeated: string;
+  }>;
+}
+
+// ─── Main Export ─────────────────────────────────────────────────
+
+/**
+ * Generate achievements image from manual + API data and post to guild info channel.
+ */
+export async function updateAchievements(client: Client): Promise<void> {
+  const channel = await getOrCreateGuildInfoChannel(client);
+  if (!channel) {
+    logger.warn('guild-info', 'Could not resolve guild info channel for Achievements');
+    return;
+  }
+
+  const db = getDatabase();
+
+  // Get manual achievements
+  const manualRows = db
+    .prepare('SELECT * FROM achievements_manual ORDER BY expansion, sort_order')
+    .all() as AchievementsManualRow[];
+
+  // Get achievements title
+  const titleRow = db
+    .prepare('SELECT * FROM guild_info_content WHERE key = ?')
+    .get('achievements_title') as GuildInfoContentRow | undefined;
+  const title = titleRow?.title ?? 'Current Progress & Past Achievements';
+
+  // Build manual sections grouped by expansion
+  const manualSections = buildManualSections(manualRows);
+
+  // Fetch API achievements for expansions 6+
+  const apiSections = await fetchApiAchievements();
+
+  // Combine: API sections (reverse chronological) first, then manual sections (reverse chronological)
+  const allSections = [...apiSections.reverse(), ...manualSections.reverse()];
+
+  // Render as PNG
+  const imageBuffer = renderAchievementsImage(allSections, title);
+
+  // Build attachment
+  const attachment = new AttachmentBuilder(imageBuffer, { name: 'achievements.png' });
+
+  // Check if a previous achievements message exists
+  const existingMsg = db
+    .prepare('SELECT * FROM guild_info_messages WHERE key = ?')
+    .get('achievements') as GuildInfoMessageRow | undefined;
+
+  if (existingMsg) {
+    try {
+      const oldMessage = await channel.messages.fetch(existingMsg.message_id);
+      await oldMessage.edit({
+        embeds: [new EmbedBuilder().setColor(Colors.Green).setTitle(title).setImage('attachment://achievements.png')],
+        files: [attachment],
+      });
+      logger.info('guild-info', 'Updated existing Achievements message');
+      return;
+    } catch {
+      logger.debug('guild-info', 'Previous achievements message not found, creating new one');
+    }
+  }
+
+  // Send new message
+  const message = await channel.send({
+    embeds: [new EmbedBuilder().setColor(Colors.Green).setTitle(title).setImage('attachment://achievements.png')],
+    files: [attachment],
+  });
+
+  db.prepare('INSERT OR REPLACE INTO guild_info_messages (key, message_id) VALUES (?, ?)').run(
+    'achievements',
+    message.id,
+  );
+
+  logger.info('guild-info', 'Posted Achievements image');
+}
+
+// ─── Manual Sections ────────────────────────────────────────────
+
+function buildManualSections(rows: AchievementsManualRow[]): AchievementSection[] {
+  const grouped = new Map<number, AchievementsManualRow[]>();
+
+  for (const row of rows) {
+    const existing = grouped.get(row.expansion) ?? [];
+    existing.push(row);
+    grouped.set(row.expansion, existing);
+  }
+
+  const sections: AchievementSection[] = [];
+
+  for (const [expansion, expRows] of grouped) {
+    sections.push({
+      expansionLabel: `Expansion ${expansion}`,
+      rows: expRows.map((r) => ({
+        raid: r.raid,
+        progress: r.progress,
+        result: r.result.replace(/\*\*/g, ''),
+        isCE: r.result.includes('CE'),
+      })),
+    });
+  }
+
+  return sections;
+}
+
+// ─── API Achievements ───────────────────────────────────────────
+
+async function fetchApiAchievements(): Promise<AchievementSection[]> {
+  const sections: AchievementSection[] = [];
+  let expansionId = 6;
+
+  while (true) {
+    let staticData;
+    try {
+      staticData = await getRaidStaticData(expansionId);
+    } catch {
+      // 400 or other error means no more expansions
+      break;
+    }
+
+    const raids = (staticData.raids ?? []) as RaidStaticRaid[];
+    if (raids.length === 0) break;
+
+    // Sort raids by end date (ascending) so we process chronologically
+    const sortedRaids = [...raids].sort((a, b) => {
+      const endA = a.ends?.eu ?? a.ends?.us ?? '';
+      const endB = b.ends?.eu ?? b.ends?.us ?? '';
+      if (!endA && !endB) return 0;
+      if (!endA) return 1;
+      if (!endB) return -1;
+      return endA.localeCompare(endB);
+    });
+
+    const sectionRows: AchievementRow[] = [];
+
+    for (const raid of sortedRaids) {
+      // Skip Fated/Awakened raids
+      if (raid.name.startsWith('Fated') || raid.name.startsWith('Awakened')) continue;
+
+      try {
+        const rankings = await getRaidRankings(raid.slug) as unknown as RaidRankingEntry[];
+
+        if (!rankings || rankings.length === 0) continue;
+
+        // Use the ranking entry with the most encounters defeated
+        const best = rankings.reduce((a, b) =>
+          (b.encountersDefeated > a.encountersDefeated ? b : a), rankings[0]);
+
+        const killedBosses = best.encountersDefeated;
+        const totalBosses = best.encountersTotal || raid.encounters.length;
+
+        if (killedBosses === 0) continue;
+
+        // Determine CE status
+        const isCE = determineCE(raid, best);
+
+        const progress = `${killedBosses}/${totalBosses}M`;
+        const rank = best.rank;
+        const result = isCE ? `CE WR ${rank}` : `WR ${rank}`;
+
+        sectionRows.push({
+          raid: raid.name,
+          progress,
+          result,
+          isCE,
+        });
+      } catch (error) {
+        logger.debug('guild-info', `Failed to fetch rankings for ${raid.slug}: ${error}`);
+      }
+    }
+
+    if (sectionRows.length > 0) {
+      sections.push({
+        expansionLabel: `Expansion ${expansionId}`,
+        rows: sectionRows,
+      });
+    }
+
+    expansionId++;
+  }
+
+  return sections;
+}
+
+function determineCE(raid: RaidStaticRaid, ranking: RaidRankingEntry): boolean {
+  const totalBosses = ranking.encountersTotal || raid.encounters.length;
+
+  // Not all bosses killed = no CE
+  if (ranking.encountersDefeated < totalBosses) return false;
+
+  // Get the tier end date
+  const endDate = raid.ends?.eu ?? null;
+
+  // If ends.eu is null (ongoing tier), CE = all bosses killed
+  if (!endDate) return true;
+
+  // Check if the last boss was defeated before the tier end date
+  if (ranking.encounter_defeated && ranking.encounter_defeated.length > 0) {
+    const lastEncounterSlug = raid.encounters[raid.encounters.length - 1]?.slug;
+    const lastBossEntry = ranking.encounter_defeated.find(
+      (e) => e.slug === lastEncounterSlug,
+    );
+    if (lastBossEntry) {
+      return new Date(lastBossEntry.firstDefeated) < new Date(endDate);
+    }
+  }
+
+  // If we can't determine timing but all bosses are killed, assume CE
+  return true;
+}
+
+// ─── Image Rendering ────────────────────────────────────────────
+
+function renderAchievementsImage(sections: AchievementSection[], title: string): Buffer {
+  const PADDING = 20;
+  const ROW_HEIGHT = 28;
+  const HEADER_HEIGHT = 40;
+  const SECTION_GAP = 16;
+  const FONT_SIZE = 14;
+  const HEADER_FONT_SIZE = 12;
+  const WIDTH = 800;
+
+  // Column positions
+  const COL_RAID = PADDING;
+  const COL_PROGRESS = 520;
+  const COL_RESULT = 650;
+
+  // Calculate total height
+  let totalRows = 0;
+  for (const section of sections) {
+    totalRows += section.rows.length;
+    if (section.expansionLabel) totalRows++; // separator row
+  }
+
+  const height = PADDING + HEADER_HEIGHT + totalRows * ROW_HEIGHT + sections.length * SECTION_GAP + PADDING;
+
+  const canvas = createCanvas(WIDTH, height);
+  const ctx = canvas.getContext('2d');
+
+  // Dark background (Discord dark theme)
+  ctx.fillStyle = '#2b2d31';
+  ctx.fillRect(0, 0, WIDTH, height);
+
+  // Column headers
+  ctx.fillStyle = '#96989d';
+  ctx.font = `bold ${HEADER_FONT_SIZE}px sans-serif`;
+  ctx.fillText('RAID', COL_RAID, PADDING + 20);
+  ctx.fillText('PROGRESS', COL_PROGRESS, PADDING + 20);
+  ctx.fillText('WORLD RANK', COL_RESULT, PADDING + 20);
+
+  // Header underline
+  ctx.strokeStyle = '#3f4147';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(PADDING, PADDING + HEADER_HEIGHT - 4);
+  ctx.lineTo(WIDTH - PADDING, PADDING + HEADER_HEIGHT - 4);
+  ctx.stroke();
+
+  let y = PADDING + HEADER_HEIGHT + ROW_HEIGHT;
+
+  for (const section of sections) {
+    // Expansion separator
+    if (section.expansionLabel) {
+      ctx.fillStyle = '#5865f2';
+      ctx.font = `bold ${FONT_SIZE}px sans-serif`;
+      ctx.fillText(section.expansionLabel, COL_RAID, y);
+      y += ROW_HEIGHT;
+    }
+
+    for (const row of section.rows) {
+      const color = row.isCE ? '#57f287' : '#ffffff';
+
+      ctx.fillStyle = color;
+      ctx.font = `${FONT_SIZE}px sans-serif`;
+      ctx.fillText(row.raid, COL_RAID, y);
+      ctx.fillText(row.progress, COL_PROGRESS, y);
+      ctx.fillText(row.result, COL_RESULT, y);
+
+      y += ROW_HEIGHT;
+    }
+
+    y += SECTION_GAP;
+  }
+
+  return Buffer.from(canvas.toBuffer('image/png'));
+}

--- a/src/functions/guild-info/updateRecruitment.ts
+++ b/src/functions/guild-info/updateRecruitment.ts
@@ -1,0 +1,93 @@
+import {
+  type Client,
+  EmbedBuilder,
+  Colors,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import { getOrCreateGuildInfoChannel } from './clearGuildInfo.js';
+import type { GuildInfoContentRow, OverlordRow, ConfigRow } from '../../types/index.js';
+
+/**
+ * Post the Recruitment embed with overlord mentions and an Apply Here button.
+ */
+export async function updateRecruitment(client: Client): Promise<void> {
+  const channel = await getOrCreateGuildInfoChannel(client);
+  if (!channel) {
+    logger.warn('guild-info', 'Could not resolve guild info channel for Recruitment');
+    return;
+  }
+
+  const db = getDatabase();
+
+  // Get all recruitment sections ordered by key
+  const sections = db
+    .prepare("SELECT * FROM guild_info_content WHERE key LIKE 'recruitment_%' ORDER BY key")
+    .all() as GuildInfoContentRow[];
+
+  if (sections.length === 0) {
+    logger.warn('guild-info', 'No recruitment sections found in guild_info_content');
+    return;
+  }
+
+  // Get overlords for mention string
+  const overlords = db.prepare('SELECT * FROM overlords').all() as OverlordRow[];
+  const overlordMentions = overlords.map((o) => `<@${o.user_id}>`).join(' / ');
+
+  // Build embed fields from sections, replacing {{OVERLORDS}} token
+  const fields: { name: string; value: string; inline?: boolean }[] = [];
+
+  for (let i = 0; i < sections.length; i++) {
+    const section = sections[i];
+    let content = section.content;
+
+    // Replace {{OVERLORDS}} token with the mentions string
+    content = content.replace('{{OVERLORDS}}', overlordMentions || 'an officer');
+
+    fields.push({
+      name: section.title ?? '\u200b',
+      value: content,
+    });
+
+    // Add spacer field between sections (but not after the last one)
+    if (i < sections.length - 1) {
+      fields.push({ name: '\u200b', value: '\u200b' });
+    }
+  }
+
+  const embed = new EmbedBuilder()
+    .setColor(Colors.Green)
+    .setTitle('Recruitment')
+    .addFields(fields);
+
+  // Build Apply Here button
+  const applicationUrlRow = db
+    .prepare('SELECT value FROM config WHERE key = ?')
+    .get('application_channel_url') as ConfigRow | undefined;
+
+  const applyUrl = applicationUrlRow?.value || 'https://discord.com';
+
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setLabel('Apply Here')
+      .setStyle(ButtonStyle.Link)
+      .setURL(applyUrl),
+  );
+
+  const message = await channel.send({
+    embeds: [embed],
+    components: [row],
+    allowedMentions: { users: [] },
+  });
+
+  // Store message ID
+  db.prepare('INSERT OR REPLACE INTO guild_info_messages (key, message_id) VALUES (?, ?)').run(
+    'recruitment',
+    message.id,
+  );
+
+  logger.info('guild-info', 'Posted Recruitment embed');
+}

--- a/src/functions/guild-info/updateSchedule.ts
+++ b/src/functions/guild-info/updateSchedule.ts
@@ -1,0 +1,54 @@
+import { type Client, EmbedBuilder, Colors } from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import { getOrCreateGuildInfoChannel } from './clearGuildInfo.js';
+import type { ScheduleConfigRow, ScheduleDayRow } from '../../types/index.js';
+
+/**
+ * Post the Schedule embed to the guild info channel.
+ */
+export async function updateSchedule(client: Client): Promise<void> {
+  const channel = await getOrCreateGuildInfoChannel(client);
+  if (!channel) {
+    logger.warn('guild-info', 'Could not resolve guild info channel for Schedule');
+    return;
+  }
+
+  const db = getDatabase();
+
+  // Get schedule config
+  const titleRow = db.prepare('SELECT value FROM schedule_config WHERE key = ?').get('title') as ScheduleConfigRow | undefined;
+  const timezoneRow = db.prepare('SELECT value FROM schedule_config WHERE key = ?').get('timezone') as ScheduleConfigRow | undefined;
+
+  const title = titleRow?.value ?? 'Raid Schedule';
+  const timezone = timezoneRow?.value ?? 'Server Time';
+
+  // Get schedule days ordered by sort_order
+  const days = db.prepare('SELECT * FROM schedule_days ORDER BY sort_order').all() as ScheduleDayRow[];
+
+  if (days.length === 0) {
+    logger.warn('guild-info', 'No schedule days found');
+    return;
+  }
+
+  // Build embed with 3 inline fields: Day, spacer, Time
+  const embed = new EmbedBuilder()
+    .setColor(Colors.Green)
+    .setTitle(title)
+    .addFields(
+      { name: 'Day', value: days.map((d) => d.day).join('\n'), inline: true },
+      { name: '\u200b', value: days.map(() => '\u200b').join('\n'), inline: true },
+      { name: 'Time', value: days.map((d) => d.time).join('\n'), inline: true },
+    )
+    .setFooter({ text: timezone });
+
+  const message = await channel.send({ embeds: [embed] });
+
+  // Store message ID
+  db.prepare('INSERT OR REPLACE INTO guild_info_messages (key, message_id) VALUES (?, ?)').run(
+    'schedule',
+    message.id,
+  );
+
+  logger.info('guild-info', 'Posted Schedule embed');
+}


### PR DESCRIPTION
## Summary

Guild Info domain: About Us, Schedule, Recruitment, and Achievements embeds posted to a dedicated channel with auto-creation.

### What's included (5 commits):

- **clearGuildInfo** - Bulk delete messages, clear DB tracking
- **updateAboutUs** - Green embed with guild description + 3 link buttons (RaiderIO, WoWProgress, WarcraftLogs)
- **updateSchedule** - Raid schedule embed with Day/Time columns and timezone footer
- **updateRecruitment** - Recruitment sections with overlord mentions, {{OVERLORDS}} token, Apply Here button
- **updateAchievements** - Generated PNG image combining manual data (expansion 4-5) + live Raider.io data (6+) with CE detection
- **/guildinfo** - Full refresh command (admin)
- **/updateachievements** - Achievements-only refresh (admin)
- **Scheduled task** - Achievements refresh every 30 minutes

### Known bugs (filed as issues):

- #7 - Achievements image should not be inside embed
- #8 - Achievements image text too small
- #9 - Recruitment sections in wrong order
- #10 - Achievements shows [object Object] for Progress/WR columns
- #11 - Guild info should use existing Welcome channel

### Chrome verified:

- All 4 embeds render in the guild-info channel
- About Us shows link buttons with emojis
- Schedule shows correct days/times
- Auto-channel creation works

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` - all 57 tests pass
- [ ] `/guildinfo` posts all 4 embeds
- [ ] `/updateachievements` refreshes achievements only

🤖 Generated with [Claude Code](https://claude.com/claude-code)