### PR TITLE
feat: Loot - boss priority signups with auto-discovery

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -45,6 +45,9 @@ All commands are Discord slash commands registered to a single guild.
 | `/trials change_trial_info` | Update a trial's character name, role, or start date | Yes | No |
 | `/trials update_trial_logs` | Refresh WarcraftLogs attendance for all active trials | Yes | No |
 | `/trials update_trial_review_messages` | Refresh all trial review thread starter messages | Yes | No |
+| `/loot create_posts` | Auto-discover current raid tier and create loot priority posts | Yes | No |
+| `/loot delete_post` | Delete a single loot priority post by boss ID | Yes | No |
+| `/loot delete_posts` | Delete multiple loot priority posts by comma-separated boss IDs | Yes | No |
 
 ## Notes
 

--- a/src/commands/loot.ts
+++ b/src/commands/loot.ts
@@ -1,0 +1,99 @@
+import {
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  MessageFlags,
+  PermissionFlagsBits,
+} from 'discord.js';
+import { requireOfficer } from '../utils.js';
+import { checkRaidExpansions } from '../functions/loot/checkRaidExpansions.js';
+import { deleteLootPost } from '../functions/loot/deleteLootPost.js';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('loot')
+    .setDescription('Manage loot priority posts')
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+    .addSubcommand((sub) =>
+      sub.setName('create_posts').setDescription('Auto-discover current raid and create loot posts'),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('delete_post')
+        .setDescription('Delete a single loot post by boss ID')
+        .addIntegerOption((opt) =>
+          opt.setName('boss_id').setDescription('The boss ID to delete').setRequired(true),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('delete_posts')
+        .setDescription('Delete multiple loot posts by boss IDs')
+        .addStringOption((opt) =>
+          opt
+            .setName('boss_ids')
+            .setDescription('Comma-separated boss IDs to delete')
+            .setRequired(true),
+        ),
+    ),
+  async execute(interaction: ChatInputCommandInteraction) {
+    if (!(await requireOfficer(interaction))) return;
+
+    const subcommand = interaction.options.getSubcommand();
+
+    switch (subcommand) {
+      case 'create_posts': {
+        await interaction.reply({
+          content: 'Checking raid expansions...',
+          flags: MessageFlags.Ephemeral,
+        });
+
+        try {
+          await checkRaidExpansions(interaction.client);
+          await interaction.editReply({ content: 'Loot posts created.' });
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error(String(error));
+          await interaction.editReply({ content: `Failed to create loot posts: ${err.message}` });
+        }
+        break;
+      }
+
+      case 'delete_post': {
+        const bossId = interaction.options.getInteger('boss_id', true);
+
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+        try {
+          await deleteLootPost(interaction.client, bossId);
+          await interaction.editReply({ content: 'Loot post removed.' });
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error(String(error));
+          await interaction.editReply({ content: `Failed to delete loot post: ${err.message}` });
+        }
+        break;
+      }
+
+      case 'delete_posts': {
+        const bossIdsStr = interaction.options.getString('boss_ids', true);
+        const bossIds = bossIdsStr.split(',').map((id) => parseInt(id.trim(), 10));
+
+        await interaction.reply({
+          content: 'Deleting posts...',
+          flags: MessageFlags.Ephemeral,
+        });
+
+        try {
+          for (const bossId of bossIds) {
+            if (!isNaN(bossId)) {
+              await deleteLootPost(interaction.client, bossId);
+            }
+          }
+          await interaction.editReply({ content: 'Deleted posts.' });
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error(String(error));
+          await interaction.editReply({ content: `Failed to delete some posts: ${err.message}` });
+        }
+        break;
+      }
+    }
+  },
+};

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -31,6 +31,10 @@ import { markForPromotion } from '../functions/trial-review/markForPromotion.js'
 import { closeTrial } from '../functions/trial-review/closeTrial.js';
 import { changeTrialInfo } from '../functions/trial-review/changeTrialInfo.js';
 import { createTrialReviewThread } from '../functions/trial-review/createTrialReviewThread.js';
