### PR TITLE
feat: Applications - DM questionnaire, voting, accept/reject, transcripts

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -31,6 +31,14 @@ All commands are Discord slash commands registered to a single guild.
 | `/raiders remove_overlord` | Remove an overlord | Yes | No |
 | `/guildinfo` | Full refresh of all guild info embeds (About Us, Schedule, Recruitment, Achievements) | Yes | No |
 | `/updateachievements` | Refresh the achievements embed only | Yes | No |
+| `/apply` | Start a guild application via DM questionnaire | No | No |
+| `/applications list_questions` | List all application questions | Yes | No |
+| `/applications add_question` | Add a new application question | Yes | No |
+| `/applications remove_question` | Remove an application question by ID | Yes | No |
+| `/applications post_apply_button` | Post an "Apply Now" button embed in the current channel | Yes | No |
+| `/applications view_pending` | View all pending applications (in_progress, active, abandoned) | Yes | No |
+| `/applications set_accept_message` | Set the default acceptance DM message via modal | Yes | No |
+| `/applications set_reject_message` | Set the default rejection DM message via modal | Yes | No |
 
 ## Notes
 

--- a/src/commands/applications.ts
+++ b/src/commands/applications.ts
@@ -1,0 +1,253 @@
+import {
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  MessageFlags,
+  PermissionFlagsBits,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  EmbedBuilder,
+  Colors,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+} from 'discord.js';
+import { getDatabase } from '../database/db.js';
+import { requireOfficer, createEmbed, asSendable } from '../utils.js';
+import { audit } from '../services/auditLog.js';
+import {
+  getQuestions,
+  addQuestion,
+  removeQuestion,
+} from '../functions/applications/applicationQuestions.js';
+import type { ApplicationRow } from '../types/index.js';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('applications')
+    .setDescription('Manage application system')
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+    .addSubcommand((sub) =>
+      sub.setName('list_questions').setDescription('List all application questions'),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('add_question')
+        .setDescription('Add a new application question')
+        .addStringOption((opt) =>
+          opt.setName('question').setDescription('The question text').setRequired(true),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('remove_question')
+        .setDescription('Remove an application question')
+        .addIntegerOption((opt) =>
+          opt.setName('id').setDescription('The question ID to remove').setRequired(true),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('post_apply_button')
+        .setDescription('Post an "Apply Now" button embed in the current channel'),
+    )
+    .addSubcommand((sub) =>
+      sub.setName('view_pending').setDescription('View all pending applications'),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('set_accept_message')
+        .setDescription('Set the default acceptance DM message'),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('set_reject_message')
+        .setDescription('Set the default rejection DM message'),
+    ),
+  async execute(interaction: ChatInputCommandInteraction) {
+    if (!(await requireOfficer(interaction))) return;
+
+    const subcommand = interaction.options.getSubcommand();
+
+    switch (subcommand) {
+      case 'list_questions': {
+        const questions = getQuestions();
+
+        if (questions.length === 0) {
+          await interaction.reply({
+            content: 'No application questions configured.',
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        const list = questions
+          .map((q) => `**${q.id}.** (order: ${q.sort_order}) ${q.question}`)
+          .join('\n');
+
+        await interaction.reply({
+          content: `**Application Questions:**\n${list}`,
+          flags: MessageFlags.Ephemeral,
+        });
+        break;
+      }
+
+      case 'add_question': {
+        const questionText = interaction.options.getString('question', true);
+        const result = addQuestion(questionText);
+
+        await audit(interaction.user, 'added application question', `#${result.id}: ${questionText}`);
+        await interaction.reply({
+          content: `Added question #${result.id} (order: ${result.sort_order}): ${questionText}`,
+          flags: MessageFlags.Ephemeral,
+        });
+        break;
+      }
+
+      case 'remove_question': {
+        const id = interaction.options.getInteger('id', true);
+        const success = removeQuestion(id);
+
+        if (success) {
+          await audit(interaction.user, 'removed application question', `#${id}`);
+          await interaction.reply({
+            content: `Removed question #${id}.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        } else {
+          await interaction.reply({
+            content: `Question #${id} not found.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+        break;
+      }
+
+      case 'post_apply_button': {
+        const embed = new EmbedBuilder()
+          .setTitle('Apply to SeriouslyCasual')
+          .setDescription(
+            'Interested in joining our guild? Click the button below to start your application!\n\n' +
+            'You will be asked a series of questions via DM. Make sure your DMs are open.',
+          )
+          .setColor(Colors.Green)
+          .setTimestamp()
+          .setFooter({ text: 'SeriouslyCasualBot' });
+
+        const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+          new ButtonBuilder()
+            .setCustomId('application:apply')
+            .setLabel('Apply Now')
+            .setStyle(ButtonStyle.Success)
+            .setEmoji('📝'),
+        );
+
+        const sendChannel = asSendable(interaction.channel);
+        if (!sendChannel) {
+          await interaction.reply({
+            content: 'This command must be used in a text channel.',
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        await sendChannel.send({ embeds: [embed], components: [row] });
+
+        await audit(interaction.user, 'posted apply button', `in #${sendChannel.name}`);
+        await interaction.reply({
+          content: 'Apply button posted!',
+          flags: MessageFlags.Ephemeral,
+        });
+        break;
+      }
+
+      case 'view_pending': {
+        const db = getDatabase();
+        const applications = db
+          .prepare(
+            `SELECT * FROM applications
+             WHERE status IN ('in_progress', 'active', 'abandoned')
+             ORDER BY started_at DESC`,
+          )
+          .all() as ApplicationRow[];
+
+        if (applications.length === 0) {
+          await interaction.reply({
+            content: 'No pending applications.',
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        const lines = applications.map((app) => {
+          const statusEmoji =
+            app.status === 'active' ? '🟢' :
+            app.status === 'in_progress' ? '🟡' :
+            '🔴';
+          const channelRef = app.channel_id ? ` | <#${app.channel_id}>` : '';
+          return `${statusEmoji} **#${app.id}** - ${app.character_name || 'Unknown'} (<@${app.applicant_user_id}>) - ${app.status}${channelRef}`;
+        });
+
+        const embed = createEmbed(`Pending Applications (${applications.length})`).setDescription(
+          lines.join('\n'),
+        );
+
+        await interaction.reply({
+          embeds: [embed],
+          flags: MessageFlags.Ephemeral,
+        });
+        break;
+      }
+
+      case 'set_accept_message': {
+        const db = getDatabase();
+        const current = db
+          .prepare('SELECT message FROM default_messages WHERE key = ?')
+          .get('application_accept') as { message: string } | undefined;
+
+        const modal = new ModalBuilder()
+          .setCustomId('application:modal:accept_message')
+          .setTitle('Set Accept Message');
+
+        const messageInput = new TextInputBuilder()
+          .setCustomId('message')
+          .setLabel('Accept DM Message')
+          .setStyle(TextInputStyle.Paragraph)
+          .setValue(current?.message ?? '')
+          .setRequired(true)
+          .setMaxLength(2000);
+
+        const row = new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput);
+        modal.addComponents(row);
+
+        await interaction.showModal(modal);
+        break;
+      }
+
+      case 'set_reject_message': {
+        const db = getDatabase();
+        const current = db
+          .prepare('SELECT message FROM default_messages WHERE key = ?')
+          .get('application_reject') as { message: string } | undefined;
+
+        const modal = new ModalBuilder()
+          .setCustomId('application:modal:reject_message')
+          .setTitle('Set Reject Message');
+
+        const messageInput = new TextInputBuilder()
+          .setCustomId('message')
+          .setLabel('Reject DM Message')
+          .setStyle(TextInputStyle.Paragraph)
+          .setValue(current?.message ?? '')
+          .setRequired(true)
+          .setMaxLength(2000);
+
+        const row = new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput);
+        modal.addComponents(row);
+
+        await interaction.showModal(modal);
+        break;
+      }
+    }
+  },
+};

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -1,0 +1,27 @@
+import {
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  MessageFlags,
+} from 'discord.js';
+import { startApplication } from '../functions/applications/startApplication.js';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('apply')
+    .setDescription('Apply to join the guild'),
+  async execute(interaction: ChatInputCommandInteraction) {
+    const success = await startApplication(interaction.user);
+
+    if (success) {
+      await interaction.reply({
+        content: 'Check your DMs! I\'ve sent you the application questions.',
+        flags: MessageFlags.Ephemeral,
+      });
+    } else {
+      await interaction.reply({
+        content: 'I was unable to send you a DM. Please make sure your DMs are open and try again.',
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+  },
+};

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -14,6 +14,9 @@ import {
   enterEditMode,
   startSessionTimeout,
 } from '../functions/applications/dmQuestionnaire.js';
+import { voteOnApplication } from '../functions/applications/voteOnApplication.js';
+import { acceptApplication, processAcceptModal } from '../functions/applications/acceptApplication.js';
+import { rejectApplication, processRejectModal } from '../functions/applications/rejectApplication.js';
 
 export default {
   name: 'interactionCreate',
@@ -208,6 +211,24 @@ export default {
             flags: MessageFlags.Ephemeral,
           });
         }
+
+        // application_vote:{type}:{applicationId} - Vote on an application
+        if (customId.startsWith('application_vote:')) {
+          const parts = customId.split(':');
+          const voteType = parts[1];
+          const applicationId = parseInt(parts[2], 10);
+          await voteOnApplication(interaction, applicationId, voteType);
+        }
+
+        // application:accept:{applicationId} - Accept button (show modal)
+        if (customId.startsWith('application:accept:')) {
+          await acceptApplication(interaction);
+        }
+
+        // application:reject:{applicationId} - Reject button (show modal)
+        if (customId.startsWith('application:reject:')) {
+          await rejectApplication(interaction);
+        }
       } catch (error) {
         const err = error instanceof Error ? error : new Error(String(error));
         logger.error('interaction', `Button handler failed (${customId}): ${err.message}`, err);
@@ -301,6 +322,16 @@ export default {
             content: 'Reject message updated.',
             flags: MessageFlags.Ephemeral,
           });
+        }
+
+        // application:modal:accept:{applicationId} - Process accept
+        if (customId.startsWith('application:modal:accept:')) {
+          await processAcceptModal(interaction);
+        }
+
+        // application:modal:reject:{applicationId} - Process reject
+        if (customId.startsWith('application:modal:reject:')) {
+          await processRejectModal(interaction);
         }
       } catch (error) {
         const err = error instanceof Error ? error : new Error(String(error));

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -7,6 +7,13 @@ import { sendAlertForRaidersWithNoUser } from '../functions/raids/sendAlertForRa
 import { audit } from '../services/auditLog.js';
 import { getDatabase } from '../database/db.js';
 import type { RaiderRow } from '../types/index.js';
+import { startApplication } from '../functions/applications/startApplication.js';
+import { submitApplication } from '../functions/applications/submitApplication.js';
+import {
+  activeSessions,
+  enterEditMode,
+  startSessionTimeout,
+} from '../functions/applications/dmQuestionnaire.js';
 
 export default {
   name: 'interactionCreate',
@@ -116,6 +123,91 @@ export default {
             });
           }
         }
+
+        // application:apply - "Apply Now" button
+        if (customId === 'application:apply') {
+          const success = await startApplication(interaction.user);
+
+          if (success) {
+            await interaction.reply({
+              content: 'Check your DMs! I\'ve sent you the application questions.',
+              flags: MessageFlags.Ephemeral,
+            });
+          } else {
+            await interaction.reply({
+              content: 'I was unable to send you a DM. Please make sure your DMs are open and try again.',
+              flags: MessageFlags.Ephemeral,
+            });
+          }
+        }
+
+        // application:edit:{applicationId} - Edit an answer
+        if (customId.startsWith('application:edit:')) {
+          const applicationId = parseInt(customId.split(':')[2], 10);
+
+          enterEditMode(interaction.user.id, applicationId);
+          startSessionTimeout(interaction.user);
+
+          try {
+            await interaction.user.send('Which answer would you like to change? (enter the number)');
+            await interaction.reply({
+              content: 'Check your DMs to edit your answer.',
+              flags: MessageFlags.Ephemeral,
+            });
+          } catch {
+            activeSessions.delete(interaction.user.id);
+            await interaction.reply({
+              content: 'I was unable to send you a DM. Please make sure your DMs are open.',
+              flags: MessageFlags.Ephemeral,
+            });
+          }
+        }
+
+        // application:confirm:{applicationId} - Submit the application
+        if (customId.startsWith('application:confirm:')) {
+          const applicationId = parseInt(customId.split(':')[2], 10);
+
+          await interaction.reply({
+            content: 'Submitting your application...',
+            flags: MessageFlags.Ephemeral,
+          });
+
+          try {
+            await submitApplication(interaction.client, applicationId, interaction.user);
+            await interaction.editReply({
+              content: 'Your application has been submitted! Officers will review it shortly.',
+            });
+          } catch (err) {
+            const error = err instanceof Error ? err : new Error(String(err));
+            logger.error('Applications', `Failed to submit application #${applicationId}: ${error.message}`, error);
+            await interaction.editReply({
+              content: 'There was an error submitting your application. Please contact an officer.',
+            });
+          }
+        }
+
+        // application:cancel:{applicationId} - Cancel the application
+        if (customId.startsWith('application:cancel:')) {
+          const applicationId = parseInt(customId.split(':')[2], 10);
+          const db = getDatabase();
+
+          db.prepare('UPDATE applications SET status = ? WHERE id = ?')
+            .run('abandoned', applicationId);
+
+          // Clean up session if exists
+          activeSessions.delete(interaction.user.id);
+
+          try {
+            await interaction.user.send('Your application has been cancelled. You can apply again anytime with /apply.');
+          } catch {
+            // DMs may be disabled
+          }
+
+          await interaction.reply({
+            content: 'Application cancelled.',
+            flags: MessageFlags.Ephemeral,
+          });
+        }
       } catch (error) {
         const err = error instanceof Error ? error : new Error(String(error));
         logger.error('interaction', `Button handler failed (${customId}): ${err.message}`, err);
@@ -170,6 +262,51 @@ export default {
         logger.error('interaction', `Select menu handler failed (${customId}): ${err.message}`, err);
 
         const reply = { content: 'An error occurred handling this selection.', flags: MessageFlags.Ephemeral } as const;
+        if (interaction.replied || interaction.deferred) {
+          await interaction.followUp(reply).catch(() => {});
+        } else {
+          await interaction.reply(reply).catch(() => {});
+        }
+      }
+    }
+
+    // Modal submit handlers
+    if (interaction.isModalSubmit()) {
+      const customId = interaction.customId;
+
+      try {
+        // application:modal:accept_message
+        if (customId === 'application:modal:accept_message') {
+          const message = interaction.fields.getTextInputValue('message');
+          const db = getDatabase();
+          db.prepare('INSERT OR REPLACE INTO default_messages (key, message) VALUES (?, ?)')
+            .run('application_accept', message);
+
+          await audit(interaction.user, 'updated accept message', message.substring(0, 100));
+          await interaction.reply({
+            content: 'Accept message updated.',
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+
+        // application:modal:reject_message
+        if (customId === 'application:modal:reject_message') {
+          const message = interaction.fields.getTextInputValue('message');
+          const db = getDatabase();
+          db.prepare('INSERT OR REPLACE INTO default_messages (key, message) VALUES (?, ?)')
+            .run('application_reject', message);
+
+          await audit(interaction.user, 'updated reject message', message.substring(0, 100));
+          await interaction.reply({
+            content: 'Reject message updated.',
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        logger.error('interaction', `Modal handler failed (${customId}): ${err.message}`, err);
+
+        const reply = { content: 'An error occurred handling this modal.', flags: MessageFlags.Ephemeral } as const;
         if (interaction.replied || interaction.deferred) {
           await interaction.followUp(reply).catch(() => {});
         } else {

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,0 +1,17 @@
+import type { Message } from 'discord.js';
+import { handleDmMessage } from '../functions/applications/dmQuestionnaire.js';
+
+export default {
+  name: 'messageCreate',
+  async execute(...args: unknown[]) {
+    const message = args[0] as Message;
+
+    // Ignore bot messages
+    if (message.author.bot) return;
+
+    // Handle DMs - check if this is an application response
+    if (!message.guild) {
+      await handleDmMessage(message);
+    }
+  },
+};

--- a/src/functions/applications/acceptApplication.ts
+++ b/src/functions/applications/acceptApplication.ts
@@ -1,0 +1,262 @@
+import {
+  type ButtonInteraction,
+  type ModalSubmitInteraction,
+  type GuildMember,
+  type ForumChannel,
+  type TextChannel,
+  type AnyThreadChannel,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  ActionRowBuilder,
+  AttachmentBuilder,
+  MessageFlags,
+} from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { config } from '../../config.js';
+import { logger } from '../../services/logger.js';
+import { audit } from '../../services/auditLog.js';
+import { generateTranscript } from './generateTranscript.js';
+import type { ApplicationRow, DefaultMessageRow } from '../../types/index.js';
+
+/**
+ * Show the Accept modal when an officer clicks the Accept button.
+ */
+export async function acceptApplication(interaction: ButtonInteraction): Promise<void> {
+  // Officer permission check
+  const member = interaction.member as GuildMember;
+  if (!member.roles.cache.has(config.officerRoleId)) {
+    await interaction.reply({
+      content: 'You do not have permission to accept applications.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const applicationId = parseInt(interaction.customId.split(':')[2], 10);
+  const db = getDatabase();
+
+  const application = db
+    .prepare('SELECT * FROM applications WHERE id = ?')
+    .get(applicationId) as ApplicationRow | undefined;
+
+  if (!application) {
+    await interaction.reply({
+      content: 'Application not found.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  // Get default accept message
+  const defaultMsg = db
+    .prepare('SELECT * FROM default_messages WHERE key = ?')
+    .get('application_accept') as DefaultMessageRow | undefined;
+
+  const defaultMessage = defaultMsg?.message ?? 'Congratulations! Your application has been accepted.';
+  const characterName = application.character_name ?? 'Unknown';
+  const today = new Date().toISOString().split('T')[0];
+
+  // Build and show modal
+  const modal = new ModalBuilder()
+    .setCustomId(`application:modal:accept:${applicationId}`)
+    .setTitle('Accept Application');
+
+  const charNameInput = new TextInputBuilder()
+    .setCustomId('character_name')
+    .setLabel('Character Name')
+    .setStyle(TextInputStyle.Short)
+    .setValue(characterName)
+    .setRequired(true);
+
+  const roleInput = new TextInputBuilder()
+    .setCustomId('role')
+    .setLabel('Role')
+    .setStyle(TextInputStyle.Short)
+    .setPlaceholder('e.g., Ranged DPS, Healer')
+    .setRequired(true);
+
+  const startDateInput = new TextInputBuilder()
+    .setCustomId('start_date')
+    .setLabel('Start Date')
+    .setStyle(TextInputStyle.Short)
+    .setPlaceholder('YYYY-MM-DD')
+    .setValue(today)
+    .setRequired(true);
+
+  const messageInput = new TextInputBuilder()
+    .setCustomId('message_to_applicant')
+    .setLabel('Message to Applicant')
+    .setStyle(TextInputStyle.Paragraph)
+    .setValue(defaultMessage)
+    .setRequired(true);
+
+  modal.addComponents(
+    new ActionRowBuilder<TextInputBuilder>().addComponents(charNameInput),
+    new ActionRowBuilder<TextInputBuilder>().addComponents(roleInput),
+    new ActionRowBuilder<TextInputBuilder>().addComponents(startDateInput),
+    new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput),
+  );
+
+  await interaction.showModal(modal);
+}
+
+/**
+ * Process the Accept modal submission.
+ */
+export async function processAcceptModal(interaction: ModalSubmitInteraction): Promise<void> {
+  const applicationId = parseInt(interaction.customId.split(':')[3], 10);
+  const db = getDatabase();
+
+  const application = db
+    .prepare('SELECT * FROM applications WHERE id = ?')
+    .get(applicationId) as ApplicationRow | undefined;
+
+  if (!application) {
+    await interaction.reply({
+      content: 'Application not found.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const characterName = interaction.fields.getTextInputValue('character_name');
+  const role = interaction.fields.getTextInputValue('role');
+  const startDate = interaction.fields.getTextInputValue('start_date');
+  const messageToApplicant = interaction.fields.getTextInputValue('message_to_applicant');
+
+  // Validate date format
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
+    await interaction.reply({
+      content: 'Invalid date format. Please use YYYY-MM-DD.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+  const guild = interaction.guild;
+  if (!guild) {
+    await interaction.editReply({ content: 'This must be used in a server.' });
+    return;
+  }
+
+  // Generate transcript from the app text channel
+  let transcriptBuffer: Buffer | null = null;
+  if (application.channel_id) {
+    try {
+      const appChannel = guild.channels.cache.get(application.channel_id) as TextChannel | undefined;
+      if (appChannel) {
+        const transcript = await generateTranscript(appChannel);
+        transcriptBuffer = transcript.buffer;
+      }
+    } catch (error) {
+      logger.warn('Applications', `Failed to generate transcript for application #${applicationId}: ${error}`);
+    }
+  }
+
+  // Post transcript to the forum thread
+  if (application.thread_id) {
+    try {
+      const thread = (await guild.channels.fetch(application.thread_id)) as AnyThreadChannel | null;
+      if (thread?.isThread()) {
+        const content = `Application **accepted** by ${interaction.user} for **${characterName}** as **${role}** starting **${startDate}**.`;
+
+        if (transcriptBuffer) {
+          const attachment = new AttachmentBuilder(transcriptBuffer, {
+            name: `transcript-${characterName.toLowerCase()}.txt`,
+          });
+          await thread.send({ content, files: [attachment] });
+        } else {
+          await thread.send(content);
+        }
+
+        // Update forum tags: remove Active, add Accepted
+        await swapForumTag(thread, 'Active', 'Accepted');
+
+        // Lock the forum thread
+        await thread.setLocked(true);
+      }
+    } catch (error) {
+      logger.warn('Applications', `Failed to update forum thread for application #${applicationId}: ${error}`);
+    }
+  }
+
+  // DM the applicant
+  try {
+    const applicant = await interaction.client.users.fetch(application.applicant_user_id);
+    const dmContent = messageToApplicant;
+
+    if (transcriptBuffer) {
+      const attachment = new AttachmentBuilder(transcriptBuffer, {
+        name: `application-transcript-${characterName.toLowerCase()}.txt`,
+      });
+      await applicant.send({ content: dmContent, files: [attachment] });
+    } else {
+      await applicant.send(dmContent);
+    }
+  } catch (error) {
+    logger.warn('Applications', `Failed to DM applicant for application #${applicationId}: ${error}`);
+  }
+
+  // Delete the app text channel
+  if (application.channel_id) {
+    try {
+      const appChannel = guild.channels.cache.get(application.channel_id);
+      if (appChannel) {
+        await appChannel.delete();
+      }
+    } catch (error) {
+      logger.warn('Applications', `Failed to delete app channel for application #${applicationId}: ${error}`);
+    }
+  }
+
+  // Update application in DB
+  db.prepare(
+    `UPDATE applications
+     SET status = 'accepted',
+         character_name = ?,
+         resolved_at = datetime('now')
+     WHERE id = ?`,
+  ).run(characterName, applicationId);
+
+  // Audit log
+  await audit(interaction.user, 'accepted application', `${characterName} as ${role} starting ${startDate}`);
+
+  // TODO: Trial creation bridge - will be implemented in the Trial Review slice
+
+  logger.info('Applications', `Application #${applicationId} accepted: ${characterName} as ${role}`);
+
+  await interaction.editReply({ content: 'Application accepted.' });
+}
+
+// ─── Helpers ──────────────────────────────────────────────────
+
+/**
+ * Swap a forum tag on a thread: remove `removeTagName`, add `addTagName`.
+ */
+async function swapForumTag(
+  thread: AnyThreadChannel,
+  removeTagName: string,
+  addTagName: string,
+): Promise<void> {
+  const parent = thread.parent;
+  if (!parent || !('availableTags' in parent)) return;
+
+  const forum = parent as ForumChannel;
+  const availableTags = forum.availableTags;
+
+  const removeTag = availableTags.find((t) => t.name === removeTagName);
+  const addTag = availableTags.find((t) => t.name === addTagName);
+
+  if (!addTag) return;
+
+  const currentTags = thread.appliedTags ?? [];
+  const newTags = currentTags.filter((id) => id !== removeTag?.id);
+  if (!newTags.includes(addTag.id)) {
+    newTags.push(addTag.id);
+  }
+
+  await thread.setAppliedTags(newTags);
+}

--- a/src/functions/applications/applicationQuestions.ts
+++ b/src/functions/applications/applicationQuestions.ts
@@ -1,0 +1,55 @@
+import { getDatabase } from '../../database/db.js';
+import type { ApplicationQuestionRow } from '../../types/index.js';
+
+/**
+ * Get all application questions ordered by sort_order.
+ */
+export function getQuestions(): ApplicationQuestionRow[] {
+  const db = getDatabase();
+  return db
+    .prepare('SELECT * FROM application_questions ORDER BY sort_order')
+    .all() as ApplicationQuestionRow[];
+}
+
+/**
+ * Get a single question by ID.
+ */
+export function getQuestionById(id: number): ApplicationQuestionRow | undefined {
+  const db = getDatabase();
+  return db
+    .prepare('SELECT * FROM application_questions WHERE id = ?')
+    .get(id) as ApplicationQuestionRow | undefined;
+}
+
+/**
+ * Add a new question with auto-incrementing sort_order.
+ */
+export function addQuestion(question: string): ApplicationQuestionRow {
+  const db = getDatabase();
+  const maxRow = db
+    .prepare('SELECT MAX(sort_order) as max_order FROM application_questions')
+    .get() as { max_order: number | null };
+  const nextOrder = (maxRow.max_order ?? 0) + 1;
+
+  const result = db
+    .prepare('INSERT INTO application_questions (question, sort_order) VALUES (?, ?)')
+    .run(question, nextOrder);
+
+  return {
+    id: result.lastInsertRowid as number,
+    question,
+    sort_order: nextOrder,
+  };
+}
+
+/**
+ * Remove a question by ID.
+ * Returns true if a row was deleted, false otherwise.
+ */
+export function removeQuestion(id: number): boolean {
+  const db = getDatabase();
+  const result = db
+    .prepare('DELETE FROM application_questions WHERE id = ?')
+    .run(id);
+  return result.changes > 0;
+}

--- a/src/functions/applications/dmQuestionnaire.ts
+++ b/src/functions/applications/dmQuestionnaire.ts
@@ -1,0 +1,275 @@
+import {
+  type Message,
+  type User,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import { getQuestions } from './applicationQuestions.js';
+import type { ApplicationQuestionRow, ApplicationAnswerRow } from '../../types/index.js';
+
+// ─── Session Tracking ─────────────────────────────────────────
+
+export interface ApplicationSession {
+  applicationId: number;
+  questionIndex: number;
+  editMode?: 'awaiting_number' | 'awaiting_answer';
+  editQuestionIndex?: number;
+  timeout?: ReturnType<typeof setTimeout>;
+}
+
+/** Map of Discord user ID -> active DM session */
+export const activeSessions = new Map<string, ApplicationSession>();
+
+const SESSION_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+
+/**
+ * Start or reset the inactivity timeout for a session.
+ */
+export function startSessionTimeout(user: User): void {
+  const session = activeSessions.get(user.id);
+  if (!session) return;
+
+  // Clear existing timeout
+  if (session.timeout) {
+    clearTimeout(session.timeout);
+  }
+
+  session.timeout = setTimeout(async () => {
+    const s = activeSessions.get(user.id);
+    if (!s) return;
+
+    activeSessions.delete(user.id);
+
+    const db = getDatabase();
+    db.prepare('UPDATE applications SET status = ? WHERE id = ?')
+      .run('abandoned', s.applicationId);
+
+    try {
+      await user.send('Your application has timed out. You can restart with /apply.');
+    } catch {
+      // DMs may be disabled
+    }
+
+    logger.info('Applications', `Application #${s.applicationId} timed out for ${user.tag}`);
+  }, SESSION_TIMEOUT_MS);
+}
+
+// ─── DM Message Handler ───────────────────────────────────────
+
+/**
+ * Handle an incoming DM message from a user who may be in an active application session.
+ */
+export async function handleDmMessage(message: Message): Promise<void> {
+  const session = activeSessions.get(message.author.id);
+  if (!session) return;
+
+  // Reset timeout on each response
+  startSessionTimeout(message.author);
+
+  // Handle edit mode
+  if (session.editMode === 'awaiting_number') {
+    await handleEditNumberResponse(message, session);
+    return;
+  }
+
+  if (session.editMode === 'awaiting_answer') {
+    await handleEditAnswerResponse(message, session);
+    return;
+  }
+
+  // Normal questionnaire flow
+  await handleQuestionResponse(message, session);
+}
+
+// ─── Normal Question Flow ─────────────────────────────────────
+
+async function handleQuestionResponse(message: Message, session: ApplicationSession): Promise<void> {
+  const db = getDatabase();
+  const questions = getQuestions();
+  const currentQuestion = questions[session.questionIndex];
+
+  if (!currentQuestion) {
+    logger.warn('Applications', `No question at index ${session.questionIndex} for application #${session.applicationId}`);
+    return;
+  }
+
+  // Store the answer
+  db.prepare('INSERT INTO application_answers (application_id, question_id, answer) VALUES (?, ?, ?)')
+    .run(session.applicationId, currentQuestion.id, message.content);
+
+  // Set character_name from the first answer
+  if (session.questionIndex === 0) {
+    db.prepare('UPDATE applications SET character_name = ? WHERE id = ?')
+      .run(message.content.substring(0, 100), session.applicationId);
+  }
+
+  // Advance to next question
+  const nextIndex = session.questionIndex + 1;
+
+  if (nextIndex < questions.length) {
+    // More questions to ask
+    session.questionIndex = nextIndex;
+
+    db.prepare('UPDATE applications SET current_question_id = ? WHERE id = ?')
+      .run(questions[nextIndex].id, session.applicationId);
+
+    await message.author.send(
+      `**Application Question ${nextIndex + 1}/${questions.length}:**\n${questions[nextIndex].question}`,
+    );
+  } else {
+    // All questions answered - show summary
+    activeSessions.delete(message.author.id);
+    if (session.timeout) clearTimeout(session.timeout);
+
+    await showSummary(message.author, session.applicationId);
+  }
+}
+
+// ─── Edit Flow ────────────────────────────────────────────────
+
+async function handleEditNumberResponse(message: Message, session: ApplicationSession): Promise<void> {
+  const questions = getQuestions();
+  const num = parseInt(message.content.trim(), 10);
+
+  if (isNaN(num) || num < 1 || num > questions.length) {
+    await message.author.send(`Please enter a number between 1 and ${questions.length}.`);
+    return;
+  }
+
+  session.editMode = 'awaiting_answer';
+  session.editQuestionIndex = num - 1;
+
+  const question = questions[num - 1];
+  await message.author.send(`**Editing Answer ${num}:**\n${question.question}`);
+}
+
+async function handleEditAnswerResponse(message: Message, session: ApplicationSession): Promise<void> {
+  const db = getDatabase();
+  const questions = getQuestions();
+  const questionIndex = session.editQuestionIndex!;
+  const question = questions[questionIndex];
+
+  // Update the answer in DB
+  const existingAnswer = db
+    .prepare('SELECT id FROM application_answers WHERE application_id = ? AND question_id = ?')
+    .get(session.applicationId, question.id) as { id: number } | undefined;
+
+  if (existingAnswer) {
+    db.prepare('UPDATE application_answers SET answer = ? WHERE id = ?')
+      .run(message.content, existingAnswer.id);
+  } else {
+    db.prepare('INSERT INTO application_answers (application_id, question_id, answer) VALUES (?, ?, ?)')
+      .run(session.applicationId, question.id, message.content);
+  }
+
+  // Update character_name if first answer was edited
+  if (questionIndex === 0) {
+    db.prepare('UPDATE applications SET character_name = ? WHERE id = ?')
+      .run(message.content.substring(0, 100), session.applicationId);
+  }
+
+  // Clear edit mode and re-display summary
+  session.editMode = undefined;
+  session.editQuestionIndex = undefined;
+
+  // Remove from active sessions since summary re-displays with buttons
+  activeSessions.delete(message.author.id);
+  if (session.timeout) clearTimeout(session.timeout);
+
+  await showSummary(message.author, session.applicationId);
+}
+
+// ─── Summary Display ──────────────────────────────────────────
+
+/**
+ * Show the application summary with Edit/Confirm/Cancel buttons.
+ */
+export async function showSummary(user: User, applicationId: number): Promise<void> {
+  const db = getDatabase();
+
+  const answers = db
+    .prepare(
+      `SELECT aq.question, aa.answer, aq.sort_order
+       FROM application_answers aa
+       JOIN application_questions aq ON aa.question_id = aq.id
+       WHERE aa.application_id = ?
+       ORDER BY aq.sort_order`,
+    )
+    .all(applicationId) as Array<{ question: string; answer: string; sort_order: number }>;
+
+  if (answers.length === 0) {
+    await user.send('Something went wrong - no answers found for your application.');
+    return;
+  }
+
+  // Build summary text
+  let summary = '**Application Summary**\n\n';
+  for (let i = 0; i < answers.length; i++) {
+    summary += `**${i + 1}. ${answers[i].question}**\n${answers[i].answer}\n\n`;
+  }
+
+  // Split across messages if > 2000 chars
+  const messages = splitMessage(summary);
+
+  for (let i = 0; i < messages.length - 1; i++) {
+    await user.send(messages[i]);
+  }
+
+  // Add buttons to the last message
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`application:edit:${applicationId}`)
+      .setLabel('Edit Answer')
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId(`application:confirm:${applicationId}`)
+      .setLabel('Confirm & Submit')
+      .setStyle(ButtonStyle.Success),
+    new ButtonBuilder()
+      .setCustomId(`application:cancel:${applicationId}`)
+      .setLabel('Cancel')
+      .setStyle(ButtonStyle.Danger),
+  );
+
+  await user.send({ content: messages[messages.length - 1], components: [row] });
+}
+
+/**
+ * Enter edit mode for an application. Called from button handler.
+ */
+export function enterEditMode(userId: string, applicationId: number): void {
+  activeSessions.set(userId, {
+    applicationId,
+    questionIndex: 0,
+    editMode: 'awaiting_number',
+  });
+}
+
+// ─── Helpers ──────────────────────────────────────────────────
+
+function splitMessage(content: string, maxLength = 2000): string[] {
+  if (content.length <= maxLength) return [content];
+
+  const parts: string[] = [];
+  let remaining = content;
+
+  while (remaining.length > maxLength) {
+    // Find last newline before the limit
+    let splitAt = remaining.lastIndexOf('\n', maxLength);
+    if (splitAt === -1 || splitAt < maxLength / 2) {
+      // No good newline - split at limit
+      splitAt = maxLength;
+    }
+    parts.push(remaining.substring(0, splitAt));
+    remaining = remaining.substring(splitAt).trimStart();
+  }
+
+  if (remaining.length > 0) {
+    parts.push(remaining);
+  }
+
+  return parts;
+}

--- a/src/functions/applications/generateTranscript.ts
+++ b/src/functions/applications/generateTranscript.ts
@@ -1,0 +1,78 @@
+import type { TextChannel, Message, Collection } from 'discord.js';
+import { logger } from '../../services/logger.js';
+
+/**
+ * Generate a text transcript of all messages in a channel.
+ * Returns both the transcript string and a Buffer for file attachment.
+ */
+export async function generateTranscript(
+  channel: TextChannel,
+): Promise<{ text: string; buffer: Buffer }> {
+  const allMessages: Message[] = [];
+
+  try {
+    let lastMessageId: string | undefined;
+
+    // Paginate through all messages (100 per fetch)
+    while (true) {
+      const options: { limit: number; before?: string } = { limit: 100 };
+      if (lastMessageId) {
+        options.before = lastMessageId;
+      }
+
+      const batch: Collection<string, Message> = await channel.messages.fetch(options);
+      if (batch.size === 0) break;
+
+      allMessages.push(...batch.values());
+      lastMessageId = batch.lastKey();
+
+      // Safety valve: cap at 5000 messages
+      if (allMessages.length >= 5000) {
+        logger.warn('Applications', `Transcript capped at 5000 messages for channel ${channel.id}`);
+        break;
+      }
+    }
+  } catch (error) {
+    logger.warn(
+      'Applications',
+      `Failed to fetch some messages for transcript in channel ${channel.id}: ${error}`,
+    );
+  }
+
+  // Sort by timestamp ascending (oldest first)
+  allMessages.sort((a, b) => a.createdTimestamp - b.createdTimestamp);
+
+  // Format each message
+  const lines: string[] = [];
+
+  for (const msg of allMessages) {
+    const timestamp = msg.createdAt.toISOString();
+    const author = msg.author.displayName ?? msg.author.username;
+    let line = `[${timestamp}] ${author}: ${msg.content}`;
+
+    // Include attachment URLs
+    if (msg.attachments.size > 0) {
+      const attachmentUrls = msg.attachments.map((a) => a.url).join(', ');
+      line += `\n  Attachments: ${attachmentUrls}`;
+    }
+
+    // Include embed descriptions for context
+    if (msg.embeds.length > 0) {
+      for (const embed of msg.embeds) {
+        if (embed.title) {
+          line += `\n  [Embed: ${embed.title}]`;
+        }
+        if (embed.description) {
+          line += `\n  ${embed.description}`;
+        }
+      }
+    }
+
+    lines.push(line);
+  }
+
+  const text = lines.join('\n');
+  const buffer = Buffer.from(text, 'utf-8');
+
+  return { text, buffer };
+}

--- a/src/functions/applications/generateVotingEmbed.ts
+++ b/src/functions/applications/generateVotingEmbed.ts
@@ -1,0 +1,115 @@
+import {
+  EmbedBuilder,
+  Colors,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import type { ApplicationVoteRow } from '../../types/index.js';
+
+/**
+ * Build the voting embed with a progress bar and voter names, plus vote buttons.
+ */
+export function generateVotingEmbed(applicationId: number): {
+  embeds: [EmbedBuilder];
+  components: [ActionRowBuilder<ButtonBuilder>];
+} {
+  const db = getDatabase();
+
+  const votes = db
+    .prepare('SELECT * FROM application_votes WHERE application_id = ?')
+    .all(applicationId) as ApplicationVoteRow[];
+
+  // Group by vote type
+  const grouped: Record<string, ApplicationVoteRow[]> = {
+    for: [],
+    neutral: [],
+    against: [],
+    kekw: [],
+  };
+
+  for (const vote of votes) {
+    if (grouped[vote.vote_type]) {
+      grouped[vote.vote_type].push(vote);
+    }
+  }
+
+  // Build progress bar (for vs against)
+  const forCount = grouped.for.length;
+  const againstCount = grouped.against.length;
+  const totalDecisive = forCount + againstCount;
+  const barLength = 20;
+
+  let progressBar: string;
+  if (totalDecisive === 0) {
+    progressBar = `${'░'.repeat(barLength)} No votes yet`;
+  } else {
+    const filledCount = Math.round((forCount / totalDecisive) * barLength);
+    const emptyCount = barLength - filledCount;
+    progressBar = `${'█'.repeat(filledCount)}${'░'.repeat(emptyCount)} ${forCount}/${totalDecisive}`;
+  }
+
+  // Build fields
+  const formatVoters = (voteList: ApplicationVoteRow[]): string =>
+    voteList.length > 0
+      ? voteList.map((v) => `<@${v.user_id}>`).join(', ')
+      : 'None';
+
+  const embed = new EmbedBuilder()
+    .setTitle('Application Vote')
+    .setColor(Colors.Green)
+    .addFields(
+      {
+        name: `For (${grouped.for.length})`,
+        value: formatVoters(grouped.for),
+        inline: true,
+      },
+      {
+        name: `Neutral (${grouped.neutral.length})`,
+        value: formatVoters(grouped.neutral),
+        inline: true,
+      },
+      {
+        name: `Against (${grouped.against.length})`,
+        value: formatVoters(grouped.against),
+        inline: true,
+      },
+      {
+        name: `Kekw (${grouped.kekw.length})`,
+        value: formatVoters(grouped.kekw),
+        inline: true,
+      },
+      {
+        name: 'Progress',
+        value: progressBar,
+        inline: false,
+      },
+    )
+    .setTimestamp();
+
+  const votingRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`application_vote:for:${applicationId}`)
+      .setLabel('For')
+      .setEmoji('👍')
+      .setStyle(ButtonStyle.Success),
+    new ButtonBuilder()
+      .setCustomId(`application_vote:neutral:${applicationId}`)
+      .setLabel('Neutral')
+      .setEmoji('🤷')
+      .setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(`application_vote:against:${applicationId}`)
+      .setLabel('Against')
+      .setEmoji('👎')
+      .setStyle(ButtonStyle.Danger),
+    new ButtonBuilder()
+      .setCustomId(`application_vote:kekw:${applicationId}`)
+      .setLabel('Kekw')
+      .setEmoji('😂')
+      .setStyle(ButtonStyle.Danger),
+  );
+
+  return { embeds: [embed], components: [votingRow] };
+}

--- a/src/functions/applications/rejectApplication.ts
+++ b/src/functions/applications/rejectApplication.ts
@@ -1,0 +1,221 @@
+import {
+  type ButtonInteraction,
+  type ModalSubmitInteraction,
+  type GuildMember,
+  type ForumChannel,
+  type TextChannel,
+  type AnyThreadChannel,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  ActionRowBuilder,
+  AttachmentBuilder,
+  MessageFlags,
+} from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { config } from '../../config.js';
+import { logger } from '../../services/logger.js';
+import { audit } from '../../services/auditLog.js';
+import { generateTranscript } from './generateTranscript.js';
+import type { ApplicationRow, DefaultMessageRow } from '../../types/index.js';
+
+/**
+ * Show the Reject modal when an officer clicks the Reject button.
+ */
+export async function rejectApplication(interaction: ButtonInteraction): Promise<void> {
+  // Officer permission check
+  const member = interaction.member as GuildMember;
+  if (!member.roles.cache.has(config.officerRoleId)) {
+    await interaction.reply({
+      content: 'You do not have permission to reject applications.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const applicationId = parseInt(interaction.customId.split(':')[2], 10);
+  const db = getDatabase();
+
+  const application = db
+    .prepare('SELECT * FROM applications WHERE id = ?')
+    .get(applicationId) as ApplicationRow | undefined;
+
+  if (!application) {
+    await interaction.reply({
+      content: 'Application not found.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  // Get default reject message
+  const defaultMsg = db
+    .prepare('SELECT * FROM default_messages WHERE key = ?')
+    .get('application_reject') as DefaultMessageRow | undefined;
+
+  const defaultMessage =
+    defaultMsg?.message ?? 'Thank you for your interest. Unfortunately, your application has been declined.';
+
+  // Build and show modal
+  const modal = new ModalBuilder()
+    .setCustomId(`application:modal:reject:${applicationId}`)
+    .setTitle('Reject Application');
+
+  const messageInput = new TextInputBuilder()
+    .setCustomId('message_to_applicant')
+    .setLabel('Message to Applicant')
+    .setStyle(TextInputStyle.Paragraph)
+    .setValue(defaultMessage)
+    .setRequired(true);
+
+  modal.addComponents(
+    new ActionRowBuilder<TextInputBuilder>().addComponents(messageInput),
+  );
+
+  await interaction.showModal(modal);
+}
+
+/**
+ * Process the Reject modal submission.
+ */
+export async function processRejectModal(interaction: ModalSubmitInteraction): Promise<void> {
+  const applicationId = parseInt(interaction.customId.split(':')[3], 10);
+  const db = getDatabase();
+
+  const application = db
+    .prepare('SELECT * FROM applications WHERE id = ?')
+    .get(applicationId) as ApplicationRow | undefined;
+
+  if (!application) {
+    await interaction.reply({
+      content: 'Application not found.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const messageToApplicant = interaction.fields.getTextInputValue('message_to_applicant');
+  const characterName = application.character_name ?? 'Unknown';
+
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+  const guild = interaction.guild;
+  if (!guild) {
+    await interaction.editReply({ content: 'This must be used in a server.' });
+    return;
+  }
+
+  // Generate transcript from the app text channel
+  let transcriptBuffer: Buffer | null = null;
+  if (application.channel_id) {
+    try {
+      const appChannel = guild.channels.cache.get(application.channel_id) as TextChannel | undefined;
+      if (appChannel) {
+        const transcript = await generateTranscript(appChannel);
+        transcriptBuffer = transcript.buffer;
+      }
+    } catch (error) {
+      logger.warn('Applications', `Failed to generate transcript for application #${applicationId}: ${error}`);
+    }
+  }
+
+  // Post transcript to the forum thread
+  if (application.thread_id) {
+    try {
+      const thread = (await guild.channels.fetch(application.thread_id)) as AnyThreadChannel | null;
+      if (thread?.isThread()) {
+        const content = `Application **rejected** by ${interaction.user} for **${characterName}**.`;
+
+        if (transcriptBuffer) {
+          const attachment = new AttachmentBuilder(transcriptBuffer, {
+            name: `transcript-${characterName.toLowerCase()}.txt`,
+          });
+          await thread.send({ content, files: [attachment] });
+        } else {
+          await thread.send(content);
+        }
+
+        // Update forum tags: remove Active, add Rejected
+        await swapForumTag(thread, 'Active', 'Rejected');
+
+        // Lock the forum thread
+        await thread.setLocked(true);
+      }
+    } catch (error) {
+      logger.warn('Applications', `Failed to update forum thread for application #${applicationId}: ${error}`);
+    }
+  }
+
+  // DM the applicant
+  try {
+    const applicant = await interaction.client.users.fetch(application.applicant_user_id);
+
+    if (transcriptBuffer) {
+      const attachment = new AttachmentBuilder(transcriptBuffer, {
+        name: `application-transcript-${characterName.toLowerCase()}.txt`,
+      });
+      await applicant.send({ content: messageToApplicant, files: [attachment] });
+    } else {
+      await applicant.send(messageToApplicant);
+    }
+  } catch (error) {
+    logger.warn('Applications', `Failed to DM applicant for application #${applicationId}: ${error}`);
+  }
+
+  // Delete the app text channel
+  if (application.channel_id) {
+    try {
+      const appChannel = guild.channels.cache.get(application.channel_id);
+      if (appChannel) {
+        await appChannel.delete();
+      }
+    } catch (error) {
+      logger.warn('Applications', `Failed to delete app channel for application #${applicationId}: ${error}`);
+    }
+  }
+
+  // Update application in DB
+  db.prepare(
+    `UPDATE applications
+     SET status = 'rejected',
+         resolved_at = datetime('now')
+     WHERE id = ?`,
+  ).run(applicationId);
+
+  // Audit log
+  await audit(interaction.user, 'rejected application', characterName);
+
+  logger.info('Applications', `Application #${applicationId} rejected: ${characterName}`);
+
+  await interaction.editReply({ content: 'Application rejected.' });
+}
+
+// ─── Helpers ──────────────────────────────────────────────────
+
+/**
+ * Swap a forum tag on a thread: remove `removeTagName`, add `addTagName`.
+ */
+async function swapForumTag(
+  thread: AnyThreadChannel,
+  removeTagName: string,
+  addTagName: string,
+): Promise<void> {
+  const parent = thread.parent;
+  if (!parent || !('availableTags' in parent)) return;
+
+  const forum = parent as ForumChannel;
+  const availableTags = forum.availableTags;
+
+  const removeTag = availableTags.find((t) => t.name === removeTagName);
+  const addTag = availableTags.find((t) => t.name === addTagName);
+
+  if (!addTag) return;
+
+  const currentTags = thread.appliedTags ?? [];
+  const newTags = currentTags.filter((id) => id !== removeTag?.id);
+  if (!newTags.includes(addTag.id)) {
+    newTags.push(addTag.id);
+  }
+
+  await thread.setAppliedTags(newTags);
+}

--- a/src/functions/applications/startApplication.ts
+++ b/src/functions/applications/startApplication.ts
@@ -1,0 +1,111 @@
+import type { User } from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import { getQuestions } from './applicationQuestions.js';
+import { activeSessions, startSessionTimeout } from './dmQuestionnaire.js';
+import type { ApplicationRow } from '../../types/index.js';
+
+/**
+ * Start (or resume) a DM questionnaire for a user.
+ * Returns true if DM was sent successfully, false if DMs are disabled.
+ */
+export async function startApplication(user: User): Promise<boolean> {
+  const db = getDatabase();
+
+  // Check for existing in_progress application
+  const existing = db
+    .prepare('SELECT * FROM applications WHERE applicant_user_id = ? AND status = ?')
+    .get(user.id, 'in_progress') as ApplicationRow | undefined;
+
+  const questions = getQuestions();
+
+  if (questions.length === 0) {
+    try {
+      await user.send('No application questions are currently configured. Please contact an officer.');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  if (existing) {
+    // Resume from where they left off
+    return await resumeApplication(user, existing, questions);
+  }
+
+  // Create new application
+  const result = db
+    .prepare('INSERT INTO applications (applicant_user_id, status, current_question_id) VALUES (?, ?, ?)')
+    .run(user.id, 'in_progress', questions[0].id);
+
+  const applicationId = result.lastInsertRowid as number;
+
+  logger.info('Applications', `New application #${applicationId} started by ${user.tag}`);
+
+  // Set up session tracking
+  activeSessions.set(user.id, {
+    applicationId,
+    questionIndex: 0,
+  });
+
+  startSessionTimeout(user);
+
+  // DM the first question
+  try {
+    await user.send(`**Application Question 1/${questions.length}:**\n${questions[0].question}`);
+    return true;
+  } catch {
+    // DMs are disabled - clean up
+    activeSessions.delete(user.id);
+    db.prepare('UPDATE applications SET status = ? WHERE id = ?').run('abandoned', applicationId);
+    return false;
+  }
+}
+
+async function resumeApplication(
+  user: User,
+  application: ApplicationRow,
+  questions: { id: number; question: string; sort_order: number }[],
+): Promise<boolean> {
+  // Find which question to resume from
+  const db = getDatabase();
+  const answeredCount = db
+    .prepare('SELECT COUNT(*) as count FROM application_answers WHERE application_id = ?')
+    .get(application.id) as { count: number };
+
+  const questionIndex = answeredCount.count;
+
+  if (questionIndex >= questions.length) {
+    // All questions answered - they need to see the summary
+    // Import dynamically to avoid circular dependency
+    const { showSummary } = await import('./dmQuestionnaire.js');
+    try {
+      await showSummary(user, application.id);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // Resume from current question
+  activeSessions.set(user.id, {
+    applicationId: application.id,
+    questionIndex,
+  });
+
+  startSessionTimeout(user);
+
+  // Update current_question_id
+  db.prepare('UPDATE applications SET current_question_id = ? WHERE id = ?')
+    .run(questions[questionIndex].id, application.id);
+
+  try {
+    await user.send(
+      `Welcome back! Resuming your application.\n\n**Application Question ${questionIndex + 1}/${questions.length}:**\n${questions[questionIndex].question}`,
+    );
+    return true;
+  } catch {
+    activeSessions.delete(user.id);
+    return false;
+  }
+}

--- a/src/functions/applications/submitApplication.ts
+++ b/src/functions/applications/submitApplication.ts
@@ -8,12 +8,14 @@ import {
   ChannelType,
   PermissionFlagsBits,
   ThreadAutoArchiveDuration,
-  EmbedBuilder,
-  Colors,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
 } from 'discord.js';
 import { getDatabase } from '../../database/db.js';
 import { logger } from '../../services/logger.js';
 import { config } from '../../config.js';
+import { generateVotingEmbed } from './generateVotingEmbed.js';
 import { getOverlords } from '../raids/overlords.js';
 import type { ApplicationRow } from '../../types/index.js';
 
@@ -67,7 +69,7 @@ export async function submitApplication(
   const channel = await createApplicationChannel(guild, channelName, user, qaText);
 
   // Create forum post
-  const { forumPost, threadId } = await createForumPost(guild, characterName, user, qaText);
+  const { forumPost, threadId } = await createForumPost(guild, characterName, user, qaText, applicationId);
 
   // Update application record
   db.prepare(
@@ -199,6 +201,7 @@ async function createForumPost(
   characterName: string,
   applicant: User,
   qaText: string,
+  applicationId: number,
 ): Promise<{ forumPost: { id: string } | null; threadId: string | null }> {
   const db = getDatabase();
 
@@ -268,17 +271,22 @@ async function createForumPost(
     await thread.send(messages[i]);
   }
 
-  // Voting embed placeholder (Part 2 will populate this)
-  const votingEmbed = new EmbedBuilder()
-    .setTitle(`Votes for ${characterName}`)
-    .setColor(Colors.Blue)
-    .setDescription('No votes yet.')
-    .setTimestamp();
+  // Voting embed with buttons
+  const votingData = generateVotingEmbed(applicationId);
+  await thread.send(votingData);
 
-  await thread.send({ embeds: [votingEmbed] });
-
-  // Accept/Reject buttons placeholder (Part 2 will populate this)
-  await thread.send('*Accept/Reject buttons will appear here after voting is implemented.*');
+  // Accept/Reject buttons
+  const decisionRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`application:accept:${applicationId}`)
+      .setLabel('Accept')
+      .setStyle(ButtonStyle.Success),
+    new ButtonBuilder()
+      .setCustomId(`application:reject:${applicationId}`)
+      .setLabel('Reject')
+      .setStyle(ButtonStyle.Danger),
+  );
+  await thread.send({ components: [decisionRow] });
 
   return { forumPost: { id: forum.id }, threadId: thread.id };
 }

--- a/src/functions/applications/submitApplication.ts
+++ b/src/functions/applications/submitApplication.ts
@@ -1,0 +1,342 @@
+import {
+  type Client,
+  type User,
+  type TextChannel,
+  type ForumChannel,
+  type CategoryChannel,
+  type Guild,
+  ChannelType,
+  PermissionFlagsBits,
+  ThreadAutoArchiveDuration,
+  EmbedBuilder,
+  Colors,
+} from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import { config } from '../../config.js';
+import { getOverlords } from '../raids/overlords.js';
+import type { ApplicationRow } from '../../types/index.js';
+
+interface AnswerWithQuestion {
+  question: string;
+  answer: string;
+  sort_order: number;
+}
+
+/**
+ * Submit a confirmed application: create text channel + forum post, update DB, notify overlords.
+ */
+export async function submitApplication(
+  client: Client,
+  applicationId: number,
+  user: User,
+): Promise<void> {
+  const db = getDatabase();
+
+  const application = db
+    .prepare('SELECT * FROM applications WHERE id = ?')
+    .get(applicationId) as ApplicationRow | undefined;
+
+  if (!application) {
+    throw new Error(`Application #${applicationId} not found`);
+  }
+
+  // Get answers with questions
+  const answers = db
+    .prepare(
+      `SELECT aq.question, aa.answer, aq.sort_order
+       FROM application_answers aa
+       JOIN application_questions aq ON aa.question_id = aq.id
+       WHERE aa.application_id = ?
+       ORDER BY aq.sort_order`,
+    )
+    .all(applicationId) as AnswerWithQuestion[];
+
+  const guild = client.guilds.cache.get(config.guildId);
+  if (!guild) {
+    throw new Error('Guild not found');
+  }
+
+  const characterName = application.character_name || user.displayName;
+  const channelName = `app-${characterName.toLowerCase().replace(/[^a-z0-9-]/g, '-').substring(0, 90)}`;
+
+  // Build the Q&A text
+  const qaText = buildQAText(answers, user, characterName);
+
+  // Create text channel
+  const channel = await createApplicationChannel(guild, channelName, user, qaText);
+
+  // Create forum post
+  const { forumPost, threadId } = await createForumPost(guild, characterName, user, qaText);
+
+  // Update application record
+  db.prepare(
+    `UPDATE applications
+     SET status = 'active',
+         channel_id = ?,
+         forum_post_id = ?,
+         thread_id = ?,
+         submitted_at = datetime('now')
+     WHERE id = ?`,
+  ).run(
+    channel.id,
+    forumPost?.id ?? null,
+    threadId ?? null,
+    applicationId,
+  );
+
+  // Notify overlords in the forum thread
+  if (threadId) {
+    await notifyOverlords(guild, threadId, characterName, user);
+  }
+
+  logger.info(
+    'Applications',
+    `Application #${applicationId} submitted by ${user.tag} (${characterName}) - channel: ${channel.id}`,
+  );
+}
+
+// ─── Q&A Text Builder ─────────────────────────────────────────
+
+function buildQAText(answers: AnswerWithQuestion[], user: User, characterName: string): string {
+  let text = `**Application: ${characterName}**\n`;
+  text += `Applicant: ${user} (${user.tag})\n`;
+  text += `Date: ${new Date().toISOString().split('T')[0]}\n\n`;
+
+  for (let i = 0; i < answers.length; i++) {
+    text += `**${i + 1}. ${answers[i].question}**\n${answers[i].answer}\n\n`;
+  }
+
+  return text;
+}
+
+// ─── Channel Creation ─────────────────────────────────────────
+
+async function createApplicationChannel(
+  guild: Guild,
+  channelName: string,
+  applicant: User,
+  qaText: string,
+): Promise<TextChannel> {
+  const db = getDatabase();
+
+  // Get or create applications category
+  let categoryId = (
+    db.prepare('SELECT value FROM config WHERE key = ?').get('applications_category_id') as
+      | { value: string }
+      | undefined
+  )?.value;
+
+  if (categoryId) {
+    // Verify category still exists
+    const existing = guild.channels.cache.get(categoryId);
+    if (!existing || existing.type !== ChannelType.GuildCategory) {
+      categoryId = undefined;
+    }
+  }
+
+  if (!categoryId) {
+    const category = await guild.channels.create({
+      name: 'Applications',
+      type: ChannelType.GuildCategory,
+    });
+    categoryId = category.id;
+    db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(
+      'applications_category_id',
+      categoryId,
+    );
+    logger.info('Applications', `Created applications category: ${categoryId}`);
+  }
+
+  // Get overlords for permissions
+  const overlords = getOverlords();
+
+  // Build permission overwrites
+  const permissionOverwrites = [
+    {
+      id: guild.id, // @everyone
+      deny: [PermissionFlagsBits.ViewChannel],
+    },
+    {
+      id: applicant.id,
+      allow: [PermissionFlagsBits.ViewChannel, PermissionFlagsBits.SendMessages],
+    },
+    ...overlords.map((o) => ({
+      id: o.user_id,
+      allow: [PermissionFlagsBits.ViewChannel, PermissionFlagsBits.SendMessages],
+    })),
+  ];
+
+  // Also add officer role permission
+  const officerRoleId = config.officerRoleId;
+  if (officerRoleId) {
+    permissionOverwrites.push({
+      id: officerRoleId,
+      allow: [PermissionFlagsBits.ViewChannel, PermissionFlagsBits.SendMessages],
+    });
+  }
+
+  const channel = await guild.channels.create({
+    name: channelName,
+    type: ChannelType.GuildText,
+    parent: categoryId,
+    permissionOverwrites,
+  });
+
+  // Post Q&A (split if > 2000 chars)
+  const messages = splitMessage(qaText);
+  for (const msg of messages) {
+    await channel.send(msg);
+  }
+
+  return channel;
+}
+
+// ─── Forum Post Creation ──────────────────────────────────────
+
+async function createForumPost(
+  guild: Guild,
+  characterName: string,
+  applicant: User,
+  qaText: string,
+): Promise<{ forumPost: { id: string } | null; threadId: string | null }> {
+  const db = getDatabase();
+
+  // Get or create application-log forum
+  let forumId = (
+    db.prepare('SELECT value FROM config WHERE key = ?').get('application_log_forum_id') as
+      | { value: string }
+      | undefined
+  )?.value;
+
+  let forum: ForumChannel | null = null;
+
+  if (forumId) {
+    const existing = guild.channels.cache.get(forumId);
+    if (existing && existing.type === ChannelType.GuildForum) {
+      forum = existing as ForumChannel;
+    }
+  }
+
+  if (!forum) {
+    forum = await guild.channels.create({
+      name: 'application-log',
+      type: ChannelType.GuildForum,
+    });
+    forumId = forum.id;
+    db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(
+      'application_log_forum_id',
+      forumId,
+    );
+    logger.info('Applications', `Created application-log forum: ${forumId}`);
+  }
+
+  // Ensure tags exist (Active, Accepted, Rejected)
+  const existingTags = forum.availableTags;
+  const requiredTags = ['Active', 'Accepted', 'Rejected'];
+  const missingTags = requiredTags.filter(
+    (tag) => !existingTags.some((t) => t.name === tag),
+  );
+
+  if (missingTags.length > 0) {
+    const newTags = [
+      ...existingTags,
+      ...missingTags.map((name) => ({ name })),
+    ];
+    await forum.setAvailableTags(newTags);
+    // Re-fetch to get the updated tag IDs
+    const updatedForum = (await forum.fetch()) as ForumChannel;
+    forum = updatedForum;
+  }
+
+  // Find Active tag
+  const activeTag = forum.availableTags.find((t) => t.name === 'Active');
+
+  // Split Q&A for the first message
+  const messages = splitMessage(qaText);
+
+  // Create the forum thread
+  const thread = await forum.threads.create({
+    name: characterName,
+    autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
+    message: { content: messages[0] },
+    appliedTags: activeTag ? [activeTag.id] : [],
+  });
+
+  // Send remaining Q&A messages if split
+  for (let i = 1; i < messages.length; i++) {
+    await thread.send(messages[i]);
+  }
+
+  // Voting embed placeholder (Part 2 will populate this)
+  const votingEmbed = new EmbedBuilder()
+    .setTitle(`Votes for ${characterName}`)
+    .setColor(Colors.Blue)
+    .setDescription('No votes yet.')
+    .setTimestamp();
+
+  await thread.send({ embeds: [votingEmbed] });
+
+  // Accept/Reject buttons placeholder (Part 2 will populate this)
+  await thread.send('*Accept/Reject buttons will appear here after voting is implemented.*');
+
+  return { forumPost: { id: forum.id }, threadId: thread.id };
+}
+
+// ─── Overlord Notification ────────────────────────────────────
+
+async function notifyOverlords(
+  guild: Guild,
+  threadId: string,
+  characterName: string,
+  applicant: User,
+): Promise<void> {
+  const overlords = getOverlords();
+  if (overlords.length === 0) return;
+
+  const thread = guild.channels.cache.get(threadId);
+  if (!thread || !thread.isThread()) {
+    // Try to fetch it
+    try {
+      const fetchedThread = await guild.channels.fetch(threadId);
+      if (!fetchedThread || !fetchedThread.isThread()) return;
+
+      const mentions = overlords.map((o) => `<@${o.user_id}>`).join(' ');
+      await fetchedThread.send(
+        `${mentions}\nNew application from **${characterName}** (${applicant.tag}). Please review!`,
+      );
+    } catch {
+      logger.warn('Applications', `Failed to notify overlords in thread ${threadId}`);
+    }
+    return;
+  }
+
+  const mentions = overlords.map((o) => `<@${o.user_id}>`).join(' ');
+  await (thread as unknown as TextChannel).send(
+    `${mentions}\nNew application from **${characterName}** (${applicant.tag}). Please review!`,
+  );
+}
+
+// ─── Helpers ──────────────────────────────────────────────────
+
+function splitMessage(content: string, maxLength = 2000): string[] {
+  if (content.length <= maxLength) return [content];
+
+  const parts: string[] = [];
+  let remaining = content;
+
+  while (remaining.length > maxLength) {
+    let splitAt = remaining.lastIndexOf('\n', maxLength);
+    if (splitAt === -1 || splitAt < maxLength / 2) {
+      splitAt = maxLength;
+    }
+    parts.push(remaining.substring(0, splitAt));
+    remaining = remaining.substring(splitAt).trimStart();
+  }
+
+  if (remaining.length > 0) {
+    parts.push(remaining);
+  }
+
+  return parts;
+}

--- a/src/functions/applications/voteOnApplication.ts
+++ b/src/functions/applications/voteOnApplication.ts
@@ -1,0 +1,23 @@
+import type { ButtonInteraction } from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { generateVotingEmbed } from './generateVotingEmbed.js';
+
+/**
+ * Handle a vote button click: upsert the vote and refresh the embed.
+ */
+export async function voteOnApplication(
+  interaction: ButtonInteraction,
+  applicationId: number,
+  voteType: string,
+): Promise<void> {
+  const db = getDatabase();
+
+  // Upsert: one vote per user per application
+  db.prepare(
+    'INSERT OR REPLACE INTO application_votes (application_id, user_id, vote_type) VALUES (?, ?, ?)',
+  ).run(applicationId, interaction.user.id, voteType);
+
+  // Regenerate the embed and update the message in place
+  const updated = generateVotingEmbed(applicationId);
+  await interaction.update(updated);
+}

--- a/tests/integration/applications-flow.test.ts
+++ b/tests/integration/applications-flow.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { initDatabase, closeDatabase, getDatabase } from '../../src/database/db.js';
+import type { ApplicationRow, ApplicationAnswerRow } from '../../src/types/index.js';
+
+// Mock the logger
+vi.mock('../../src/services/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('applications flow (integration)', () => {
+  beforeEach(() => {
+    closeDatabase();
+    initDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  it('should create an application record', () => {
+    const db = getDatabase();
+
+    const result = db
+      .prepare(
+        'INSERT INTO applications (applicant_user_id, status, current_question_id) VALUES (?, ?, ?)',
+      )
+      .run('123456789', 'in_progress', null);
+
+    expect(result.lastInsertRowid).toBeGreaterThan(0);
+
+    const app = db
+      .prepare('SELECT * FROM applications WHERE id = ?')
+      .get(result.lastInsertRowid) as ApplicationRow;
+
+    expect(app.applicant_user_id).toBe('123456789');
+    expect(app.status).toBe('in_progress');
+    expect(app.started_at).toBeTruthy();
+    expect(app.submitted_at).toBeNull();
+  });
+
+  it('should store application answers linked to questions', () => {
+    const db = getDatabase();
+
+    // Add questions
+    db.prepare('INSERT INTO application_questions (question, sort_order) VALUES (?, ?)').run(
+      'What is your name?',
+      1,
+    );
+    db.prepare('INSERT INTO application_questions (question, sort_order) VALUES (?, ?)').run(
+      'What class?',
+      2,
+    );
+
+    const q1 = db.prepare('SELECT id FROM application_questions WHERE sort_order = 1').get() as {
+      id: number;
+    };
+    const q2 = db.prepare('SELECT id FROM application_questions WHERE sort_order = 2').get() as {
+      id: number;
+    };
+
+    // Create application
+    const appResult = db
+      .prepare('INSERT INTO applications (applicant_user_id, status) VALUES (?, ?)')
+      .run('123456789', 'in_progress');
+    const appId = appResult.lastInsertRowid as number;
+
+    // Store answers
+    db.prepare(
+      'INSERT INTO application_answers (application_id, question_id, answer) VALUES (?, ?, ?)',
+    ).run(appId, q1.id, 'TestCharacter');
+    db.prepare(
+      'INSERT INTO application_answers (application_id, question_id, answer) VALUES (?, ?, ?)',
+    ).run(appId, q2.id, 'Holy Paladin');
+
+    const answers = db
+      .prepare(
+        `SELECT aa.*, aq.question
+         FROM application_answers aa
+         JOIN application_questions aq ON aa.question_id = aq.id
+         WHERE aa.application_id = ?
+         ORDER BY aq.sort_order`,
+      )
+      .all(appId) as Array<ApplicationAnswerRow & { question: string }>;
+
+    expect(answers).toHaveLength(2);
+    expect(answers[0].answer).toBe('TestCharacter');
+    expect(answers[0].question).toBe('What is your name?');
+    expect(answers[1].answer).toBe('Holy Paladin');
+    expect(answers[1].question).toBe('What class?');
+  });
+
+  it('should transition application status correctly', () => {
+    const db = getDatabase();
+
+    // Create application
+    const result = db
+      .prepare('INSERT INTO applications (applicant_user_id, status) VALUES (?, ?)')
+      .run('123456789', 'in_progress');
+    const appId = result.lastInsertRowid as number;
+
+    // Verify initial status
+    let app = db.prepare('SELECT * FROM applications WHERE id = ?').get(appId) as ApplicationRow;
+    expect(app.status).toBe('in_progress');
+
+    // Transition to active (submitted)
+    db.prepare(
+      "UPDATE applications SET status = 'active', submitted_at = datetime('now') WHERE id = ?",
+    ).run(appId);
+    app = db.prepare('SELECT * FROM applications WHERE id = ?').get(appId) as ApplicationRow;
+    expect(app.status).toBe('active');
+    expect(app.submitted_at).toBeTruthy();
+
+    // Transition to accepted
+    db.prepare(
+      "UPDATE applications SET status = 'accepted', resolved_at = datetime('now') WHERE id = ?",
+    ).run(appId);
+    app = db.prepare('SELECT * FROM applications WHERE id = ?').get(appId) as ApplicationRow;
+    expect(app.status).toBe('accepted');
+    expect(app.resolved_at).toBeTruthy();
+  });
+
+  it('should transition application to abandoned', () => {
+    const db = getDatabase();
+
+    const result = db
+      .prepare('INSERT INTO applications (applicant_user_id, status) VALUES (?, ?)')
+      .run('123456789', 'in_progress');
+    const appId = result.lastInsertRowid as number;
+
+    db.prepare("UPDATE applications SET status = 'abandoned' WHERE id = ?").run(appId);
+
+    const app = db
+      .prepare('SELECT * FROM applications WHERE id = ?')
+      .get(appId) as ApplicationRow;
+    expect(app.status).toBe('abandoned');
+  });
+
+  it('should enforce foreign key between answers and questions', () => {
+    const db = getDatabase();
+
+    const appResult = db
+      .prepare('INSERT INTO applications (applicant_user_id, status) VALUES (?, ?)')
+      .run('123456789', 'in_progress');
+    const appId = appResult.lastInsertRowid as number;
+
+    // Try to insert answer with non-existent question_id
+    expect(() => {
+      db.prepare(
+        'INSERT INTO application_answers (application_id, question_id, answer) VALUES (?, ?, ?)',
+      ).run(appId, 99999, 'Invalid answer');
+    }).toThrow();
+  });
+
+  it('should store and retrieve character_name', () => {
+    const db = getDatabase();
+
+    const result = db
+      .prepare(
+        'INSERT INTO applications (applicant_user_id, status, character_name) VALUES (?, ?, ?)',
+      )
+      .run('123456789', 'in_progress', 'TestPaladin');
+
+    const app = db
+      .prepare('SELECT * FROM applications WHERE id = ?')
+      .get(result.lastInsertRowid) as ApplicationRow;
+
+    expect(app.character_name).toBe('TestPaladin');
+  });
+
+  it('should find in_progress applications by user ID', () => {
+    const db = getDatabase();
+
+    // Create multiple applications for the same user
+    db.prepare('INSERT INTO applications (applicant_user_id, status) VALUES (?, ?)').run(
+      '123456789',
+      'abandoned',
+    );
+    db.prepare('INSERT INTO applications (applicant_user_id, status) VALUES (?, ?)').run(
+      '123456789',
+      'in_progress',
+    );
+    db.prepare('INSERT INTO applications (applicant_user_id, status) VALUES (?, ?)').run(
+      '987654321',
+      'in_progress',
+    );
+
+    const userApps = db
+      .prepare('SELECT * FROM applications WHERE applicant_user_id = ? AND status = ?')
+      .all('123456789', 'in_progress') as ApplicationRow[];
+
+    expect(userApps).toHaveLength(1);
+    expect(userApps[0].applicant_user_id).toBe('123456789');
+    expect(userApps[0].status).toBe('in_progress');
+  });
+});

--- a/tests/unit/applicationQuestions.test.ts
+++ b/tests/unit/applicationQuestions.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { initDatabase, closeDatabase, getDatabase } from '../../src/database/db.js';
+
+// Mock the logger
+import { vi } from 'vitest';
+vi.mock('../../src/services/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import {
+  getQuestions,
+  getQuestionById,
+  addQuestion,
+  removeQuestion,
+} from '../../src/functions/applications/applicationQuestions.js';
+
+describe('applicationQuestions', () => {
+  beforeEach(() => {
+    closeDatabase();
+    initDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  it('should return empty array on fresh DB', () => {
+    const questions = getQuestions();
+    expect(questions).toEqual([]);
+  });
+
+  it('should add a question and auto-increment sort_order', () => {
+    const q1 = addQuestion('What is your character name?');
+    expect(q1.id).toBeGreaterThan(0);
+    expect(q1.sort_order).toBe(1);
+    expect(q1.question).toBe('What is your character name?');
+
+    const q2 = addQuestion('What class and spec?');
+    expect(q2.sort_order).toBe(2);
+
+    const q3 = addQuestion('Why do you want to join?');
+    expect(q3.sort_order).toBe(3);
+
+    const all = getQuestions();
+    expect(all).toHaveLength(3);
+    expect(all[0].sort_order).toBe(1);
+    expect(all[1].sort_order).toBe(2);
+    expect(all[2].sort_order).toBe(3);
+  });
+
+  it('should get a question by ID', () => {
+    const added = addQuestion('Test question?');
+    const found = getQuestionById(added.id);
+
+    expect(found).toBeDefined();
+    expect(found!.question).toBe('Test question?');
+    expect(found!.id).toBe(added.id);
+  });
+
+  it('should return undefined for non-existent question ID', () => {
+    const found = getQuestionById(9999);
+    expect(found).toBeUndefined();
+  });
+
+  it('should remove a question by ID', () => {
+    const q = addQuestion('To be deleted');
+    expect(getQuestions()).toHaveLength(1);
+
+    const result = removeQuestion(q.id);
+    expect(result).toBe(true);
+    expect(getQuestions()).toHaveLength(0);
+  });
+
+  it('should return false when removing non-existent question', () => {
+    const result = removeQuestion(9999);
+    expect(result).toBe(false);
+  });
+
+  it('should maintain sort_order gap after deletion', () => {
+    addQuestion('Q1');
+    const q2 = addQuestion('Q2');
+    addQuestion('Q3');
+
+    removeQuestion(q2.id);
+
+    const remaining = getQuestions();
+    expect(remaining).toHaveLength(2);
+    expect(remaining[0].sort_order).toBe(1);
+    expect(remaining[1].sort_order).toBe(3);
+
+    // Next added question should get sort_order 4
+    const q4 = addQuestion('Q4');
+    expect(q4.sort_order).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary

Complete Applications domain: custom DM questionnaire, forum voting, accept/reject with officer modals, DM notifications, and channel transcript generation.

### What's included (11 commits):

**Part 1 - Core:**
- **Application questions CRUD** - Add/remove/list configurable questions
- **DM questionnaire** - One question at a time, edit answers, confirm/cancel, 30-min timeout
- **Application submission** - Creates text channel (applicant + overlords) + forum post with Active tag
- **/apply command** - User-facing trigger
- **/applications command** - 7 admin subcommands (questions, apply button, view pending, set messages)

**Part 2 - Voting + Accept/Reject:**
- **Voting system** - For/neutral/against/kekw buttons with progress bar embed
- **Accept flow** - Modal (character name, role, start date, message), DM applicant + transcript, tag swap Active->Accepted, lock thread, delete channel
- **Reject flow** - Modal (message), DM applicant + transcript, tag swap Active->Rejected, lock thread, delete channel
- **Transcript generation** - Full channel transcript as .txt file attachment
- **Button/modal handlers** - All interaction routing in interactionCreate.ts

### Test coverage:

- 71 tests passing (14 new for applications)
- Unit: application questions CRUD
- Integration: application records, answers, status transitions

### Known bugs (filed as issues):

- #13 - /apply command fails with "The application did not respond"

### Chrome verified:

- /applications add_question - adds questions successfully
- /apply - fails (bug #13, needs investigation)
- All commands visible in autocomplete

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` - all 71 tests pass
- [ ] `/applications add_question` adds a question
- [ ] `/applications list_questions` shows questions
- [ ] `/applications view_pending` shows applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)