### PR TITLE
fix: Application bugs, expansion names in achievements (#21, #22)

### DIFF
--- a/src/functions/applications/startApplication.ts
+++ b/src/functions/applications/startApplication.ts
@@ -12,11 +12,6 @@ import type { ApplicationRow } from '../../types/index.js';
 export async function startApplication(user: User): Promise<boolean> {
   const db = getDatabase();
 
-  // Check for existing in_progress application
-  const existing = db
-    .prepare('SELECT * FROM applications WHERE applicant_user_id = ? AND status = ?')
-    .get(user.id, 'in_progress') as ApplicationRow | undefined;
-
   const questions = getQuestions();
 
   if (questions.length === 0) {
@@ -28,38 +23,26 @@ export async function startApplication(user: User): Promise<boolean> {
     }
   }
 
+  // Clean up any stale in-memory session for this user before proceeding.
+  // This prevents duplicate messages if a previous session wasn't fully cleaned up.
+  const staleSession = activeSessions.get(user.id);
+  if (staleSession?.timeout) {
+    clearTimeout(staleSession.timeout);
+  }
+  activeSessions.delete(user.id);
+
+  // Check for existing in_progress application
+  const existing = db
+    .prepare('SELECT * FROM applications WHERE applicant_user_id = ? AND status = ?')
+    .get(user.id, 'in_progress') as ApplicationRow | undefined;
+
   if (existing) {
-    // Resume from where they left off
+    // Resume from where they left off - return immediately, no other code path runs
     return await resumeApplication(user, existing, questions);
   }
 
-  // Create new application
-  const result = db
-    .prepare('INSERT INTO applications (applicant_user_id, status, current_question_id) VALUES (?, ?, ?)')
-    .run(user.id, 'in_progress', questions[0].id);
-
-  const applicationId = result.lastInsertRowid as number;
-
-  logger.info('Applications', `New application #${applicationId} started by ${user.tag}`);
-
-  // Set up session tracking
-  activeSessions.set(user.id, {
-    applicationId,
-    questionIndex: 0,
-  });
-
-  startSessionTimeout(user);
-
-  // DM the first question
-  try {
-    await user.send(`**Application Question 1/${questions.length}:**\n${questions[0].question}`);
-    return true;
-  } catch {
-    // DMs are disabled - clean up
-    activeSessions.delete(user.id);
-    db.prepare('UPDATE applications SET status = ? WHERE id = ?').run('abandoned', applicationId);
-    return false;
-  }
+  // No in_progress application exists - create a new one
+  return await createNewApplication(user, questions);
 }
 
 async function resumeApplication(
@@ -67,13 +50,27 @@ async function resumeApplication(
   application: ApplicationRow,
   questions: { id: number; question: string; sort_order: number }[],
 ): Promise<boolean> {
-  // Find which question to resume from
   const db = getDatabase();
-  const answeredCount = db
-    .prepare('SELECT COUNT(*) as count FROM application_answers WHERE application_id = ?')
-    .get(application.id) as { count: number };
 
-  const questionIndex = answeredCount.count;
+  // Verify the existing answers still align with current questions.
+  // If questions have changed (added/removed), abandon the old application and start fresh.
+  const answeredQuestionIds = db
+    .prepare('SELECT question_id FROM application_answers WHERE application_id = ?')
+    .all(application.id) as { question_id: number }[];
+
+  const currentQuestionIds = new Set(questions.map((q) => q.id));
+  const hasOrphanedAnswers = answeredQuestionIds.some((a) => !currentQuestionIds.has(a.question_id));
+
+  if (hasOrphanedAnswers) {
+    logger.info('Applications', `Application #${application.id} has orphaned answers (questions changed) - abandoning and starting fresh`);
+    db.prepare('UPDATE applications SET status = ? WHERE id = ?').run('abandoned', application.id);
+
+    // Create a fresh application instead
+    return await createNewApplication(user, questions);
+  }
+
+  // Find which question to resume from
+  const questionIndex = answeredQuestionIds.length;
 
   if (questionIndex >= questions.length) {
     // All questions answered - they need to see the summary
@@ -106,6 +103,40 @@ async function resumeApplication(
     return true;
   } catch {
     activeSessions.delete(user.id);
+    return false;
+  }
+}
+
+/**
+ * Create a brand-new application and send the first question.
+ */
+async function createNewApplication(
+  user: User,
+  questions: { id: number; question: string; sort_order: number }[],
+): Promise<boolean> {
+  const db = getDatabase();
+
+  const result = db
+    .prepare('INSERT INTO applications (applicant_user_id, status, current_question_id) VALUES (?, ?, ?)')
+    .run(user.id, 'in_progress', questions[0].id);
+
+  const applicationId = result.lastInsertRowid as number;
+
+  logger.info('Applications', `New application #${applicationId} started by ${user.tag}`);
+
+  activeSessions.set(user.id, {
+    applicationId,
+    questionIndex: 0,
+  });
+
+  startSessionTimeout(user);
+
+  try {
+    await user.send(`**Application Question 1/${questions.length}:**\n${questions[0].question}`);
+    return true;
+  } catch {
+    activeSessions.delete(user.id);
+    db.prepare('UPDATE applications SET status = ? WHERE id = ?').run('abandoned', applicationId);
     return false;
   }
 }

--- a/src/functions/applications/submitApplication.ts
+++ b/src/functions/applications/submitApplication.ts
@@ -3,7 +3,6 @@ import {
   type User,
   type TextChannel,
   type ForumChannel,
-  type CategoryChannel,
   type Guild,
   ChannelType,
   PermissionFlagsBits,
@@ -54,6 +53,10 @@ export async function submitApplication(
     )
     .all(applicationId) as AnswerWithQuestion[];
 
+  if (answers.length === 0) {
+    throw new Error(`Application #${applicationId} has no answers`);
+  }
+
   const guild = client.guilds.cache.get(config.guildId);
   if (!guild) {
     throw new Error('Guild not found');
@@ -65,31 +68,59 @@ export async function submitApplication(
   // Build the Q&A text
   const qaText = buildQAText(answers, user, characterName);
 
-  // Create text channel
-  const channel = await createApplicationChannel(guild, channelName, user, qaText);
+  // Step 1: Create text channel
+  let channel: TextChannel;
+  try {
+    channel = await createApplicationChannel(guild, channelName, user, qaText);
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    logger.error('Applications', `Failed to create application channel for #${applicationId}: ${error.message}`, error);
+    throw new Error(`Failed to create application channel: ${error.message}`);
+  }
 
-  // Create forum post
-  const { forumPost, threadId } = await createForumPost(guild, characterName, user, qaText, applicationId);
+  // Step 2: Create forum post
+  let forumPost: { id: string } | null = null;
+  let threadId: string | null = null;
+  try {
+    const result = await createForumPost(guild, characterName, user, qaText, applicationId);
+    forumPost = result.forumPost;
+    threadId = result.threadId;
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    logger.error('Applications', `Failed to create forum post for #${applicationId}: ${error.message}`, error);
+    // Don't throw here - the text channel was already created, so update the record with what we have
+  }
 
-  // Update application record
-  db.prepare(
-    `UPDATE applications
-     SET status = 'active',
-         channel_id = ?,
-         forum_post_id = ?,
-         thread_id = ?,
-         submitted_at = datetime('now')
-     WHERE id = ?`,
-  ).run(
-    channel.id,
-    forumPost?.id ?? null,
-    threadId ?? null,
-    applicationId,
-  );
+  // Step 3: Update application record
+  try {
+    db.prepare(
+      `UPDATE applications
+       SET status = 'active',
+           channel_id = ?,
+           forum_post_id = ?,
+           thread_id = ?,
+           submitted_at = datetime('now')
+       WHERE id = ?`,
+    ).run(
+      channel.id,
+      forumPost?.id ?? null,
+      threadId ?? null,
+      applicationId,
+    );
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    logger.error('Applications', `Failed to update application #${applicationId} record: ${error.message}`, error);
+    throw new Error(`Failed to update application record: ${error.message}`);
+  }
 
-  // Notify overlords in the forum thread
+  // Step 4: Notify overlords in the forum thread (non-fatal if it fails)
   if (threadId) {
-    await notifyOverlords(guild, threadId, characterName, user);
+    try {
+      await notifyOverlords(guild, threadId, characterName, user);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      logger.warn('Applications', `Failed to notify overlords for application #${applicationId}: ${error.message}`);
+    }
   }
 
   logger.info(
@@ -130,24 +161,34 @@ async function createApplicationChannel(
   )?.value;
 
   if (categoryId) {
-    // Verify category still exists
-    const existing = guild.channels.cache.get(categoryId);
-    if (!existing || existing.type !== ChannelType.GuildCategory) {
+    // Verify category still exists (it may have been deleted)
+    try {
+      const existing = guild.channels.cache.get(categoryId) ?? await guild.channels.fetch(categoryId).catch(() => null);
+      if (!existing || existing.type !== ChannelType.GuildCategory) {
+        logger.info('Applications', `Applications category ${categoryId} no longer exists, creating a new one`);
+        categoryId = undefined;
+      }
+    } catch {
       categoryId = undefined;
     }
   }
 
   if (!categoryId) {
-    const category = await guild.channels.create({
-      name: 'Applications',
-      type: ChannelType.GuildCategory,
-    });
-    categoryId = category.id;
-    db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(
-      'applications_category_id',
-      categoryId,
-    );
-    logger.info('Applications', `Created applications category: ${categoryId}`);
+    try {
+      const category = await guild.channels.create({
+        name: 'Applications',
+        type: ChannelType.GuildCategory,
+      });
+      categoryId = category.id;
+      db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(
+        'applications_category_id',
+        categoryId,
+      );
+      logger.info('Applications', `Created applications category: ${categoryId}`);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      throw new Error(`Failed to create Applications category (does the bot have Manage Channels permission?): ${error.message}`);
+    }
   }
 
   // Get overlords for permissions
@@ -178,12 +219,18 @@ async function createApplicationChannel(
     });
   }
 
-  const channel = await guild.channels.create({
-    name: channelName,
-    type: ChannelType.GuildText,
-    parent: categoryId,
-    permissionOverwrites,
-  });
+  let channel: TextChannel;
+  try {
+    channel = await guild.channels.create({
+      name: channelName,
+      type: ChannelType.GuildText,
+      parent: categoryId,
+      permissionOverwrites,
+    }) as TextChannel;
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    throw new Error(`Failed to create text channel "${channelName}" (does the bot have Manage Channels permission?): ${error.message}`);
+  }
 
   // Post Q&A (split if > 2000 chars)
   const messages = splitMessage(qaText);
@@ -215,41 +262,59 @@ async function createForumPost(
   let forum: ForumChannel | null = null;
 
   if (forumId) {
-    const existing = guild.channels.cache.get(forumId);
-    if (existing && existing.type === ChannelType.GuildForum) {
-      forum = existing as ForumChannel;
+    // Check cache first, then try fetching from API
+    try {
+      const existing = guild.channels.cache.get(forumId) ?? await guild.channels.fetch(forumId).catch(() => null);
+      if (existing && existing.type === ChannelType.GuildForum) {
+        forum = existing as ForumChannel;
+      } else {
+        logger.info('Applications', `Application-log forum ${forumId} no longer exists or is wrong type, creating a new one`);
+      }
+    } catch {
+      logger.info('Applications', `Failed to fetch application-log forum ${forumId}, creating a new one`);
     }
   }
 
   if (!forum) {
-    forum = await guild.channels.create({
-      name: 'application-log',
-      type: ChannelType.GuildForum,
-    });
-    forumId = forum.id;
-    db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(
-      'application_log_forum_id',
-      forumId,
-    );
-    logger.info('Applications', `Created application-log forum: ${forumId}`);
+    try {
+      forum = (await guild.channels.create({
+        name: 'application-log',
+        type: ChannelType.GuildForum,
+      })) as ForumChannel;
+      forumId = forum.id;
+      db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(
+        'application_log_forum_id',
+        forumId,
+      );
+      logger.info('Applications', `Created application-log forum: ${forumId}`);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      throw new Error(`Failed to create application-log forum channel (does the bot have Manage Channels permission?): ${error.message}`);
+    }
   }
 
   // Ensure tags exist (Active, Accepted, Rejected)
-  const existingTags = forum.availableTags;
-  const requiredTags = ['Active', 'Accepted', 'Rejected'];
-  const missingTags = requiredTags.filter(
-    (tag) => !existingTags.some((t) => t.name === tag),
-  );
+  try {
+    const existingTags = forum.availableTags;
+    const requiredTags = ['Active', 'Accepted', 'Rejected'];
+    const missingTags = requiredTags.filter(
+      (tag) => !existingTags.some((t) => t.name === tag),
+    );
 
-  if (missingTags.length > 0) {
-    const newTags = [
-      ...existingTags,
-      ...missingTags.map((name) => ({ name })),
-    ];
-    await forum.setAvailableTags(newTags);
-    // Re-fetch to get the updated tag IDs
-    const updatedForum = (await forum.fetch()) as ForumChannel;
-    forum = updatedForum;
+    if (missingTags.length > 0) {
+      const newTags = [
+        ...existingTags,
+        ...missingTags.map((name) => ({ name })),
+      ];
+      await forum.setAvailableTags(newTags);
+      // Re-fetch to get the updated tag IDs
+      const updatedForum = (await forum.fetch()) as ForumChannel;
+      forum = updatedForum;
+    }
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    logger.warn('Applications', `Failed to set forum tags for application-log: ${error.message}`);
+    // Non-fatal - we can still create the thread without tags
   }
 
   // Find Active tag
@@ -258,13 +323,22 @@ async function createForumPost(
   // Split Q&A for the first message
   const messages = splitMessage(qaText);
 
+  // Truncate thread name to Discord's 100-character limit
+  const threadName = characterName.substring(0, 100);
+
   // Create the forum thread
-  const thread = await forum.threads.create({
-    name: characterName,
-    autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
-    message: { content: messages[0] },
-    appliedTags: activeTag ? [activeTag.id] : [],
-  });
+  let thread;
+  try {
+    thread = await forum.threads.create({
+      name: threadName,
+      autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
+      message: { content: messages[0] },
+      appliedTags: activeTag ? [activeTag.id] : [],
+    });
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    throw new Error(`Failed to create forum thread for "${threadName}": ${error.message}`);
+  }
 
   // Send remaining Q&A messages if split
   for (let i = 1; i < messages.length; i++) {
@@ -272,21 +346,31 @@ async function createForumPost(
   }
 
   // Voting embed with buttons
-  const votingData = generateVotingEmbed(applicationId);
-  await thread.send(votingData);
+  try {
+    const votingData = generateVotingEmbed(applicationId);
+    await thread.send(votingData);
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    logger.warn('Applications', `Failed to send voting embed for application #${applicationId}: ${error.message}`);
+  }
 
   // Accept/Reject buttons
-  const decisionRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder()
-      .setCustomId(`application:accept:${applicationId}`)
-      .setLabel('Accept')
-      .setStyle(ButtonStyle.Success),
-    new ButtonBuilder()
-      .setCustomId(`application:reject:${applicationId}`)
-      .setLabel('Reject')
-      .setStyle(ButtonStyle.Danger),
-  );
-  await thread.send({ components: [decisionRow] });
+  try {
+    const decisionRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`application:accept:${applicationId}`)
+        .setLabel('Accept')
+        .setStyle(ButtonStyle.Success),
+      new ButtonBuilder()
+        .setCustomId(`application:reject:${applicationId}`)
+        .setLabel('Reject')
+        .setStyle(ButtonStyle.Danger),
+    );
+    await thread.send({ components: [decisionRow] });
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    logger.warn('Applications', `Failed to send decision buttons for application #${applicationId}: ${error.message}`);
+  }
 
   return { forumPost: { id: forum.id }, threadId: thread.id };
 }

--- a/src/functions/guild-info/updateAchievements.ts
+++ b/src/functions/guild-info/updateAchievements.ts
@@ -6,6 +6,26 @@ import { getOrCreateGuildInfoChannel } from './clearGuildInfo.js';
 import { getRaidStaticData, getRaidRankings } from '../../services/raiderio.js';
 import type { AchievementsManualRow, GuildInfoContentRow, GuildInfoMessageRow } from '../../types/index.js';
 
+// ─── Expansion Names ───────────────────────────────────────────
+
+const EXPANSION_NAMES: Record<number, string> = {
+  1: 'Classic',
+  2: 'The Burning Crusade',
+  3: 'Wrath of the Lich King',
+  4: 'Mists of Pandaria',
+  5: 'Warlords of Draenor',
+  6: 'Legion',
+  7: 'Battle for Azeroth',
+  8: 'Shadowlands',
+  9: 'Dragonflight',
+  10: 'The War Within',
+  11: 'Midnight',
+};
+
+function getExpansionName(id: number): string {
+  return EXPANSION_NAMES[id] ?? `Expansion ${id}`;
+}
+
 // ─── Types ──────────────────────────────────────────────────────
 
 interface AchievementRow {
@@ -140,7 +160,7 @@ function buildManualSections(rows: AchievementsManualRow[]): AchievementSection[
 
   for (const [expansion, expRows] of grouped) {
     sections.push({
-      expansionLabel: `Expansion ${expansion}`,
+      expansionLabel: getExpansionName(expansion),
       rows: expRows.map((r) => ({
         raid: r.raid,
         progress: r.progress,
@@ -231,7 +251,7 @@ async function fetchApiAchievements(): Promise<AchievementSection[]> {
 
     if (sectionRows.length > 0) {
       sections.push({
-        expansionLabel: `Expansion ${expansionId}`,
+        expansionLabel: getExpansionName(expansionId),
         rows: sectionRows,
       });
     }


### PR DESCRIPTION
## Summary

Fixes 2 new bugs found during Chrome testing + achievement expansion name enhancement.

### Fixes:

- **#21** - `/apply` no longer sends duplicate messages (question + "no questions configured") when restarting after timeout. Fixed stale session cleanup and orphaned answer detection.
- **#22** - Application submission now has granular error handling per step (channel creation, forum creation, thread creation, voting embed, overlord notification). Each step is non-fatal where possible so partial submissions are saved. Includes cache-miss fallback for channel lookups and 100-char thread name truncation.
- **Expansion names** - Achievements image now shows "Mists of Pandaria", "Warlords of Draenor", "Dragonflight", etc. instead of "Expansion 4", "Expansion 5", "Expansion 9".

### Verification:

- 130 tests passing, zero type errors

Closes #21, closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)