+import { updateLootResponse } from '../functions/loot/updateLootResponse.js';
+import { updateLootPost } from '../functions/loot/updateLootPost.js';
+import { generateLootPost } from '../functions/loot/generateLootPost.js';
+import type { LootPostRow, LootResponseRow } from '../types/index.js';
 
 export default {
   name: 'interactionCreate',
@@ -372,6 +376,74 @@ export default {
           } catch (err) {
             const error = err instanceof Error ? err : new Error(String(err));
             await interaction.editReply({ content: `Failed to close trial: ${error.message}` });
+          }
+        }
+
+        // loot:{responseType}:{bossId} - Loot priority button
+        if (customId.startsWith('loot:')) {
+          const [, responseType, bossIdStr] = customId.split(':');
+          const bossId = parseInt(bossIdStr, 10);
+
+          // Validate raider exists
+          const db = getDatabase();
+          const raider = db
+            .prepare('SELECT * FROM raiders WHERE discord_user_id = ?')
+            .get(interaction.user.id) as RaiderRow | undefined;
+
+          if (!raider) {
+            await interaction.reply({
+              content: 'Could not find a character linked to your Discord account. Please contact an officer!',
+              flags: MessageFlags.Ephemeral,
+            });
+            return;
+          }
+
+          await updateLootResponse(interaction.client, responseType, bossId, interaction.user.id);
+
+          // Build updated post data for the interaction update
+          const lootPost = db
+            .prepare('SELECT * FROM loot_posts WHERE boss_id = ?')
+            .get(bossId) as LootPostRow | undefined;
+
+          if (lootPost) {
+            const responses = db
+              .prepare('SELECT * FROM loot_responses WHERE loot_post_id = ?')
+              .all(lootPost.id) as LootResponseRow[];
+
+            const raiders = db
+              .prepare('SELECT * FROM raiders WHERE discord_user_id IS NOT NULL')
+              .all() as RaiderRow[];
+
+            const userToCharacter = new Map<string, string>();
+            for (const r of raiders) {
+              if (r.discord_user_id && !userToCharacter.has(r.discord_user_id)) {
+                userToCharacter.set(r.discord_user_id, r.character_name);
+              }
+            }
+
+            const grouped: Record<string, string[]> = {
+              major: [],
+              minor: [],
+              wantIn: [],
+              wantOut: [],
+            };
+
+            for (const response of responses) {
+              const charName = userToCharacter.get(response.user_id) ?? 'Unknown';
+              if (grouped[response.response_type]) {
+                grouped[response.response_type].push(charName);
+              }
+            }
+
+            const playerResponses = {
+              major: grouped.major.length > 0 ? grouped.major.join('\n') : '*None*',
+              minor: grouped.minor.length > 0 ? grouped.minor.join('\n') : '*None*',
+              wantIn: grouped.wantIn.length > 0 ? grouped.wantIn.join('\n') : '*None*',
+              wantOut: grouped.wantOut.length > 0 ? grouped.wantOut.join('\n') : '*None*',
+            };
+
+            const postData = generateLootPost(lootPost.boss_name, bossId, playerResponses);
+            await interaction.update(postData);
           }
         }
       } catch (error) {

--- a/src/functions/loot/addLootPost.ts
+++ b/src/functions/loot/addLootPost.ts
@@ -1,0 +1,25 @@
+import type { TextChannel } from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { generateLootPost } from './generateLootPost.js';
+
+export interface Boss {
+  id: number;
+  name: string;
+  url?: string;
+}
+
+export async function addLootPost(channel: TextChannel, boss: Boss): Promise<void> {
+  const postData = generateLootPost(boss.name, boss.id, {
+    major: '*None*',
+    minor: '*None*',
+    wantIn: '*None*',
+    wantOut: '*None*',
+  });
+
+  const message = await channel.send(postData);
+
+  const db = getDatabase();
+  db.prepare(
+    'INSERT INTO loot_posts (boss_id, boss_name, boss_url, channel_id, message_id) VALUES (?, ?, ?, ?, ?)',
+  ).run(boss.id, boss.name, boss.url ?? null, channel.id, message.id);
+}

--- a/src/functions/loot/checkRaidExpansions.ts
+++ b/src/functions/loot/checkRaidExpansions.ts
@@ -1,0 +1,97 @@
+import { type Client, type TextChannel, ChannelType } from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import { config } from '../../config.js';
+import { getRaidStaticData } from '../../services/raiderio.js';
+import { addLootPost } from './addLootPost.js';
+import type { ConfigRow } from '../../types/index.js';
+
+async function getLootChannel(client: Client): Promise<TextChannel | null> {
+  const db = getDatabase();
+
+  const row = db
+    .prepare('SELECT value FROM config WHERE key = ?')
+    .get('loot_channel_id') as ConfigRow | undefined;
+
+  if (row) {
+    try {
+      const channel = await client.channels.fetch(row.value);
+      if (channel && channel.type === ChannelType.GuildText) {
+        return channel as TextChannel;
+      }
+    } catch {
+      logger.warn('Loot', 'Configured loot channel not found, will auto-create');
+    }
+  }
+
+  // Auto-create the channel
+  try {
+    const guild = await client.guilds.fetch(config.guildId);
+    const channel = await guild.channels.create({
+      name: 'loot-priorities',
+      type: ChannelType.GuildText,
+      topic: 'Loot priority declarations per boss',
+    });
+
+    db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(
+      'loot_channel_id',
+      channel.id,
+    );
+
+    logger.info('Loot', `Auto-created loot channel: #${channel.name}`);
+    return channel;
+  } catch (error) {
+    logger.error('Loot', 'Failed to auto-create loot channel', error as Error);
+    return null;
+  }
+}
+
+export async function checkRaidExpansions(client: Client): Promise<void> {
+  const channel = await getLootChannel(client);
+  if (!channel) {
+    logger.warn('Loot', 'No loot channel available, skipping raid expansion check');
+    return;
+  }
+
+  const now = new Date();
+  let expansion = 9;
+  let done = false;
+
+  while (!done) {
+    try {
+      const staticData = await getRaidStaticData(expansion);
+
+      // Sort raids: past raids first (by end date), then current/future
+      const raids = staticData.raids.sort((a, b) => {
+        const aEnd = a.ends.eu ? new Date(a.ends.eu).getTime() : Infinity;
+        const bEnd = b.ends.eu ? new Date(b.ends.eu).getTime() : Infinity;
+        return aEnd - bEnd;
+      });
+
+      // Find the first raid where ends.eu > now or ends.eu is null (current tier)
+      const currentRaid = raids.find((raid) => {
+        if (raid.ends.eu === null) return true;
+        return new Date(raid.ends.eu) > now;
+      });
+
+      if (currentRaid) {
+        logger.info('Loot', `Found current raid: ${currentRaid.name} (expansion ${expansion})`);
+
+        for (const encounter of currentRaid.encounters) {
+          await addLootPost(channel, {
+            id: encounter.id,
+            name: encounter.name,
+          });
+        }
+
+        // Found and processed the current raid, we're done
+        done = true;
+      }
+
+      expansion++;
+    } catch {
+      // API returned error (e.g. 400 for unknown expansion) - no more expansions
+      done = true;
+    }
+  }
+}

--- a/src/functions/loot/deleteLootPost.ts
+++ b/src/functions/loot/deleteLootPost.ts
@@ -1,0 +1,32 @@
+import type { Client } from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import type { LootPostRow } from '../../types/index.js';
+
+export async function deleteLootPost(client: Client, bossId: number): Promise<void> {
+  const db = getDatabase();
+
+  const lootPost = db
+    .prepare('SELECT * FROM loot_posts WHERE boss_id = ?')
+    .get(bossId) as LootPostRow | undefined;
+
+  if (!lootPost) {
+    logger.warn('Loot', `No loot post found for boss_id ${bossId}`);
+    return;
+  }
+
+  // Delete Discord message
+  try {
+    const channel = await client.channels.fetch(lootPost.channel_id);
+    if (channel && 'messages' in channel) {
+      const message = await channel.messages.fetch(lootPost.message_id);
+      await message.delete();
+    }
+  } catch (error) {
+    logger.warn('Loot', `Failed to delete Discord message for boss_id ${bossId}: ${error}`);
+  }
+
+  // Delete from DB (responses first due to FK, then post)
+  db.prepare('DELETE FROM loot_responses WHERE loot_post_id = ?').run(lootPost.id);
+  db.prepare('DELETE FROM loot_posts WHERE boss_id = ?').run(bossId);
+}

--- a/src/functions/loot/generateLootPost.ts
+++ b/src/functions/loot/generateLootPost.ts
@@ -1,0 +1,52 @@
+import {
+  EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  Colors,
+} from 'discord.js';
+
+export interface PlayerResponses {
+  major: string;
+  minor: string;
+  wantIn: string;
+  wantOut: string;
+}
+
+export function generateLootPost(
+  bossName: string,
+  bossId: number,
+  playerResponses: PlayerResponses,
+): { embeds: [EmbedBuilder]; components: [ActionRowBuilder<ButtonBuilder>] } {
+  const embed = new EmbedBuilder()
+    .setColor(Colors.Green)
+    .setTitle(bossName)
+    .setTimestamp()
+    .addFields(
+      { name: 'Major', value: playerResponses.major, inline: true },
+      { name: 'Minor', value: playerResponses.minor, inline: true },
+      { name: 'Want In', value: playerResponses.wantIn, inline: true },
+      { name: 'Do not need', value: playerResponses.wantOut, inline: true },
+    );
+
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`loot:major:${bossId}`)
+      .setLabel('Major')
+      .setStyle(ButtonStyle.Success),
+    new ButtonBuilder()
+      .setCustomId(`loot:minor:${bossId}`)
+      .setLabel('Minor')
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId(`loot:wantIn:${bossId}`)
+      .setLabel('Want In')
+      .setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(`loot:wantOut:${bossId}`)
+      .setLabel('Do not need')
+      .setStyle(ButtonStyle.Danger),
+  );
+
+  return { embeds: [embed], components: [row] };
+}

