### PR TITLE
fix: Address all reported bugs (#6-#10, #13, #16, #17)

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -10,18 +10,18 @@ export default {
     .setName('apply')
     .setDescription('Apply to join the guild'),
   async execute(interaction: ChatInputCommandInteraction) {
-    const success = await startApplication(interaction.user);
+    await interaction.reply({
+      content: 'Check your DMs!',
+      flags: MessageFlags.Ephemeral,
+    });
 
-    if (success) {
-      await interaction.reply({
-        content: 'Check your DMs! I\'ve sent you the application questions.',
-        flags: MessageFlags.Ephemeral,
-      });
-    } else {
-      await interaction.reply({
-        content: 'I was unable to send you a DM. Please make sure your DMs are open and try again.',
-        flags: MessageFlags.Ephemeral,
-      });
+    try {
+      const success = await startApplication(interaction.user);
+      if (!success) {
+        await interaction.editReply('Failed to start application. Please make sure your DMs are open and try again.');
+      }
+    } catch {
+      await interaction.editReply('Failed to start application. Please try again or contact an officer.');
     }
   },
 };

--- a/src/commands/raiders.ts
+++ b/src/commands/raiders.ts
@@ -232,7 +232,7 @@ export default {
 
       case 'check_missing_users': {
         const unlinked = db
-          .prepare('SELECT * FROM raiders WHERE discord_user_id IS NULL')
+          .prepare('SELECT * FROM raiders WHERE discord_user_id IS NULL AND missing_since IS NULL')
           .all() as RaiderRow[];
 
         if (unlinked.length === 0) {

--- a/src/functions/guild-info/updateAchievements.ts
+++ b/src/functions/guild-info/updateAchievements.ts
@@ -193,11 +193,21 @@ async function fetchApiAchievements(): Promise<AchievementSection[]> {
         if (!rankings || rankings.length === 0) continue;
 
         // Use the ranking entry with the most encounters defeated
-        const best = rankings.reduce((a, b) =>
-          (b.encountersDefeated > a.encountersDefeated ? b : a), rankings[0]);
+        // Guard against encountersDefeated being an array (API may return either)
+        const getDefeatedCount = (entry: RaidRankingEntry): number => {
+          const val = entry.encountersDefeated;
+          if (Array.isArray(val)) return (val as unknown[]).length;
+          if (typeof val === 'number') return val;
+          return 0;
+        };
 
-        const killedBosses = best.encountersDefeated;
-        const totalBosses = best.encountersTotal || raid.encounters.length;
+        const best = rankings.reduce((a, b) =>
+          (getDefeatedCount(b) > getDefeatedCount(a) ? b : a), rankings[0]);
+
+        const killedBosses = getDefeatedCount(best);
+        const totalBosses = typeof best.encountersTotal === 'number'
+          ? best.encountersTotal
+          : raid.encounters.length;
 
         if (killedBosses === 0) continue;
 
@@ -205,7 +215,7 @@ async function fetchApiAchievements(): Promise<AchievementSection[]> {
         const isCE = determineCE(raid, best);
 
         const progress = `${killedBosses}/${totalBosses}M`;
-        const rank = best.rank;
+        const rank = typeof best.rank === 'number' ? best.rank : 0;
         const result = isCE ? `CE WR ${rank}` : `WR ${rank}`;
 
         sectionRows.push({
@@ -233,10 +243,15 @@ async function fetchApiAchievements(): Promise<AchievementSection[]> {
 }
 
 function determineCE(raid: RaidStaticRaid, ranking: RaidRankingEntry): boolean {
-  const totalBosses = ranking.encountersTotal || raid.encounters.length;
+  const totalBosses = typeof ranking.encountersTotal === 'number'
+    ? ranking.encountersTotal
+    : raid.encounters.length;
 
   // Not all bosses killed = no CE
-  if (ranking.encountersDefeated < totalBosses) return false;
+  const defeated = Array.isArray(ranking.encountersDefeated)
+    ? (ranking.encountersDefeated as unknown[]).length
+    : (typeof ranking.encountersDefeated === 'number' ? ranking.encountersDefeated : 0);
+  if (defeated < totalBosses) return false;
 
   // Get the tier end date
   const endDate = raid.ends?.eu ?? null;

--- a/src/functions/guild-info/updateAchievements.ts
+++ b/src/functions/guild-info/updateAchievements.ts
@@ -262,18 +262,18 @@ function determineCE(raid: RaidStaticRaid, ranking: RaidRankingEntry): boolean {
 // ─── Image Rendering ────────────────────────────────────────────
 
 function renderAchievementsImage(sections: AchievementSection[], title: string): Buffer {
-  const PADDING = 20;
+  const PADDING = 24;
   const ROW_HEIGHT = 28;
-  const HEADER_HEIGHT = 40;
+  const HEADER_HEIGHT = 44;
   const SECTION_GAP = 16;
-  const FONT_SIZE = 14;
-  const HEADER_FONT_SIZE = 12;
-  const WIDTH = 800;
+  const FONT_SIZE = 16;
+  const HEADER_FONT_SIZE = 18;
+  const WIDTH = 1000;
 
   // Column positions
   const COL_RAID = PADDING;
-  const COL_PROGRESS = 520;
-  const COL_RESULT = 650;
+  const COL_PROGRESS = 640;
+  const COL_RESULT = 800;
 
   // Calculate total height
   let totalRows = 0;

--- a/src/functions/guild-info/updateAchievements.ts
+++ b/src/functions/guild-info/updateAchievements.ts
@@ -1,4 +1,4 @@
-import { type Client, AttachmentBuilder, EmbedBuilder, Colors } from 'discord.js';
+import { type Client, AttachmentBuilder } from 'discord.js';
 import { createCanvas } from '@napi-rs/canvas';
 import { getDatabase } from '../../database/db.js';
 import { logger } from '../../services/logger.js';
@@ -100,7 +100,8 @@ export async function updateAchievements(client: Client): Promise<void> {
     try {
       const oldMessage = await channel.messages.fetch(existingMsg.message_id);
       await oldMessage.edit({
-        embeds: [new EmbedBuilder().setColor(Colors.Green).setTitle(title).setImage('attachment://achievements.png')],
+        content: `**${title}**`,
+        embeds: [],
         files: [attachment],
       });
       logger.info('guild-info', 'Updated existing Achievements message');
@@ -112,7 +113,7 @@ export async function updateAchievements(client: Client): Promise<void> {
 
   // Send new message
   const message = await channel.send({
-    embeds: [new EmbedBuilder().setColor(Colors.Green).setTitle(title).setImage('attachment://achievements.png')],
+    content: `**${title}**`,
     files: [attachment],
   });
 

--- a/src/functions/guild-info/updateRecruitment.ts
+++ b/src/functions/guild-info/updateRecruitment.ts
@@ -23,9 +23,18 @@ export async function updateRecruitment(client: Client): Promise<void> {
 
   const db = getDatabase();
 
-  // Get all recruitment sections ordered by key
+  // Get all recruitment sections in logical reading order
   const sections = db
-    .prepare("SELECT * FROM guild_info_content WHERE key LIKE 'recruitment_%' ORDER BY key")
+    .prepare(
+      `SELECT * FROM guild_info_content WHERE key LIKE 'recruitment_%'
+       ORDER BY CASE key
+         WHEN 'recruitment_who' THEN 1
+         WHEN 'recruitment_want' THEN 2
+         WHEN 'recruitment_give' THEN 3
+         WHEN 'recruitment_contact' THEN 4
+         ELSE 99
+       END`,
+    )
     .all() as GuildInfoContentRow[];
 
   if (sections.length === 0) {

--- a/src/functions/trial-review/createTrialReviewThread.ts
+++ b/src/functions/trial-review/createTrialReviewThread.ts
@@ -23,6 +23,14 @@ export interface TrialData {
 }
 
 /**
+ * Convert a Date to a Discord epoch timestamp string.
+ * Styles: 'D' = long date, 'R' = relative, 'f' = short datetime.
+ */
+function toDiscordTimestamp(date: Date, style: 'D' | 'R' | 'f' = 'D'): string {
+  return `<t:${Math.floor(date.getTime() / 1000)}:${style}>`;
+}
+
+/**
  * Build the review message content for a trial.
  */
 export function buildReviewMessage(
@@ -33,18 +41,18 @@ export function buildReviewMessage(
   fourWeek: Date,
   sixWeek: Date,
 ): string {
-  const fmt = (d: Date) => d.toISOString().split('T')[0];
+  const startDateObj = new Date(startDate + 'T00:00:00Z');
 
   return [
     `**Trial Review: ${characterName}**`,
     '',
     `**Role:** ${role}`,
-    `**Start Date:** ${startDate}`,
+    `**Start Date:** ${toDiscordTimestamp(startDateObj)}`,
     '',
     `**Review Schedule:**`,
-    `  2-week review: ${fmt(twoWeek)}`,
-    `  4-week review: ${fmt(fourWeek)}`,
-    `  6-week review: ${fmt(sixWeek)}`,
+    `  2-week review: ${toDiscordTimestamp(twoWeek)} (${toDiscordTimestamp(twoWeek, 'R')})`,
+    `  4-week review: ${toDiscordTimestamp(fourWeek)} (${toDiscordTimestamp(fourWeek, 'R')})`,
+    `  6-week review: ${toDiscordTimestamp(sixWeek)} (${toDiscordTimestamp(sixWeek, 'R')})`,
   ].join('\n');
 }
 

--- a/src/functions/trial-review/scheduleTrialAlerts.ts
+++ b/src/functions/trial-review/scheduleTrialAlerts.ts
@@ -3,10 +3,35 @@ import { getDatabase } from '../../database/db.js';
 import { logger } from '../../services/logger.js';
 import type { TrialAlertRow, TrialRow, PromoteAlertRow } from '../../types/index.js';
 
+// ─── Constants ──────────────────────────────────────────────
+
+// setTimeout max safe delay is 2^31-1 ms (~24.85 days).
+// Delays exceeding this overflow to 0 and fire immediately.
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
 // ─── Timer Storage ───────────────────────────────────────────
 
 const alertTimers = new Map<number, NodeJS.Timeout>();
 const promoteTimers = new Map<number, NodeJS.Timeout>();
+
+/**
+ * Schedule a callback with a delay that may exceed setTimeout's 2^31-1 ms limit.
+ * If the delay is larger, it chains intermediate timeouts.
+ */
+function safeSetTimeout(callback: () => void, delay: number): NodeJS.Timeout {
+  if (delay <= MAX_TIMEOUT_MS) {
+    return setTimeout(callback, delay);
+  }
+  // Chain: wait MAX_TIMEOUT_MS, then re-check remaining delay
+  return setTimeout(() => {
+    const remaining = delay - MAX_TIMEOUT_MS;
+    if (remaining <= 0) {
+      callback();
+    } else {
+      safeSetTimeout(callback, remaining);
+    }
+  }, MAX_TIMEOUT_MS);
+}
 
 /**
  * Clear all scheduled timers. Call on shutdown.
@@ -149,7 +174,7 @@ export function scheduleTrialAlerts(client: Client, trialId: number): void {
       // Past due - fire immediately (async, don't await)
       void fireAlert(client, alert);
     } else {
-      const timer = setTimeout(() => {
+      const timer = safeSetTimeout(() => {
         void fireAlert(client, alert);
       }, delay);
       alertTimers.set(alert.id, timer);
@@ -180,14 +205,14 @@ export function rescheduleAllAlerts(client: Client): void {
 
   for (const alert of alerts) {
     const alertTime = new Date(alert.alert_date + 'T12:00:00Z').getTime();
-    const delay = Math.max(0, alertTime - now);
+    const delay = alertTime - now;
 
-    if (delay === 0) {
+    if (delay <= 0) {
       pastDue++;
       void fireAlert(client, alert);
     } else {
       scheduled++;
-      const timer = setTimeout(() => {
+      const timer = safeSetTimeout(() => {
         void fireAlert(client, alert);
       }, delay);
       alertTimers.set(alert.id, timer);
@@ -204,14 +229,14 @@ export function rescheduleAllAlerts(client: Client): void {
 
   for (const pa of promoteAlerts) {
     const promoteTime = new Date(pa.promote_date + 'T12:00:00Z').getTime();
-    const delay = Math.max(0, promoteTime - now);
+    const delay = promoteTime - now;
 
-    if (delay === 0) {
+    if (delay <= 0) {
       promotePastDue++;
       void firePromoteAlert(client, pa);
     } else {
       promoteScheduled++;
-      const timer = setTimeout(() => {
+      const timer = safeSetTimeout(() => {
         void firePromoteAlert(client, pa);
       }, delay);
       promoteTimers.set(pa.id, timer);
@@ -247,16 +272,16 @@ export function schedulePromoteAlert(
   const promoteAlertId = result.lastInsertRowid as number;
   const now = Date.now();
   const promoteTime = new Date(promoteDate + 'T12:00:00Z').getTime();
-  const delay = Math.max(0, promoteTime - now);
+  const delay = promoteTime - now;
 
   const promoteAlert = db
     .prepare('SELECT * FROM promote_alerts WHERE id = ?')
     .get(promoteAlertId) as PromoteAlertRow;
 
-  if (delay === 0) {
+  if (delay <= 0) {
     void firePromoteAlert(client, promoteAlert);
   } else {
-    const timer = setTimeout(() => {
+    const timer = safeSetTimeout(() => {
       void firePromoteAlert(client, promoteAlert);
     }, delay);
     promoteTimers.set(promoteAlertId, timer);


### PR DESCRIPTION
## Summary

Fixes 8 bugs and 1 enhancement reported during Chrome testing.

### Fixes:

- **#6** - `/raiders check_missing_users` now correctly finds unlinked raiders (was missing `AND missing_since IS NULL`)
- **#7** - Achievements image sent as standalone attachment, not wrapped in embed
- **#8** - Achievements image font size increased to 16-18px, canvas widened to 1000px
- **#9** - Recruitment sections ordered logically (Who -> Want -> Give -> Contact) using CASE ordering
- **#10** - Fixed [object Object] in achievements by adding type guards for API response shapes
- **#13** - `/apply` now replies immediately before starting DM (prevents Discord 3-second timeout)
- **#16** - Trial alerts use safe setTimeout chaining for delays > 24.85 days (2^31-1 ms overflow)
- **#17** - Trial review dates use Discord epoch timestamps for localized display

### Not addressed:

- **#11** - Guild info channel selection (UX issue, use `/setup set_channel` as workaround)

### Verification:

- 130 tests passing, zero type errors
- Each fix committed individually for easy review/revert

## Test plan

- [ ] `npm test` - all 130 tests pass
- [ ] `/raiders check_missing_users` finds unlinked raiders
- [ ] `/guildinfo` achievements renders readable image without embed wrapper
- [ ] Recruitment sections in correct order
- [ ] `/apply` responds within 3 seconds
- [ ] Trial alerts schedule for future dates, not immediately

Closes #6, closes #7, closes #8, closes #9, closes #10, closes #13, closes #16, closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)