--- a/src/functions/loot/updateLootPost.ts
+++ b/src/functions/loot/updateLootPost.ts
@@ -1,0 +1,69 @@
+import type { Client } from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import { generateLootPost } from './generateLootPost.js';
+import type { LootPostRow, LootResponseRow, RaiderRow } from '../../types/index.js';
+
+export async function updateLootPost(client: Client, bossId: number): Promise<void> {
+  const db = getDatabase();
+
+  const lootPost = db
+    .prepare('SELECT * FROM loot_posts WHERE boss_id = ?')
+    .get(bossId) as LootPostRow | undefined;
+
+  if (!lootPost) {
+    logger.warn('Loot', `No loot post found for boss_id ${bossId}`);
+    return;
+  }
+
+  const responses = db
+    .prepare('SELECT * FROM loot_responses WHERE loot_post_id = ?')
+    .all(lootPost.id) as LootResponseRow[];
+
+  const raiders = db
+    .prepare('SELECT * FROM raiders WHERE discord_user_id IS NOT NULL')
+    .all() as RaiderRow[];
+
+  const userToCharacter = new Map<string, string>();
+  for (const raider of raiders) {
+    if (raider.discord_user_id && !userToCharacter.has(raider.discord_user_id)) {
+      userToCharacter.set(raider.discord_user_id, raider.character_name);
+    }
+  }
+
+  const grouped: Record<string, string[]> = {
+    major: [],
+    minor: [],
+    wantIn: [],
+    wantOut: [],
+  };
+
+  for (const response of responses) {
+    const charName = userToCharacter.get(response.user_id) ?? 'Unknown';
+    if (grouped[response.response_type]) {
+      grouped[response.response_type].push(charName);
+    }
+  }
+
+  const playerResponses = {
+    major: grouped.major.length > 0 ? grouped.major.join('\n') : '*None*',
+    minor: grouped.minor.length > 0 ? grouped.minor.join('\n') : '*None*',
+    wantIn: grouped.wantIn.length > 0 ? grouped.wantIn.join('\n') : '*None*',
+    wantOut: grouped.wantOut.length > 0 ? grouped.wantOut.join('\n') : '*None*',
+  };
+
+  const postData = generateLootPost(lootPost.boss_name, bossId, playerResponses);
+
+  try {
+    const channel = await client.channels.fetch(lootPost.channel_id);
+    if (!channel || !('messages' in channel)) {
+      logger.warn('Loot', `Channel ${lootPost.channel_id} not found or not a text channel`);
+      return;
+    }
+
+    const message = await channel.messages.fetch(lootPost.message_id);
+    await message.edit(postData);
+  } catch (error) {
+    logger.error('Loot', `Failed to update loot post for boss_id ${bossId}`, error as Error);
+  }
+}

--- a/src/functions/loot/updateLootResponse.ts
+++ b/src/functions/loot/updateLootResponse.ts
@@ -1,0 +1,37 @@
+import type { Client } from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import { updateLootPost } from './updateLootPost.js';
+import type { LootPostRow } from '../../types/index.js';
+
+export async function updateLootResponse(
+  client: Client,
+  responseType: string,
+  bossId: number,
+  userId: string,
+): Promise<string> {
+  const db = getDatabase();
+
+  const lootPost = db
+    .prepare('SELECT * FROM loot_posts WHERE boss_id = ?')
+    .get(bossId) as LootPostRow | undefined;
+
+  if (!lootPost) {
+    logger.warn('Loot', `No loot post found for boss_id ${bossId}`);
+    return '';
+  }
+
+  const txn = db.transaction(() => {
+    db.prepare('DELETE FROM loot_responses WHERE loot_post_id = ? AND user_id = ?')
+      .run(lootPost.id, userId);
+
+    db.prepare('INSERT INTO loot_responses (loot_post_id, user_id, response_type) VALUES (?, ?, ?)')
+      .run(lootPost.id, userId, responseType);
+  });
+
+  txn();
+
+  await updateLootPost(client, bossId);
+
+  return '';
+}

--- a/src/services/raiderio.ts
+++ b/src/services/raiderio.ts
@@ -30,6 +30,8 @@ export interface RaidStaticData {
     slug: string;
     name: string;
     expansion_id: number;
+    starts: { us: string | null; eu: string | null };
+    ends: { us: string | null; eu: string | null };
     encounters: Array<{
       id: number;
       slug: string;

--- a/tests/unit/loot.test.ts
+++ b/tests/unit/loot.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { generateLootPost } from '../../src/functions/loot/generateLootPost.js';
+
+describe('generateLootPost', () => {
+  it('should return an embed with the boss name as title', () => {
+    const result = generateLootPost('Kyveza', 12345, {
+      major: '*None*',
+      minor: '*None*',
+      wantIn: '*None*',
+      wantOut: '*None*',
+    });
+
+    expect(result.embeds).toHaveLength(1);
+    expect(result.embeds[0].data.title).toBe('Kyveza');
+  });
+
+  it('should return an embed with green color', () => {
+    const result = generateLootPost('Kyveza', 12345, {
+      major: '*None*',
+      minor: '*None*',
+      wantIn: '*None*',
+      wantOut: '*None*',
+    });
+
+    // Colors.Green = 0x57F287 = 5763719
+    expect(result.embeds[0].data.color).toBe(5763719);
+  });
+
+  it('should have 4 inline fields with correct names', () => {
+    const result = generateLootPost('Kyveza', 12345, {
+      major: '*None*',
+      minor: '*None*',
+      wantIn: '*None*',
+      wantOut: '*None*',
+    });
+
+    const fields = result.embeds[0].data.fields;
+    expect(fields).toHaveLength(4);
+    expect(fields![0].name).toBe('Major');
+    expect(fields![1].name).toBe('Minor');
+    expect(fields![2].name).toBe('Want In');
+    expect(fields![3].name).toBe('Do not need');
+
+    for (const field of fields!) {
+      expect(field.inline).toBe(true);
+    }
+  });
+
+  it('should display player names when provided', () => {
+    const result = generateLootPost('Kyveza', 12345, {
+      major: 'Thrall\nJaina',
+      minor: 'Arthas',
+      wantIn: '*None*',
+      wantOut: 'Sylvanas',
+    });
+
+    const fields = result.embeds[0].data.fields!;
+    expect(fields[0].value).toBe('Thrall\nJaina');
+    expect(fields[1].value).toBe('Arthas');
+    expect(fields[2].value).toBe('*None*');
+    expect(fields[3].value).toBe('Sylvanas');
+  });
+
+  it('should have a timestamp on the embed', () => {
+    const result = generateLootPost('Kyveza', 12345, {
+      major: '*None*',
+      minor: '*None*',
+      wantIn: '*None*',
+      wantOut: '*None*',
+    });
+
+    expect(result.embeds[0].data.timestamp).toBeDefined();
+  });
+
+  it('should return an action row with 4 buttons', () => {
+    const result = generateLootPost('Kyveza', 12345, {
+      major: '*None*',
+      minor: '*None*',
+      wantIn: '*None*',
+      wantOut: '*None*',
+    });
+
+    expect(result.components).toHaveLength(1);
+    const buttons = result.components[0].components;
+    expect(buttons).toHaveLength(4);
+  });
+
+  it('should use correct custom IDs with colon separator', () => {
+    const bossId = 99999;
+    const result = generateLootPost('TestBoss', bossId, {
+      major: '*None*',
+      minor: '*None*',
+      wantIn: '*None*',
+      wantOut: '*None*',
+    });
+
+    const buttons = result.components[0].components;
+    expect(buttons[0].data).toMatchObject({ custom_id: `loot:major:${bossId}` });
+    expect(buttons[1].data).toMatchObject({ custom_id: `loot:minor:${bossId}` });
+    expect(buttons[2].data).toMatchObject({ custom_id: `loot:wantIn:${bossId}` });
+    expect(buttons[3].data).toMatchObject({ custom_id: `loot:wantOut:${bossId}` });
+  });
+
+  it('should use correct button styles', () => {
+    const result = generateLootPost('TestBoss', 1, {
+      major: '*None*',
+      minor: '*None*',
+      wantIn: '*None*',
+      wantOut: '*None*',
+    });
+
+    const buttons = result.components[0].components;
+    // ButtonStyle: Success=3, Primary=1, Secondary=2, Danger=4
+    expect(buttons[0].data).toMatchObject({ style: 3 }); // Success
+    expect(buttons[1].data).toMatchObject({ style: 1 }); // Primary
+    expect(buttons[2].data).toMatchObject({ style: 2 }); // Secondary
+    expect(buttons[3].data).toMatchObject({ style: 4 }); // Danger
+  });
+
+  it('should use correct button labels', () => {
+    const result = generateLootPost('TestBoss', 1, {
+      major: '*None*',
+      minor: '*None*',
+      wantIn: '*None*',
+      wantOut: '*None*',
+    });
+
+    const buttons = result.components[0].components;
+    expect(buttons[0].data).toMatchObject({ label: 'Major' });
+    expect(buttons[1].data).toMatchObject({ label: 'Minor' });
+    expect(buttons[2].data).toMatchObject({ label: 'Want In' });
+    expect(buttons[3].data).toMatchObject({ label: 'Do not need' });
+  });
+});
+
+describe('response type values', () => {
+  it('should accept all four response types in playerResponses', () => {
+    const responses = {
+      major: 'Player1',
+      minor: 'Player2',
+      wantIn: 'Player3',
+      wantOut: 'Player4',
+    };
+
+    const result = generateLootPost('Boss', 1, responses);
+    const fields = result.embeds[0].data.fields!;
+
+    expect(fields[0].value).toBe('Player1');
+    expect(fields[1].value).toBe('Player2');
+    expect(fields[2].value).toBe('Player3');
+    expect(fields[3].value).toBe('Player4');
+  });
+});


### PR DESCRIPTION
## Summary

Loot domain: per-boss loot priority signups for the current raid tier with Raider.io auto-discovery.

### What's included (6 commits):

- **generateLootPost** - Embed with 4 inline fields (Major/Minor/Want In/Do Not Need) + 4 buttons
- **addLootPost** - Send embed and store in DB
- **updateLootResponse** - Atomic transaction: swap response type, re-render embed with character names
- **updateLootPost** - Resolve user IDs to character names via raiders table
- **checkRaidExpansions** - Auto-discover current raid tier from Raider.io, create posts per boss
- **deleteLootPost** - Delete Discord message and clean up DB
- **/loot command** - 3 subcommands: create_posts, delete_post, delete_posts
- **Button handlers** - Raider validation with early return (V1 bug fix)

### Test coverage:

- 91 tests passing (10 new for loot)

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` - all 91 tests pass
- [ ] `/loot create_posts` auto-discovers current raid and creates per-boss embeds
- [ ] Clicking a loot button updates the embed with character name

🤖 Generated with [Claude Code](https://claude.com/claude-code)