### PR TITLE
feat: remaining features - backups, status, DM resume, pagination

### DIFF
--- a/src/commands/applications.ts
+++ b/src/commands/applications.ts
@@ -198,14 +198,14 @@ export default {
         } else {
           const embed = buildPageEmbed(title, pages[0], 1, pages.length);
           const buttons = buildPageButtons('applications', 1, pages.length);
-          const { resource: reply } = await interaction.reply({
+          const { resource } = await interaction.reply({
             embeds: [embed],
             components: buttons ? [buttons] : [],
             flags: MessageFlags.Ephemeral,
             withResponse: true,
           });
-          const messageId = reply?.message?.id ?? interaction.id;
-          cachePaginatedData(`applications:${messageId}`, title, pages);
+          // withResponse: true guarantees resource.message is present
+          cachePaginatedData(`applications:${resource!.message!.id}`, title, pages);
         }
         break;
       }

--- a/src/commands/applications.ts
+++ b/src/commands/applications.ts
@@ -20,6 +20,7 @@ import {
   addQuestion,
   removeQuestion,
 } from '../functions/applications/applicationQuestions.js';
+import { paginateLines, buildPageEmbed, buildPageButtons, cachePaginatedData } from '../functions/pagination.js';
 import type { ApplicationRow } from '../types/index.js';
 
 export default {
@@ -188,14 +189,24 @@ export default {
           return `${statusEmoji} **#${app.id}** - ${app.character_name || 'Unknown'} (<@${app.applicant_user_id}>) - ${app.status}${channelRef}`;
         });
 
-        const embed = createEmbed(`Pending Applications (${applications.length})`).setDescription(
-          lines.join('\n'),
-        );
+        const title = `Pending Applications (${applications.length})`;
+        const pages = paginateLines(lines);
 
-        await interaction.reply({
-          embeds: [embed],
-          flags: MessageFlags.Ephemeral,
-        });
+        if (pages.length === 1) {
+          const embed = buildPageEmbed(title, pages[0], 1, 1);
+          await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
+        } else {
+          const embed = buildPageEmbed(title, pages[0], 1, pages.length);
+          const buttons = buildPageButtons('applications', 1, pages.length);
+          const { resource: reply } = await interaction.reply({
+            embeds: [embed],
+            components: buttons ? [buttons] : [],
+            flags: MessageFlags.Ephemeral,
+            withResponse: true,
+          });
+          const messageId = reply?.message?.id ?? interaction.id;
+          cachePaginatedData(`applications:${messageId}`, title, pages);
+        }
         break;
       }
 

--- a/src/commands/epgp.ts
+++ b/src/commands/epgp.ts
@@ -134,8 +134,18 @@ export default {
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         try {
-          const [header, body, footer] = generateDisplay(tierToken);
-          await interaction.editReply({ content: `${header}\n${body}\n${footer}` });
+          const { header, bodies, footer } = generateDisplay(tierToken);
+          const combined = [header, ...bodies, footer].join('\n');
+          // Discord ephemeral reply limit is 2000 chars; split into follow-ups if needed
+          if (combined.length <= 2000) {
+            await interaction.editReply({ content: combined });
+          } else {
+            await interaction.editReply({ content: header });
+            for (const body of bodies) {
+              await interaction.followUp({ content: body, flags: MessageFlags.Ephemeral });
+            }
+            await interaction.followUp({ content: footer, flags: MessageFlags.Ephemeral });
+          }
         } catch (error) {
           const err = error instanceof Error ? error : new Error(String(error));
           await interaction.editReply({ content: `Failed to generate display: ${err.message}` });
@@ -149,8 +159,17 @@ export default {
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
         try {
-          const [header, body, footer] = generateDisplay(null, armourType);
-          await interaction.editReply({ content: `${header}\n${body}\n${footer}` });
+          const { header, bodies, footer } = generateDisplay(null, armourType);
+          const combined = [header, ...bodies, footer].join('\n');
+          if (combined.length <= 2000) {
+            await interaction.editReply({ content: combined });
+          } else {
+            await interaction.editReply({ content: header });
+            for (const body of bodies) {
+              await interaction.followUp({ content: body, flags: MessageFlags.Ephemeral });
+            }
+            await interaction.followUp({ content: footer, flags: MessageFlags.Ephemeral });
+          }
         } catch (error) {
           const err = error instanceof Error ? error : new Error(String(error));
           await interaction.editReply({ content: `Failed to generate display: ${err.message}` });

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -6,8 +6,13 @@ export default {
     .setDescription('Check bot latency'),
   async execute(interaction: ChatInputCommandInteraction) {
     const response = await interaction.reply({ content: 'Pinging...', withResponse: true });
-    const latency = response.resource!.message!.createdTimestamp - interaction.createdTimestamp;
+    const created = response.resource?.message?.createdTimestamp;
+    const latency = created ? created - interaction.createdTimestamp : -1;
     const apiLatency = Math.round(interaction.client.ws.ping);
-    await interaction.editReply(`Pong! Latency: ${latency}ms | API Latency: ${apiLatency}ms`);
+    await interaction.editReply(
+      latency >= 0
+        ? `Pong! Latency: ${latency}ms | API Latency: ${apiLatency}ms`
+        : `Pong! API Latency: ${apiLatency}ms`,
+    );
   },
 };

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -5,8 +5,8 @@ export default {
     .setName('ping')
     .setDescription('Check bot latency'),
   async execute(interaction: ChatInputCommandInteraction) {
-    const sent = await interaction.reply({ content: 'Pinging...', fetchReply: true });
-    const latency = sent.createdTimestamp - interaction.createdTimestamp;
+    const response = await interaction.reply({ content: 'Pinging...', withResponse: true });
+    const latency = response.resource!.message!.createdTimestamp - interaction.createdTimestamp;
     const apiLatency = Math.round(interaction.client.ws.ping);
     await interaction.editReply(`Pong! Latency: ${latency}ms | API Latency: ${apiLatency}ms`);
   },

--- a/src/commands/raiders.ts
+++ b/src/commands/raiders.ts
@@ -133,13 +133,13 @@ export default {
           // Multiple pages - use buttons and cache
           const embed = buildPageEmbed(title, pages[0], 1, pages.length);
           const buttons = buildPageButtons('raiders', 1, pages.length);
-          const { resource: reply } = await interaction.reply({
+          const { resource } = await interaction.reply({
             embeds: [embed],
             components: buttons ? [buttons] : [],
             withResponse: true,
           });
-          const messageId = reply?.message?.id ?? interaction.id;
-          cachePaginatedData(`raiders:${messageId}`, title, pages);
+          // withResponse: true guarantees resource.message is present
+          cachePaginatedData(`raiders:${resource!.message!.id}`, title, pages);
         }
         break;
       }

--- a/src/commands/raiders.ts
+++ b/src/commands/raiders.ts
@@ -7,6 +7,7 @@ import {
 } from 'discord.js';
 import { getDatabase } from '../database/db.js';
 import { requireOfficer, createEmbed, audit } from '../utils.js';
+import { paginateLines, buildPageEmbed, buildPageButtons, cachePaginatedData } from '../functions/pagination.js';
 import { syncRaiders } from '../functions/raids/syncRaiders.js';
 import { autoMatchRaiders } from '../functions/raids/autoMatchRaiders.js';
 import { sendAlertForRaidersWithNoUser } from '../functions/raids/sendAlertForRaidersWithNoUser.js';
@@ -116,41 +117,29 @@ export default {
           return;
         }
 
-        // Build pages of raider listings
+        const title = `Raiders (${raiders.length} total)`;
         const lines = raiders.map(
           (r) =>
             `**${r.character_name}** (${r.realm}) - ${r.class ?? 'Unknown'} | ${r.discord_user_id ? `<@${r.discord_user_id}>` : 'Unlinked'}`,
         );
 
-        const pages: string[] = [];
-        let current = '';
-        for (const line of lines) {
-          if ((current + '\n' + line).length > 2000) {
-            pages.push(current);
-            current = line;
-          } else {
-            current = current ? current + '\n' + line : line;
-          }
-        }
-        if (current) pages.push(current);
+        const pages = paginateLines(lines);
 
-        // Send first page as embed
-        const embed = createEmbed(`Raiders (${raiders.length} total)`).setDescription(
-          pages[0],
-        );
-
-        if (pages.length > 1) {
-          embed.setFooter({ text: `Page 1/${pages.length} | SeriouslyCasualBot` });
-        }
-
-        await interaction.reply({ embeds: [embed] });
-
-        // Send remaining pages as follow-ups
-        for (let i = 1; i < pages.length; i++) {
-          const pageEmbed = createEmbed().setDescription(pages[i]).setFooter({
-            text: `Page ${i + 1}/${pages.length} | SeriouslyCasualBot`,
+        if (pages.length === 1) {
+          // Single page - no buttons or cache needed
+          const embed = buildPageEmbed(title, pages[0], 1, 1);
+          await interaction.reply({ embeds: [embed] });
+        } else {
+          // Multiple pages - use buttons and cache
+          const embed = buildPageEmbed(title, pages[0], 1, pages.length);
+          const buttons = buildPageButtons('raiders', 1, pages.length);
+          const { resource: reply } = await interaction.reply({
+            embeds: [embed],
+            components: buttons ? [buttons] : [],
+            withResponse: true,
           });
-          await interaction.followUp({ embeds: [pageEmbed] });
+          const messageId = reply?.message?.id ?? interaction.id;
+          cachePaginatedData(`raiders:${messageId}`, title, pages);
         }
         break;
       }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,9 +1,29 @@
+import { statSync } from 'fs';
 import { SlashCommandBuilder, type ChatInputCommandInteraction, MessageFlags } from 'discord.js';
 import { createEmbed } from '../utils.js';
 import { getDatabase } from '../database/db.js';
 import { logger } from '../services/logger.js';
+import { getTaskStatus } from '../services/statusTracker.js';
 
 const startTime = Date.now();
+
+function formatAge(date: Date | null | undefined): string {
+  if (!date) return 'Never';
+  const diffMs = Date.now() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return 'Just now';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const hours = Math.floor(diffMin / 60);
+  const mins = diffMin % 60;
+  return mins > 0 ? `${hours}h ${mins}m ago` : `${hours}h ago`;
+}
+
+function formatDbSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
 
 export default {
   data: new SlashCommandBuilder()
@@ -19,15 +39,35 @@ export default {
     const raiders = db.prepare('SELECT COUNT(*) as total, COUNT(discord_user_id) as linked FROM raiders').get() as { total: number; linked: number };
     const activeApps = db.prepare("SELECT COUNT(*) as count FROM applications WHERE status IN ('in_progress', 'submitted', 'active')").get() as { count: number };
     const activeTrials = db.prepare("SELECT COUNT(*) as count FROM trials WHERE status = 'active'").get() as { count: number };
+    const epgpUpload = db.prepare('SELECT MAX(timestamp) as ts FROM epgp_upload_history').get() as { ts: string | null };
+
+    const dbPath = process.env.DB_PATH || 'db.sqlite';
+    let dbSizeStr = 'N/A';
+    try {
+      const stats = statSync(dbPath);
+      dbSizeStr = formatDbSize(stats.size);
+    } catch {
+      // file not found or inaccessible
+    }
+
+    const syncStatus = getTaskStatus('syncRaiders');
+    const achievementsStatus = getTaskStatus('updateAchievements');
+    const trialLogsStatus = getTaskStatus('updateTrialLogs');
+
+    const epgpLastUpload = epgpUpload?.ts ? formatAge(new Date(epgpUpload.ts)) : 'Never';
 
     const embed = createEmbed('Bot Status')
       .addFields(
         { name: 'Uptime', value: `${hours}h ${minutes}m ${seconds}s`, inline: true },
         { name: 'Log Level', value: logger.getLevel(), inline: true },
-        { name: '\u200b', value: '\u200b', inline: true },
+        { name: 'DB Size', value: dbSizeStr, inline: true },
         { name: 'Raiders', value: `${raiders.linked}/${raiders.total} linked`, inline: true },
         { name: 'Active Applications', value: `${activeApps.count}`, inline: true },
         { name: 'Active Trials', value: `${activeTrials.count}`, inline: true },
+        { name: 'Last Roster Sync', value: formatAge(syncStatus?.lastRun), inline: true },
+        { name: 'Last Achievements Update', value: formatAge(achievementsStatus?.lastRun), inline: true },
+        { name: 'Last Trial Logs Update', value: formatAge(trialLogsStatus?.lastRun), inline: true },
+        { name: 'EPGP Last Upload', value: epgpLastUpload, inline: true },
       );
 
     await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });

--- a/src/commands/testdata.ts
+++ b/src/commands/testdata.ts
@@ -43,118 +43,54 @@ export default {
     if (!requireOfficer(interaction)) return;
 
     const sub = interaction.options.getSubcommand();
+    const db = getDatabase();
 
-    if (sub === 'seed_raiders') {
-      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-
-      try {
-        const db = getDatabase();
+    const handlers: Record<string, () => string> = {
+      seed_raiders: () => {
         seedRaiders(db);
-        logger.info('TestData', 'Seeded 15 mock raiders');
-        await interaction.editReply({ content: 'Seeded 15 mock raiders into the database.' });
-      } catch (err) {
-        logger.error('TestData', 'Failed to seed raiders', err as Error);
-        await interaction.editReply({ content: 'Failed to seed raiders. Check logs for details.' });
-      }
-
-      return;
-    }
-
-    if (sub === 'seed_application') {
-      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-
-      try {
-        const db = getDatabase();
-        const result = seedApplication(db);
-        logger.info('TestData', `Seeded mock application ID ${result.applicationId}`);
-        await interaction.editReply({
-          content: `Seeded 1 mock application (ID: ${result.applicationId}) with ${result.questionCount} answers and 2 votes.`,
-        });
-      } catch (err) {
-        logger.error('TestData', 'Failed to seed application', err as Error);
-        await interaction.editReply({ content: 'Failed to seed application. Check logs for details.' });
-      }
-
-      return;
-    }
-
-    if (sub === 'seed_trial') {
-      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-
-      try {
-        const db = getDatabase();
-        const result = seedTrial(db);
-        logger.info('TestData', `Seeded mock trial ID ${result.trialId}`);
-        await interaction.editReply({
-          content: `Seeded 1 mock trial (ID: ${result.trialId}) with ${result.alertCount} trial alerts.`,
-        });
-      } catch (err) {
-        logger.error('TestData', 'Failed to seed trial', err as Error);
-        await interaction.editReply({ content: 'Failed to seed trial. Check logs for details.' });
-      }
-
-      return;
-    }
-
-    if (sub === 'seed_epgp') {
-      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-
-      try {
-        const db = getDatabase();
-        const result = seedEpgp(db);
-        logger.info('TestData', `Seeded EPGP data for ${result.raiderCount} raiders`);
-        await interaction.editReply({
-          content: [
-            `Seeded EPGP data for **${result.raiderCount}** raiders:`,
-            `• ${result.effortPointsInserted} effort point entries`,
-            `• ${result.gearPointsInserted} gear point entries`,
-            `• ${result.lootHistoryInserted} loot history entries`,
-            `• ${result.uploadHistoryInserted} upload history record`,
-          ].join('\n'),
-        });
-      } catch (err) {
-        logger.error('TestData', 'Failed to seed EPGP', err as Error);
-        const message = err instanceof Error ? err.message : 'Check logs for details.';
-        await interaction.editReply({ content: `Failed to seed EPGP. ${message}` });
-      }
-
-      return;
-    }
-
-    if (sub === 'seed_loot') {
-      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-
-      try {
-        const db = getDatabase();
-        const result = seedLoot(db);
-        logger.info('TestData', `Seeded ${result.postsInserted} mock loot posts`);
-        await interaction.editReply({
-          content: `Seeded ${result.postsInserted} mock loot posts (boss IDs 99901–99903).`,
-        });
-      } catch (err) {
-        logger.error('TestData', 'Failed to seed loot', err as Error);
-        await interaction.editReply({ content: 'Failed to seed loot posts. Check logs for details.' });
-      }
-
-      return;
-    }
-
-    if (sub === 'reset') {
-      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-
-      try {
-        const db = getDatabase();
+        return 'Seeded 15 mock raiders into the database.';
+      },
+      seed_application: () => {
+        const r = seedApplication(db);
+        return `Seeded 1 mock application (ID: ${r.applicationId}) with ${r.questionCount} answers and 2 votes.`;
+      },
+      seed_trial: () => {
+        const r = seedTrial(db);
+        return `Seeded 1 mock trial (ID: ${r.trialId}) with ${r.alertCount} trial alerts.`;
+      },
+      seed_epgp: () => {
+        const r = seedEpgp(db);
+        return [
+          `Seeded EPGP data for **${r.raiderCount}** raiders:`,
+          `• ${r.effortPointsInserted} effort point entries`,
+          `• ${r.gearPointsInserted} gear point entries`,
+          `• ${r.lootHistoryInserted} loot history entries`,
+          `• ${r.uploadHistoryInserted} upload history record`,
+        ].join('\n');
+      },
+      seed_loot: () => {
+        const r = seedLoot(db);
+        return `Seeded ${r.postsInserted} mock loot posts (boss IDs 99901-99903).`;
+      },
+      reset: () => {
         resetData(db);
-        logger.info('TestData', 'Reset all data and re-seeded defaults');
-        await interaction.editReply({
-          content: 'All data wiped and defaults re-seeded successfully.',
-        });
-      } catch (err) {
-        logger.error('TestData', 'Failed to reset data', err as Error);
-        await interaction.editReply({ content: 'Failed to reset data. Check logs for details.' });
-      }
+        return 'All data wiped and defaults re-seeded successfully.';
+      },
+    };
 
-      return;
+    const handler = handlers[sub];
+    if (!handler) return;
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+      const message = handler();
+      logger.info('TestData', `${sub}: ${message}`);
+      await interaction.editReply({ content: message });
+    } catch (err) {
+      logger.error('TestData', `Failed to run ${sub}`, err as Error);
+      const detail = err instanceof Error ? err.message : 'Check logs for details.';
+      await interaction.editReply({ content: `Failed to run ${sub}. ${detail}` });
     }
   },
 };

--- a/src/commands/testdata.ts
+++ b/src/commands/testdata.ts
@@ -7,6 +7,11 @@ import {
 import { requireOfficer } from '../utils.js';
 import { getDatabase } from '../database/db.js';
 import { seedRaiders } from '../functions/testdata/seedRaiders.js';
+import { seedApplication } from '../functions/testdata/seedApplication.js';
+import { seedTrial } from '../functions/testdata/seedTrial.js';
+import { seedEpgp } from '../functions/testdata/seedEpgp.js';
+import { seedLoot } from '../functions/testdata/seedLoot.js';
+import { resetData } from '../functions/testdata/resetData.js';
 import { logger } from '../services/logger.js';
 
 export default {
@@ -19,19 +24,19 @@ export default {
       sub.setName('seed_raiders').setDescription('Insert 15 mock raiders into the database'),
     )
     .addSubcommand((sub) =>
-      sub.setName('seed_application').setDescription('Insert a mock application (not yet implemented)'),
+      sub.setName('seed_application').setDescription('Insert a mock application with answers and votes'),
     )
     .addSubcommand((sub) =>
-      sub.setName('seed_trial').setDescription('Insert a mock trial (not yet implemented)'),
+      sub.setName('seed_trial').setDescription('Insert a mock trial with 3 scheduled alerts'),
     )
     .addSubcommand((sub) =>
-      sub.setName('seed_epgp').setDescription('Insert mock EPGP data (not yet implemented)'),
+      sub.setName('seed_epgp').setDescription('Insert mock EPGP data for existing raiders'),
     )
     .addSubcommand((sub) =>
-      sub.setName('seed_loot').setDescription('Insert mock loot posts (not yet implemented)'),
+      sub.setName('seed_loot').setDescription('Insert 3 mock loot posts'),
     )
     .addSubcommand((sub) =>
-      sub.setName('reset').setDescription('Wipe all test data (not yet implemented)'),
+      sub.setName('reset').setDescription('Wipe all test data and re-seed defaults'),
     ),
 
   async execute(interaction: ChatInputCommandInteraction): Promise<void> {
@@ -55,8 +60,101 @@ export default {
       return;
     }
 
-    // Stubs for remaining subcommands
-    const reply = { content: `\`${sub}\` is not yet implemented.`, flags: MessageFlags.Ephemeral } as const;
-    await interaction.reply(reply);
+    if (sub === 'seed_application') {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      try {
+        const db = getDatabase();
+        const result = seedApplication(db);
+        logger.info('TestData', `Seeded mock application ID ${result.applicationId}`);
+        await interaction.editReply({
+          content: `Seeded 1 mock application (ID: ${result.applicationId}) with ${result.questionCount} answers and 2 votes.`,
+        });
+      } catch (err) {
+        logger.error('TestData', 'Failed to seed application', err as Error);
+        await interaction.editReply({ content: 'Failed to seed application. Check logs for details.' });
+      }
+
+      return;
+    }
+
+    if (sub === 'seed_trial') {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      try {
+        const db = getDatabase();
+        const result = seedTrial(db);
+        logger.info('TestData', `Seeded mock trial ID ${result.trialId}`);
+        await interaction.editReply({
+          content: `Seeded 1 mock trial (ID: ${result.trialId}) with ${result.alertCount} trial alerts.`,
+        });
+      } catch (err) {
+        logger.error('TestData', 'Failed to seed trial', err as Error);
+        await interaction.editReply({ content: 'Failed to seed trial. Check logs for details.' });
+      }
+
+      return;
+    }
+
+    if (sub === 'seed_epgp') {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      try {
+        const db = getDatabase();
+        const result = seedEpgp(db);
+        logger.info('TestData', `Seeded EPGP data for ${result.raiderCount} raiders`);
+        await interaction.editReply({
+          content: [
+            `Seeded EPGP data for **${result.raiderCount}** raiders:`,
+            `• ${result.effortPointsInserted} effort point entries`,
+            `• ${result.gearPointsInserted} gear point entries`,
+            `• ${result.lootHistoryInserted} loot history entries`,
+            `• ${result.uploadHistoryInserted} upload history record`,
+          ].join('\n'),
+        });
+      } catch (err) {
+        logger.error('TestData', 'Failed to seed EPGP', err as Error);
+        const message = err instanceof Error ? err.message : 'Check logs for details.';
+        await interaction.editReply({ content: `Failed to seed EPGP. ${message}` });
+      }
+
+      return;
+    }
+
+    if (sub === 'seed_loot') {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      try {
+        const db = getDatabase();
+        const result = seedLoot(db);
+        logger.info('TestData', `Seeded ${result.postsInserted} mock loot posts`);
+        await interaction.editReply({
+          content: `Seeded ${result.postsInserted} mock loot posts (boss IDs 99901–99903).`,
+        });
+      } catch (err) {
+        logger.error('TestData', 'Failed to seed loot', err as Error);
+        await interaction.editReply({ content: 'Failed to seed loot posts. Check logs for details.' });
+      }
+
+      return;
+    }
+
+    if (sub === 'reset') {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      try {
+        const db = getDatabase();
+        resetData(db);
+        logger.info('TestData', 'Reset all data and re-seeded defaults');
+        await interaction.editReply({
+          content: 'All data wiped and defaults re-seeded successfully.',
+        });
+      } catch (err) {
+        logger.error('TestData', 'Failed to reset data', err as Error);
+        await interaction.editReply({ content: 'Failed to reset data. Check logs for details.' });
+      }
+
+      return;
+    }
   },
 };

--- a/src/commands/testdata.ts
+++ b/src/commands/testdata.ts
@@ -1,0 +1,62 @@
+import {
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  MessageFlags,
+  PermissionFlagsBits,
+} from 'discord.js';
+import { requireOfficer } from '../utils.js';
+import { getDatabase } from '../database/db.js';
+import { seedRaiders } from '../functions/testdata/seedRaiders.js';
+import { logger } from '../services/logger.js';
+
+export default {
+  devOnly: true,
+  data: new SlashCommandBuilder()
+    .setName('testdata')
+    .setDescription('Dev-only: seed or reset test data in the database')
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+    .addSubcommand((sub) =>
+      sub.setName('seed_raiders').setDescription('Insert 15 mock raiders into the database'),
+    )
+    .addSubcommand((sub) =>
+      sub.setName('seed_application').setDescription('Insert a mock application (not yet implemented)'),
+    )
+    .addSubcommand((sub) =>
+      sub.setName('seed_trial').setDescription('Insert a mock trial (not yet implemented)'),
+    )
+    .addSubcommand((sub) =>
+      sub.setName('seed_epgp').setDescription('Insert mock EPGP data (not yet implemented)'),
+    )
+    .addSubcommand((sub) =>
+      sub.setName('seed_loot').setDescription('Insert mock loot posts (not yet implemented)'),
+    )
+    .addSubcommand((sub) =>
+      sub.setName('reset').setDescription('Wipe all test data (not yet implemented)'),
+    ),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    if (!requireOfficer(interaction)) return;
+
+    const sub = interaction.options.getSubcommand();
+
+    if (sub === 'seed_raiders') {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      try {
+        const db = getDatabase();
+        seedRaiders(db);
+        logger.info('TestData', 'Seeded 15 mock raiders');
+        await interaction.editReply({ content: 'Seeded 15 mock raiders into the database.' });
+      } catch (err) {
+        logger.error('TestData', 'Failed to seed raiders', err as Error);
+        await interaction.editReply({ content: 'Failed to seed raiders. Check logs for details.' });
+      }
+
+      return;
+    }
+
+    // Stubs for remaining subcommands
+    const reply = { content: `\`${sub}\` is not yet implemented.`, flags: MessageFlags.Ephemeral } as const;
+    await interaction.reply(reply);
+  },
+};

--- a/src/commands/trials.ts
+++ b/src/commands/trials.ts
@@ -152,14 +152,14 @@ export default {
         } else {
           const embed = buildPageEmbed(title, pages[0], 1, pages.length);
           const buttons = buildPageButtons('trials', 1, pages.length);
-          const { resource: reply } = await interaction.reply({
+          const { resource } = await interaction.reply({
             embeds: [embed],
             components: buttons ? [buttons] : [],
             flags: MessageFlags.Ephemeral,
             withResponse: true,
           });
-          const messageId = reply?.message?.id ?? interaction.id;
-          cachePaginatedData(`trials:${messageId}`, title, pages);
+          // withResponse: true guarantees resource.message is present
+          cachePaginatedData(`trials:${resource!.message!.id}`, title, pages);
         }
         break;
       }

--- a/src/commands/trials.ts
+++ b/src/commands/trials.ts
@@ -12,6 +12,7 @@ import { getDatabase } from '../database/db.js';
 import { requireOfficer, createEmbed } from '../utils.js';
 import { audit } from '../services/auditLog.js';
 import { logger } from '../services/logger.js';
+import { paginateLines, buildPageEmbed, buildPageButtons, cachePaginatedData } from '../functions/pagination.js';
 import { closeTrial } from '../functions/trial-review/closeTrial.js';
 import { changeTrialInfo } from '../functions/trial-review/changeTrialInfo.js';
 import { updateTrialLogs } from '../functions/trial-review/updateTrialLogs.js';
@@ -142,14 +143,24 @@ export default {
           return `**${t.character_name}** - ${t.role} | Started: ${t.start_date} ${statusIndicator}${threadRef}`;
         });
 
-        const embed = createEmbed(`Active Trials (${trials.length})`).setDescription(
-          lines.join('\n'),
-        );
+        const title = `Active Trials (${trials.length})`;
+        const pages = paginateLines(lines);
 
-        await interaction.reply({
-          embeds: [embed],
-          flags: MessageFlags.Ephemeral,
-        });
+        if (pages.length === 1) {
+          const embed = buildPageEmbed(title, pages[0], 1, 1);
+          await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
+        } else {
+          const embed = buildPageEmbed(title, pages[0], 1, pages.length);
+          const buttons = buildPageButtons('trials', 1, pages.length);
+          const { resource: reply } = await interaction.reply({
+            embeds: [embed],
+            components: buttons ? [buttons] : [],
+            flags: MessageFlags.Ephemeral,
+            withResponse: true,
+          });
+          const messageId = reply?.message?.id ?? interaction.id;
+          cachePaginatedData(`trials:${messageId}`, title, pages);
+        }
         break;
       }
 

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -386,7 +386,7 @@ export default {
           const commandName = parts[1];
           const page = parseInt(parts[2], 10);
 
-          const cacheKey = `${commandName}:${interaction.message.interaction?.id ?? interaction.message.id}`;
+          const cacheKey = `${commandName}:${interaction.message.id}`;
           const data = getCachedPage(cacheKey, page);
 
           if (!data) {

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -35,6 +35,7 @@ import { updateLootResponse } from '../functions/loot/updateLootResponse.js';
 import { updateLootPost } from '../functions/loot/updateLootPost.js';
 import { generateLootPost } from '../functions/loot/generateLootPost.js';
 import type { LootPostRow, LootResponseRow } from '../types/index.js';
+import { getCachedPage, buildPageEmbed, buildPageButtons } from '../functions/pagination.js';
 
 export default {
   name: 'interactionCreate',
@@ -377,6 +378,31 @@ export default {
             const error = err instanceof Error ? err : new Error(String(err));
             await interaction.editReply({ content: `Failed to close trial: ${error.message}` });
           }
+        }
+
+        // page:{commandName}:{targetPage}:{totalPages} - Pagination navigation
+        if (customId.startsWith('page:')) {
+          const parts = customId.split(':');
+          const commandName = parts[1];
+          const page = parseInt(parts[2], 10);
+
+          const cacheKey = `${commandName}:${interaction.message.interaction?.id ?? interaction.message.id}`;
+          const data = getCachedPage(cacheKey, page);
+
+          if (!data) {
+            await interaction.reply({
+              content: 'This list has expired. Please run the command again.',
+              flags: MessageFlags.Ephemeral,
+            });
+            return;
+          }
+
+          const embed = buildPageEmbed(data.title, data.content, page, data.totalPages);
+          const buttons = buildPageButtons(commandName, page, data.totalPages);
+          await interaction.update({
+            embeds: [embed],
+            components: buttons ? [buttons] : [],
+          });
         }
 
         // loot:{responseType}:{bossId} - Loot priority button

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -9,11 +9,14 @@ import { refreshLinkingMessages } from '../functions/raids/refreshLinkingMessage
 import { updateAchievements } from '../functions/guild-info/updateAchievements.js';
 import { rescheduleAllAlerts } from '../functions/trial-review/scheduleTrialAlerts.js';
 import { updateTrialLogs } from '../functions/trial-review/updateTrialLogs.js';
+import { resumeSessions } from '../functions/applications/resumeSessions.js';
+import { dailyBackup } from '../functions/backups/dailyBackup.js';
+import { recordTaskRun } from '../services/statusTracker.js';
 
 export const scheduler = new Scheduler();
 
 export default {
-  name: 'ready',
+  name: 'clientReady',
   once: true,
   async execute(...args: unknown[]) {
     const client = args[0] as Client;
@@ -31,13 +34,29 @@ export default {
     scheduler.registerInterval({
       name: 'syncRaiders',
       intervalMs: 600_000,
-      handler: () => syncRaiders(client),
+      handler: async () => {
+        try {
+          await syncRaiders(client);
+          recordTaskRun('syncRaiders', true);
+        } catch (error) {
+          recordTaskRun('syncRaiders', false, String(error));
+          throw error;
+        }
+      },
     });
 
     scheduler.registerInterval({
       name: 'refreshLinkingMessages',
       intervalMs: 600_000,
-      handler: () => refreshLinkingMessages(client),
+      handler: async () => {
+        try {
+          await refreshLinkingMessages(client);
+          recordTaskRun('refreshLinkingMessages', true);
+        } catch (error) {
+          recordTaskRun('refreshLinkingMessages', false, String(error));
+          throw error;
+        }
+      },
     });
 
     scheduler.registerCron({
@@ -55,19 +74,44 @@ export default {
     scheduler.registerInterval({
       name: 'updateAchievements',
       intervalMs: 1_800_000,
-      handler: () => updateAchievements(client),
+      handler: async () => {
+        try {
+          await updateAchievements(client);
+          recordTaskRun('updateAchievements', true);
+        } catch (error) {
+          recordTaskRun('updateAchievements', false, String(error));
+          throw error;
+        }
+      },
     });
 
     scheduler.registerInterval({
       name: 'updateTrialLogs',
       intervalMs: 3_600_000,
-      handler: () => updateTrialLogs(client),
+      handler: async () => {
+        try {
+          await updateTrialLogs(client);
+          recordTaskRun('updateTrialLogs', true);
+        } catch (error) {
+          recordTaskRun('updateTrialLogs', false, String(error));
+          throw error;
+        }
+      },
+    });
+
+    scheduler.registerCron({
+      name: 'dailyBackup',
+      expression: '0 4 * * *',
+      handler: () => dailyBackup(),
     });
 
     scheduler.start();
 
     // Reschedule trial alerts from DB (must happen after scheduler.start)
     rescheduleAllAlerts(client);
+
+    // Resume any in-progress DM application sessions from before restart
+    await resumeSessions(client);
 
     logger.info('bot', 'Startup complete');
   },

--- a/src/events/threadUpdate.ts
+++ b/src/events/threadUpdate.ts
@@ -3,6 +3,15 @@ import { getDatabase } from '../database/db.js';
 import { logger } from '../services/logger.js';
 import type { ApplicationRow, TrialRow } from '../types/index.js';
 
+async function tryUnarchive(thread: ThreadChannel, domain: string, name: string, id: number): Promise<void> {
+  try {
+    await thread.setArchived(false);
+    logger.info(domain, `Unarchived thread for "${name}" (#${id})`);
+  } catch (error) {
+    logger.error(domain, `Failed to unarchive thread ${thread.id}: ${error}`, error as Error);
+  }
+}
+
 export default {
   name: 'threadUpdate',
   async execute(...args: unknown[]) {
@@ -20,20 +29,7 @@ export default {
       .get(newThread.id) as TrialRow | undefined;
 
     if (trial) {
-      // Unarchive the trial thread
-      try {
-        await newThread.setArchived(false);
-        logger.info(
-          'Trials',
-          `Unarchived trial thread for "${trial.character_name}" (#${trial.id})`,
-        );
-      } catch (error) {
-        logger.error(
-          'Trials',
-          `Failed to unarchive trial thread ${newThread.id}: ${error}`,
-          error as Error,
-        );
-      }
+      await tryUnarchive(newThread, 'Trials', trial.character_name, trial.id);
       return;
     }
 
@@ -44,21 +40,8 @@ export default {
       )
       .get(newThread.id, newThread.id) as ApplicationRow | undefined;
 
-    if (!application) return;
-
-    // Unarchive the application thread
-    try {
-      await newThread.setArchived(false);
-      logger.info(
-        'Applications',
-        `Unarchived application thread for "${application.character_name}" (#${application.id})`,
-      );
-    } catch (error) {
-      logger.error(
-        'Applications',
-        `Failed to unarchive application thread ${newThread.id}: ${error}`,
-        error as Error,
-      );
+    if (application) {
+      await tryUnarchive(newThread, 'Applications', application.character_name ?? 'unknown', application.id);
     }
   },
 };

--- a/src/events/threadUpdate.ts
+++ b/src/events/threadUpdate.ts
@@ -1,7 +1,7 @@
 import type { ThreadChannel } from 'discord.js';
 import { getDatabase } from '../database/db.js';
 import { logger } from '../services/logger.js';
-import type { TrialRow } from '../types/index.js';
+import type { ApplicationRow, TrialRow } from '../types/index.js';
 
 export default {
   name: 'threadUpdate',
@@ -19,19 +19,44 @@ export default {
       .prepare("SELECT * FROM trials WHERE thread_id = ? AND status IN ('active', 'promoted')")
       .get(newThread.id) as TrialRow | undefined;
 
-    if (!trial) return;
+    if (trial) {
+      // Unarchive the trial thread
+      try {
+        await newThread.setArchived(false);
+        logger.info(
+          'Trials',
+          `Unarchived trial thread for "${trial.character_name}" (#${trial.id})`,
+        );
+      } catch (error) {
+        logger.error(
+          'Trials',
+          `Failed to unarchive trial thread ${newThread.id}: ${error}`,
+          error as Error,
+        );
+      }
+      return;
+    }
 
-    // Unarchive the trial thread
+    // Check if this thread belongs to an active application
+    const application = db
+      .prepare(
+        "SELECT * FROM applications WHERE (forum_post_id = ? OR thread_id = ?) AND status IN ('in_progress', 'submitted', 'active')",
+      )
+      .get(newThread.id, newThread.id) as ApplicationRow | undefined;
+
+    if (!application) return;
+
+    // Unarchive the application thread
     try {
       await newThread.setArchived(false);
       logger.info(
-        'Trials',
-        `Unarchived trial thread for "${trial.character_name}" (#${trial.id})`,
+        'Applications',
+        `Unarchived application thread for "${application.character_name}" (#${application.id})`,
       );
     } catch (error) {
       logger.error(
-        'Trials',
-        `Failed to unarchive trial thread ${newThread.id}: ${error}`,
+        'Applications',
+        `Failed to unarchive application thread ${newThread.id}: ${error}`,
         error as Error,
       );
     }

--- a/src/functions/applications/applicationQuestions.ts
+++ b/src/functions/applications/applicationQuestions.ts
@@ -1,4 +1,5 @@
 import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
 import type { ApplicationQuestionRow } from '../../types/index.js';
 
 /**
@@ -35,6 +36,8 @@ export function addQuestion(question: string): ApplicationQuestionRow {
     .prepare('INSERT INTO application_questions (question, sort_order) VALUES (?, ?)')
     .run(question, nextOrder);
 
+  logger.info('Applications', `Added question #${result.lastInsertRowid} (sort_order=${nextOrder})`);
+
   return {
     id: result.lastInsertRowid as number,
     question,
@@ -51,5 +54,12 @@ export function removeQuestion(id: number): boolean {
   const result = db
     .prepare('DELETE FROM application_questions WHERE id = ?')
     .run(id);
+
+  if (result.changes > 0) {
+    logger.info('Applications', `Removed question #${id}`);
+  } else {
+    logger.warn('Applications', `Attempted to remove non-existent question #${id}`);
+  }
+
   return result.changes > 0;
 }

--- a/src/functions/applications/dmQuestionnaire.ts
+++ b/src/functions/applications/dmQuestionnaire.ts
@@ -100,6 +100,8 @@ async function handleQuestionResponse(message: Message, session: ApplicationSess
   db.prepare('INSERT INTO application_answers (application_id, question_id, answer) VALUES (?, ?, ?)')
     .run(session.applicationId, currentQuestion.id, message.content);
 
+  logger.debug('Applications', `Answer recorded for application #${session.applicationId}, question #${currentQuestion.id} (${session.questionIndex + 1}/${getQuestions().length})`);
+
   // Set character_name from the first answer
   if (session.questionIndex === 0) {
     db.prepare('UPDATE applications SET character_name = ? WHERE id = ?')
@@ -142,6 +144,8 @@ async function handleEditNumberResponse(message: Message, session: ApplicationSe
   session.editMode = 'awaiting_answer';
   session.editQuestionIndex = num - 1;
 
+  logger.debug('Applications', `User ${message.author.id} entered edit mode for question ${num} on application #${session.applicationId}`);
+
   const question = questions[num - 1];
   await message.author.send(`**Editing Answer ${num}:**\n${question.question}`);
 }
@@ -160,9 +164,11 @@ async function handleEditAnswerResponse(message: Message, session: ApplicationSe
   if (existingAnswer) {
     db.prepare('UPDATE application_answers SET answer = ? WHERE id = ?')
       .run(message.content, existingAnswer.id);
+    logger.info('Applications', `Edited answer for application #${session.applicationId}, question #${question.id}`);
   } else {
     db.prepare('INSERT INTO application_answers (application_id, question_id, answer) VALUES (?, ?, ?)')
       .run(session.applicationId, question.id, message.content);
+    logger.info('Applications', `Inserted edited answer for application #${session.applicationId}, question #${question.id} (no prior answer)`);
   }
 
   // Update character_name if first answer was edited
@@ -214,11 +220,10 @@ export async function showSummary(user: User, applicationId: number): Promise<vo
   // Split across messages if > 2000 chars
   const messages = splitMessage(summary);
 
-  for (let i = 0; i < messages.length - 1; i++) {
-    await user.send(messages[i]);
+  for (const msg of messages) {
+    await user.send(msg);
   }
 
-  // Add buttons to the last message
   const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder()
       .setCustomId(`application:edit:${applicationId}`)
@@ -234,7 +239,11 @@ export async function showSummary(user: User, applicationId: number): Promise<vo
       .setStyle(ButtonStyle.Danger),
   );
 
-  await user.send({ content: messages[messages.length - 1], components: [row] });
+  const confirmPrompt =
+    'We try to review and respond to applications as quickly as we can. Please be warned that it can take up to a week for us to come to a decision.\n\n' +
+    'Would you like to submit your application?';
+
+  await user.send({ content: confirmPrompt, components: [row] });
 }
 
 /**

--- a/src/functions/applications/generateTranscript.ts
+++ b/src/functions/applications/generateTranscript.ts
@@ -74,5 +74,7 @@ export async function generateTranscript(
   const text = lines.join('\n');
   const buffer = Buffer.from(text, 'utf-8');
 
+  logger.info('Applications', `Transcript generated for channel ${channel.id}: ${allMessages.length} messages, ${buffer.length} bytes`);
+
   return { text, buffer };
 }

--- a/src/functions/applications/generateVotingEmbed.ts
+++ b/src/functions/applications/generateVotingEmbed.ts
@@ -6,6 +6,7 @@ import {
   ButtonStyle,
 } from 'discord.js';
 import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
 import type { ApplicationVoteRow } from '../../types/index.js';
 
 /**
@@ -110,6 +111,8 @@ export function generateVotingEmbed(applicationId: number): {
       .setEmoji('😂')
       .setStyle(ButtonStyle.Danger),
   );
+
+  logger.debug('Applications', `Generated voting embed for application #${applicationId} (${votes.length} total votes)`);
 
   return { embeds: [embed], components: [votingRow] };
 }

--- a/src/functions/applications/resumeSessions.ts
+++ b/src/functions/applications/resumeSessions.ts
@@ -1,0 +1,104 @@
+import type { Client, User } from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import { activeSessions, startSessionTimeout } from './dmQuestionnaire.js';
+import type { ApplicationRow, ApplicationQuestionRow } from '../../types/index.js';
+
+/**
+ * Resume in-progress DM application sessions after a bot restart.
+ * Queries the DB for all applications with status='in_progress', determines
+ * which question each applicant was on, restores the session, and DMs the user.
+ */
+export async function resumeSessions(client: Client): Promise<void> {
+  const db = getDatabase();
+
+  const inProgress = db
+    .prepare(`SELECT * FROM applications WHERE status = 'in_progress'`)
+    .all() as ApplicationRow[];
+
+  if (inProgress.length === 0) {
+    logger.info('Applications', 'resumeSessions: no in-progress sessions to restore');
+    return;
+  }
+
+  const questions = db
+    .prepare('SELECT * FROM application_questions ORDER BY sort_order')
+    .all() as ApplicationQuestionRow[];
+
+  let resumed = 0;
+  let skipped = 0;
+
+  for (const app of inProgress) {
+    const { count } = db
+      .prepare('SELECT COUNT(*) as count FROM application_answers WHERE application_id = ?')
+      .get(app.id) as { count: number };
+
+    // If all questions are answered the user was at the summary stage - skip
+    if (questions.length > 0 && count >= questions.length) {
+      logger.debug(
+        'Applications',
+        `resumeSessions: application #${app.id} (user ${app.applicant_user_id}) is at summary stage, skipping`,
+      );
+      skipped++;
+      continue;
+    }
+
+    // questionIndex is the next unanswered question
+    const questionIndex = count;
+    const nextQuestion = questions[questionIndex];
+
+    if (!nextQuestion) {
+      logger.warn(
+        'Applications',
+        `resumeSessions: application #${app.id} has questionIndex=${questionIndex} but no question at that index, skipping`,
+      );
+      skipped++;
+      continue;
+    }
+
+    // Restore session
+    activeSessions.set(app.applicant_user_id, {
+      applicationId: app.id,
+      questionIndex,
+    });
+
+    let user: User | undefined;
+    try {
+      user = await client.users.fetch(app.applicant_user_id);
+    } catch {
+      logger.warn(
+        'Applications',
+        `resumeSessions: could not fetch user ${app.applicant_user_id} for application #${app.id}`,
+      );
+      activeSessions.delete(app.applicant_user_id);
+      skipped++;
+      continue;
+    }
+
+    // Set up the inactivity timeout
+    startSessionTimeout(user);
+
+    // DM the user to resume
+    try {
+      await user.send(
+        `Sorry, I had to restart! Let's continue where we left off.\n\nQuestion ${questionIndex + 1}/${questions.length}: ${nextQuestion.question}`,
+      );
+      logger.info(
+        'Applications',
+        `resumeSessions: resumed application #${app.id} for ${user.tag} at question ${questionIndex + 1}/${questions.length}`,
+      );
+      resumed++;
+    } catch {
+      logger.warn(
+        'Applications',
+        `resumeSessions: could not DM user ${user.tag} (${app.applicant_user_id}) for application #${app.id} - DMs may be disabled`,
+      );
+      // Leave session in activeSessions so handleDmMessage can still process if they reply
+    }
+  }
+
+  logger.info(
+    'Applications',
+    `resumeSessions: complete — ${resumed} resumed, ${skipped} skipped out of ${inProgress.length} in-progress`,
+  );
+}

--- a/src/functions/applications/resumeSessions.ts
+++ b/src/functions/applications/resumeSessions.ts
@@ -33,7 +33,10 @@ export async function resumeSessions(client: Client): Promise<void> {
       .prepare('SELECT COUNT(*) as count FROM application_answers WHERE application_id = ?')
       .get(app.id) as { count: number };
 
-    // If all questions are answered the user was at the summary stage - skip
+    // If all questions are answered the user was at the summary stage. The
+    // summary message has persistent Confirm/Edit/Cancel buttons (custom IDs),
+    // so Discord will route the click to interactionCreate without needing an
+    // active in-memory session. We skip these rather than re-sending the summary.
     if (questions.length > 0 && count >= questions.length) {
       logger.debug(
         'Applications',

--- a/src/functions/applications/voteOnApplication.ts
+++ b/src/functions/applications/voteOnApplication.ts
@@ -1,5 +1,6 @@
 import type { ButtonInteraction } from 'discord.js';
 import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
 import { generateVotingEmbed } from './generateVotingEmbed.js';
 
 /**
@@ -16,6 +17,8 @@ export async function voteOnApplication(
   db.prepare(
     'INSERT OR REPLACE INTO application_votes (application_id, user_id, vote_type) VALUES (?, ?, ?)',
   ).run(applicationId, interaction.user.id, voteType);
+
+  logger.info('Applications', `Vote recorded: user ${interaction.user.id} voted '${voteType}' on application #${applicationId}`);
 
   // Regenerate the embed and update the message in place
   const updated = generateVotingEmbed(applicationId);

--- a/src/functions/backups/dailyBackup.ts
+++ b/src/functions/backups/dailyBackup.ts
@@ -1,9 +1,10 @@
 import { existsSync, mkdirSync, readdirSync, unlinkSync, statSync } from 'fs';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { getDatabase } from '../../database/db.js';
 import { logger } from '../../services/logger.js';
 
-const BACKUP_DIR = 'backups';
+/** Absolute path to backup directory, anchored to cwd at import time. */
+const BACKUP_DIR = resolve(process.cwd(), 'backups');
 const MAX_BACKUPS = 7;
 
 export async function dailyBackup(): Promise<void> {

--- a/src/functions/backups/dailyBackup.ts
+++ b/src/functions/backups/dailyBackup.ts
@@ -1,0 +1,50 @@
+import { existsSync, mkdirSync, readdirSync, unlinkSync, statSync } from 'fs';
+import { join } from 'path';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+
+const BACKUP_DIR = 'backups';
+const MAX_BACKUPS = 7;
+
+export async function dailyBackup(): Promise<void> {
+  if (!existsSync(BACKUP_DIR)) {
+    mkdirSync(BACKUP_DIR, { recursive: true });
+  }
+
+  const date = new Date().toISOString().split('T')[0];
+  const filename = `db-${date}.sqlite`;
+  const filepath = join(BACKUP_DIR, filename);
+
+  try {
+    const db = getDatabase();
+    await db.backup(filepath);
+
+    const size = statSync(filepath).size;
+    const sizeMB = (size / 1024 / 1024).toFixed(2);
+    logger.info('Backup', `Daily backup complete: ${filename} (${sizeMB} MB)`);
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    logger.error('Backup', `Daily backup failed: ${err.message}`, err);
+    return;
+  }
+
+  // Clean up old backups
+  try {
+    const files = readdirSync(BACKUP_DIR)
+      .filter((f) => f.startsWith('db-') && f.endsWith('.sqlite'))
+      .sort()
+      .reverse();
+
+    const toDelete = files.slice(MAX_BACKUPS);
+    for (const file of toDelete) {
+      unlinkSync(join(BACKUP_DIR, file));
+      logger.debug('Backup', `Deleted old backup: ${file}`);
+    }
+
+    if (toDelete.length > 0) {
+      logger.info('Backup', `Cleaned up ${toDelete.length} old backups`);
+    }
+  } catch (error) {
+    logger.warn('Backup', `Failed to clean old backups: ${error}`);
+  }
+}

--- a/src/functions/epgp/calculatePoints.ts
+++ b/src/functions/epgp/calculatePoints.ts
@@ -3,6 +3,7 @@
  */
 
 import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
 import type { RaiderRow, EpgpUploadHistoryRow } from '../../types/index.js';
 
 // ─── Class Mappings ─────────────────────────────────────────
@@ -94,6 +95,7 @@ export function getAllPoints(
     const allowedClasses = TIER_TOKEN_CLASSES[tierToken];
     if (allowedClasses) {
       raiders = raiders.filter((r) => r.class && allowedClasses.includes(r.class));
+      logger.debug('EPGP', `Filtered by tier token "${tierToken}": ${raiders.length} raiders remain`);
     }
   }
 
@@ -102,6 +104,7 @@ export function getAllPoints(
     const allowedClasses = ARMOUR_TYPE_CLASSES[armourType];
     if (allowedClasses) {
       raiders = raiders.filter((r) => r.class && allowedClasses.includes(r.class));
+      logger.debug('EPGP', `Filtered by armour type "${armourType}": ${raiders.length} raiders remain`);
     }
   }
 
@@ -135,6 +138,8 @@ export function getAllPoints(
   // Should we apply decay?
   const applyDecay =
     cutoffDate.getUTCDay() === 3 && lastUploadDate !== null && lastUploadDate > cutoffDate;
+
+  logger.debug('EPGP', `Calculating points for ${raiders.length} raiders (decay=${applyDecay}, cutoff=${cutoffIso})`);
 
   const result: EpgpRaiderPoints[] = [];
 
@@ -174,6 +179,8 @@ export function getAllPoints(
 
   // Sort by priority descending
   result.sort((a, b) => b.priority - a.priority);
+
+  logger.debug('EPGP', `Point calculation complete: ${result.length} raiders with standings`);
 
   return {
     lastUploadedDate,

--- a/src/functions/epgp/createDisplayPost.ts
+++ b/src/functions/epgp/createDisplayPost.ts
@@ -22,6 +22,12 @@ function setEpgpConfig(key: string, value: string): void {
   db.prepare('INSERT OR REPLACE INTO epgp_config (key, value) VALUES (?, ?)').run(key, value);
 }
 
+/** Remove the legacy single body_message_id key if it exists (replaced by body_message_ids JSON array). */
+function cleanupLegacyBodyKey(): void {
+  const db = getDatabase();
+  db.prepare("DELETE FROM epgp_config WHERE key = 'body_message_id'").run();
+}
+
 async function getEpgpChannel(client: Client): Promise<TextChannel | null> {
   const db = getDatabase();
   const channelConfig = db
@@ -63,9 +69,7 @@ export async function createDisplayPost(client: Client): Promise<void> {
   const footerMsg = await channel.send(footer);
   setEpgpConfig('footer_message_id', footerMsg.id);
 
-  // Clean up legacy single body_message_id if it exists
-  const db = getDatabase();
-  db.prepare("DELETE FROM epgp_config WHERE key = 'body_message_id'").run();
+  cleanupLegacyBodyKey();
 
   logger.info('EPGP', `Created EPGP display post (${bodies.length} body message(s)).`);
 }
@@ -138,11 +142,7 @@ export async function updateDisplayPost(client: Client): Promise<void> {
 
   setEpgpConfig('body_message_ids', JSON.stringify(newBodyIds));
 
-  // Clean up legacy key
-  if (legacyBodyMsgId) {
-    const db = getDatabase();
-    db.prepare("DELETE FROM epgp_config WHERE key = 'body_message_id'").run();
-  }
+  if (legacyBodyMsgId) cleanupLegacyBodyKey();
 
   // Update footer
   try {

--- a/src/functions/epgp/createDisplayPost.ts
+++ b/src/functions/epgp/createDisplayPost.ts
@@ -48,17 +48,26 @@ export async function createDisplayPost(client: Client): Promise<void> {
     throw new Error('EPGP channel not configured or not accessible.');
   }
 
-  const [header, body, footer] = generateDisplay();
+  const { header, bodies, footer } = generateDisplay();
 
   const headerMsg = await channel.send(header);
-  const bodyMsg = await channel.send(body);
-  const footerMsg = await channel.send(footer);
-
   setEpgpConfig('header_message_id', headerMsg.id);
-  setEpgpConfig('body_message_id', bodyMsg.id);
+
+  const bodyIds: string[] = [];
+  for (const bodyContent of bodies) {
+    const msg = await channel.send(bodyContent);
+    bodyIds.push(msg.id);
+  }
+  setEpgpConfig('body_message_ids', JSON.stringify(bodyIds));
+
+  const footerMsg = await channel.send(footer);
   setEpgpConfig('footer_message_id', footerMsg.id);
 
-  logger.info('EPGP', 'Created EPGP display post.');
+  // Clean up legacy single body_message_id if it exists
+  const db = getDatabase();
+  db.prepare("DELETE FROM epgp_config WHERE key = 'body_message_id'").run();
+
+  logger.info('EPGP', `Created EPGP display post (${bodies.length} body message(s)).`);
 }
 
 export async function updateDisplayPost(client: Client): Promise<void> {
@@ -68,17 +77,26 @@ export async function updateDisplayPost(client: Client): Promise<void> {
   }
 
   const headerMsgId = getEpgpConfig('header_message_id');
-  const bodyMsgId = getEpgpConfig('body_message_id');
+  const bodyMsgIdsJson = getEpgpConfig('body_message_ids');
+  const legacyBodyMsgId = getEpgpConfig('body_message_id');
   const footerMsgId = getEpgpConfig('footer_message_id');
 
-  if (!headerMsgId || !bodyMsgId || !footerMsgId) {
+  // Migrate from legacy single body_message_id if needed
+  const existingBodyIds: string[] = bodyMsgIdsJson
+    ? JSON.parse(bodyMsgIdsJson) as string[]
+    : legacyBodyMsgId
+      ? [legacyBodyMsgId]
+      : [];
+
+  if (!headerMsgId || existingBodyIds.length === 0 || !footerMsgId) {
     logger.warn('EPGP', 'No existing display post found. Creating new one.');
     await createDisplayPost(client);
     return;
   }
 
-  const [header, body, footer] = generateDisplay();
+  const { header, bodies, footer } = generateDisplay();
 
+  // Update header
   try {
     const headerMsg = await channel.messages.fetch(headerMsgId);
     await headerMsg.edit(header);
@@ -86,13 +104,47 @@ export async function updateDisplayPost(client: Client): Promise<void> {
     logger.warn('EPGP', 'Could not edit header message. It may have been deleted.');
   }
 
-  try {
-    const bodyMsg = await channel.messages.fetch(bodyMsgId);
-    await bodyMsg.edit(body);
-  } catch {
-    logger.warn('EPGP', 'Could not edit body message. It may have been deleted.');
+  // Update body messages: edit existing, add new if needed, delete extras
+  const newBodyIds: string[] = [];
+
+  for (let i = 0; i < bodies.length; i++) {
+    if (i < existingBodyIds.length) {
+      // Edit existing body message
+      try {
+        const msg = await channel.messages.fetch(existingBodyIds[i]);
+        await msg.edit(bodies[i]);
+        newBodyIds.push(existingBodyIds[i]);
+      } catch {
+        // Message deleted - send a new one
+        const msg = await channel.send(bodies[i]);
+        newBodyIds.push(msg.id);
+      }
+    } else {
+      // Need a new body message (content grew)
+      const msg = await channel.send(bodies[i]);
+      newBodyIds.push(msg.id);
+    }
   }
 
+  // Delete extra body messages if content shrunk
+  for (let i = bodies.length; i < existingBodyIds.length; i++) {
+    try {
+      const msg = await channel.messages.fetch(existingBodyIds[i]);
+      await msg.delete();
+    } catch {
+      // Already gone
+    }
+  }
+
+  setEpgpConfig('body_message_ids', JSON.stringify(newBodyIds));
+
+  // Clean up legacy key
+  if (legacyBodyMsgId) {
+    const db = getDatabase();
+    db.prepare("DELETE FROM epgp_config WHERE key = 'body_message_id'").run();
+  }
+
+  // Update footer
   try {
     const footerMsg = await channel.messages.fetch(footerMsgId);
     await footerMsg.edit(footer);
@@ -100,5 +152,5 @@ export async function updateDisplayPost(client: Client): Promise<void> {
     logger.warn('EPGP', 'Could not edit footer message. It may have been deleted.');
   }
 
-  logger.info('EPGP', 'Updated EPGP display post.');
+  logger.info('EPGP', `Updated EPGP display post (${bodies.length} body message(s)).`);
 }

--- a/src/functions/epgp/generateDisplay.ts
+++ b/src/functions/epgp/generateDisplay.ts
@@ -2,6 +2,7 @@
  * Generate the 3-message CSS code block display for EPGP standings.
  */
 
+import { logger } from '../../services/logger.js';
 import { getAllPoints } from './calculatePoints.js';
 
 function pad(str: string, width: number): string {
@@ -20,10 +21,22 @@ function formatDate(isoString: string): string {
   return d.toUTCString();
 }
 
+/** Discord message content limit. */
+const MAX_MESSAGE_CHARS = 2000;
+/** Overhead from code block wrapper: ```css\n ... \n``` */
+const CODE_BLOCK_OVERHEAD = '```css\n'.length + '\n```'.length;
+
+export interface EpgpDisplay {
+  header: string;
+  bodies: string[];
+  footer: string;
+}
+
 export function generateDisplay(
   tierToken?: string | null,
   armourType?: string | null,
-): [string, string, string] {
+): EpgpDisplay {
+  logger.debug('EPGP', `Generating display (tierToken=${tierToken ?? 'none'}, armourType=${armourType ?? 'none'})`);
   const data = getAllPoints(tierToken, armourType);
 
   // ─── Header ─────────────────────────────────────────────
@@ -52,8 +65,27 @@ export function generateDisplay(
     lines.push(`${name} ${pad(epStr, 13)} ${pad(gpStr, 13)} ${prStr}`);
   }
 
-  const bodyContent = lines.length > 0 ? lines.join('\n') : 'No EPGP data available.';
-  const body = '```css\n' + bodyContent + '\n```';
+  // Split body into multiple messages if content exceeds Discord's 2000-char limit
+  const bodies: string[] = [];
+  if (lines.length === 0) {
+    bodies.push('```css\nNo EPGP data available.\n```');
+  } else {
+    const maxContentChars = MAX_MESSAGE_CHARS - CODE_BLOCK_OVERHEAD;
+    let current = '';
+
+    for (const line of lines) {
+      const candidate = current ? current + '\n' + line : line;
+      if (candidate.length > maxContentChars && current) {
+        bodies.push('```css\n' + current + '\n```');
+        current = line;
+      } else {
+        current = candidate;
+      }
+    }
+    if (current) {
+      bodies.push('```css\n' + current + '\n```');
+    }
+  }
 
   // ─── Footer ─────────────────────────────────────────────
   const lastUpload = data.lastUploadedDate ? formatDate(data.lastUploadedDate) : 'Never';
@@ -65,5 +97,6 @@ export function generateDisplay(
     `[Cutoff Date: ${cutoff}]\n` +
     '```';
 
-  return [header, body, footer];
+  logger.debug('EPGP', `Display generated with ${data.raiders.length} raiders across ${bodies.length} body message(s)`);
+  return { header, bodies, footer };
 }

--- a/src/functions/epgp/parseEpgpUpload.ts
+++ b/src/functions/epgp/parseEpgpUpload.ts
@@ -2,6 +2,8 @@
  * Parse EPGP addon JSON upload format into structured data.
  */
 
+import { logger } from '../../services/logger.js';
+
 export interface EpgpRosterEntry {
   characterName: string;
   realm: string;
@@ -51,6 +53,7 @@ function splitNameRealm(nameRealm: string): { characterName: string; realm: stri
 }
 
 export function parseEpgpUpload(jsonString: string): EpgpUploadData {
+  logger.debug('EPGP', 'Parsing EPGP upload data');
   const raw = JSON.parse(jsonString) as RawUpload;
 
   const roster: EpgpRosterEntry[] = (raw.Roster ?? []).map((entry) => {
@@ -73,6 +76,8 @@ export function parseEpgpUpload(jsonString: string): EpgpUploadData {
       gp: entry[3],
     };
   });
+
+  logger.info('EPGP', `Parsed upload for guild "${raw.Guild}": ${roster.length} roster entries, ${loot.length} loot entries, decay=${raw.Decay_p}%`);
 
   return {
     guild: raw.Guild,

--- a/src/functions/epgp/processLoot.ts
+++ b/src/functions/epgp/processLoot.ts
@@ -3,6 +3,7 @@
  */
 
 import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
 import type { RaiderRow } from '../../types/index.js';
 import type { EpgpLootEntry } from './parseEpgpUpload.js';
 
@@ -16,6 +17,7 @@ function extractItemId(itemString: string): string | null {
 }
 
 export function processLoot(lootEntries: EpgpLootEntry[]): { inserted: number; duplicates: number; skipped: number } {
+  logger.debug('EPGP', `Processing ${lootEntries.length} loot entries`);
   const db = getDatabase();
 
   const findRaider = db.prepare(
@@ -39,6 +41,7 @@ export function processLoot(lootEntries: EpgpLootEntry[]): { inserted: number; d
       const raider = findRaider.get(entry.characterName, entry.realm) as RaiderRow | undefined;
 
       if (!raider) {
+        logger.debug('EPGP', `Loot entry skipped: raider not found for ${entry.characterName}-${entry.realm}`);
         skipped++;
         continue;
       }
@@ -60,5 +63,6 @@ export function processLoot(lootEntries: EpgpLootEntry[]): { inserted: number; d
 
   transaction();
 
+  logger.info('EPGP', `Loot processing complete: ${inserted} inserted, ${duplicates} duplicates, ${skipped} skipped`);
   return { inserted, duplicates, skipped };
 }

--- a/src/functions/epgp/processRoster.ts
+++ b/src/functions/epgp/processRoster.ts
@@ -21,6 +21,7 @@ async function fetchCharacterClass(
     const data = (await response.json()) as { class: string };
     return data.class ?? null;
   } catch {
+    logger.debug('EPGP', `Failed to fetch class for ${name}-${realm}`);
     return null;
   }
 }
@@ -91,5 +92,6 @@ export async function processRoster(
     }
   }
 
+  logger.info('EPGP', `Roster processing complete: ${processed} processed, ${skipped} skipped, ${classUpdates.length} class lookups attempted`);
   return { processed, skipped };
 }

--- a/src/functions/guild-info/clearGuildInfo.ts
+++ b/src/functions/guild-info/clearGuildInfo.ts
@@ -63,7 +63,8 @@ export async function clearGuildInfo(client: Client): Promise<void> {
 }
 
 /**
- * Get the guild info channel from config, or create one if it doesn't exist.
+ * Get the guild info channel from config, or find an existing one by name.
+ * Only creates a new channel as a last resort.
  */
 export async function getOrCreateGuildInfoChannel(client: Client): Promise<TextChannel | null> {
   const db = getDatabase();
@@ -73,16 +74,31 @@ export async function getOrCreateGuildInfoChannel(client: Client): Promise<TextC
     const channel = await client.channels.fetch(row.value).catch(() => null);
     const sendable = asSendable(channel);
     if (sendable) return sendable;
-    logger.warn('guild-info', `Configured guild info channel ${row.value} not found, creating new one`);
+    logger.warn('guild-info', `Configured guild info channel ${row.value} not found, searching for existing channel`);
   }
 
-  // Auto-create the channel
   const guild = await client.guilds.fetch(config.guildId).catch(() => null);
   if (!guild) {
-    logger.error('guild-info', 'Could not fetch guild to create guild info channel');
+    logger.error('guild-info', 'Could not fetch guild to resolve guild info channel');
     return null;
   }
 
+  // Search for an existing channel by name before creating a new one
+  const channels = guild.channels.cache;
+  const existing = channels.find(
+    (ch) => (ch.name === 'welcome' || ch.name === 'guild-info') && ch.type === ChannelType.GuildText,
+  );
+
+  if (existing) {
+    db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(
+      'guild_info_channel_id',
+      existing.id,
+    );
+    logger.info('guild-info', `Using existing channel #${existing.name} (${existing.id}) for guild info`);
+    return existing as TextChannel;
+  }
+
+  // Last resort: create a new channel
   try {
     const newChannel = await guild.channels.create({
       name: 'guild-info',

--- a/src/functions/guild-info/updateAchievements.ts
+++ b/src/functions/guild-info/updateAchievements.ts
@@ -161,12 +161,11 @@ function buildManualSections(rows: AchievementsManualRow[]): AchievementSection[
   for (const [expansion, expRows] of grouped) {
     sections.push({
       expansionLabel: getExpansionName(expansion),
-      rows: expRows.map((r) => ({
-        raid: r.raid,
-        progress: r.progress,
-        result: r.result.replace(/\*\*/g, ''),
-        isCE: r.result.includes('CE'),
-      })),
+      rows: expRows.map((r) => {
+        const isCE = r.result.includes('CE');
+        const result = r.result.replace(/\*\*/g, '').replace(/^CE\s*/, '').trim();
+        return { raid: r.raid, progress: r.progress, result, isCE };
+      }).reverse(),
     });
   }
 
@@ -179,38 +178,49 @@ async function fetchApiAchievements(): Promise<AchievementSection[]> {
   const sections: AchievementSection[] = [];
   let expansionId = 6;
 
+  logger.info('Achievements', 'Fetching API achievements starting from expansion 6');
+
   while (true) {
     let staticData;
     try {
       staticData = await getRaidStaticData(expansionId);
     } catch {
-      // 400 or other error means no more expansions
+      logger.debug('Achievements', `No data for expansion ${expansionId}, stopping`);
       break;
     }
 
     const raids = (staticData.raids ?? []) as RaidStaticRaid[];
     if (raids.length === 0) break;
 
-    // Sort raids by end date (ascending) so we process chronologically
+    const expName = getExpansionName(expansionId);
+    logger.info('Achievements', `Processing ${expName}: ${raids.length} raids found`);
+
+    // Sort raids by end date descending (most recent first, ongoing at top)
     const sortedRaids = [...raids].sort((a, b) => {
       const endA = a.ends?.eu ?? a.ends?.us ?? '';
       const endB = b.ends?.eu ?? b.ends?.us ?? '';
       if (!endA && !endB) return 0;
-      if (!endA) return 1;
-      if (!endB) return -1;
-      return endA.localeCompare(endB);
+      if (!endA) return -1; // ongoing raids sort to top
+      if (!endB) return 1;
+      return endB.localeCompare(endA);
     });
 
     const sectionRows: AchievementRow[] = [];
 
     for (const raid of sortedRaids) {
       // Skip Fated/Awakened raids
-      if (raid.name.startsWith('Fated') || raid.name.startsWith('Awakened')) continue;
+      if (raid.name.startsWith('Fated') || raid.name.startsWith('Awakened')) {
+        logger.debug('Achievements', `Skipping ${raid.name} (Fated/Awakened)`);
+        continue;
+      }
 
       try {
         const rankings = await getRaidRankings(raid.slug) as unknown as RaidRankingEntry[];
 
-        if (!rankings || rankings.length === 0) continue;
+        if (!rankings || rankings.length === 0) {
+          logger.debug('Achievements', `No rankings for ${raid.name}`);
+          continue;
+        }
 
         // Use the ranking entry with the most encounters defeated
         // Guard against encountersDefeated being an array (API may return either)
@@ -236,7 +246,9 @@ async function fetchApiAchievements(): Promise<AchievementSection[]> {
 
         const progress = `${killedBosses}/${totalBosses}M`;
         const rank = typeof best.rank === 'number' ? best.rank : 0;
-        const result = isCE ? `CE WR ${rank}` : `WR ${rank}`;
+        const result = rank > 0 ? `WR ${rank}` : '';
+
+        logger.info('Achievements', `  ${raid.name}: ${progress} ${isCE ? 'CE' : ''} ${result}`);
 
         sectionRows.push({
           raid: raid.name,
@@ -245,13 +257,13 @@ async function fetchApiAchievements(): Promise<AchievementSection[]> {
           isCE,
         });
       } catch (error) {
-        logger.debug('guild-info', `Failed to fetch rankings for ${raid.slug}: ${error}`);
+        logger.warn('Achievements', `Failed to fetch rankings for ${raid.name} (${raid.slug}): ${error}`);
       }
     }
 
     if (sectionRows.length > 0) {
       sections.push({
-        expansionLabel: getExpansionName(expansionId),
+        expansionLabel: expName,
         rows: sectionRows,
       });
     }
@@ -259,6 +271,7 @@ async function fetchApiAchievements(): Promise<AchievementSection[]> {
     expansionId++;
   }
 
+  logger.info('Achievements', `Fetched ${sections.length} expansion sections with ${sections.reduce((sum, s) => sum + s.rows.length, 0)} total raids`);
   return sections;
 }
 
@@ -297,18 +310,24 @@ function determineCE(raid: RaidStaticRaid, ranking: RaidRankingEntry): boolean {
 // ─── Image Rendering ────────────────────────────────────────────
 
 function renderAchievementsImage(sections: AchievementSection[], title: string): Buffer {
-  const PADDING = 24;
-  const ROW_HEIGHT = 28;
-  const HEADER_HEIGHT = 44;
-  const SECTION_GAP = 16;
-  const FONT_SIZE = 16;
-  const HEADER_FONT_SIZE = 18;
-  const WIDTH = 1000;
+  const PADDING = 32;
+  const ROW_HEIGHT = 38;
+  const HEADER_HEIGHT = 56;
+  const SECTION_GAP = 20;
+  const FONT_SIZE = 22;
+  const HEADER_FONT_SIZE = 24;
+  const WIDTH = 1400;
 
   // Column positions
   const COL_RAID = PADDING;
-  const COL_PROGRESS = 640;
-  const COL_RESULT = 800;
+  const COL_PROGRESS = 720;
+  const COL_CE = 900;
+  const COL_RESULT = 1060;
+
+  // CE badge dimensions
+  const CE_BADGE_W = 54;
+  const CE_BADGE_H = 26;
+  const CE_BADGE_RADIUS = 5;
 
   // Calculate total height
   let totalRows = 0;
@@ -331,6 +350,7 @@ function renderAchievementsImage(sections: AchievementSection[], title: string):
   ctx.font = `bold ${HEADER_FONT_SIZE}px sans-serif`;
   ctx.fillText('RAID', COL_RAID, PADDING + 20);
   ctx.fillText('PROGRESS', COL_PROGRESS, PADDING + 20);
+  ctx.fillText('CE', COL_CE + 10, PADDING + 20);
   ctx.fillText('WORLD RANK', COL_RESULT, PADDING + 20);
 
   // Header underline
@@ -360,6 +380,24 @@ function renderAchievementsImage(sections: AchievementSection[], title: string):
       ctx.fillText(row.raid, COL_RAID, y);
       ctx.fillText(row.progress, COL_PROGRESS, y);
       ctx.fillText(row.result, COL_RESULT, y);
+
+      // CE badge
+      if (row.isCE) {
+        const badgeX = COL_CE;
+        const badgeY = y - CE_BADGE_H + 4;
+
+        // Rounded rectangle background
+        ctx.beginPath();
+        ctx.roundRect(badgeX, badgeY, CE_BADGE_W, CE_BADGE_H, CE_BADGE_RADIUS);
+        ctx.fillStyle = '#248046';
+        ctx.fill();
+
+        // CE text centered in badge
+        ctx.fillStyle = '#ffffff';
+        ctx.font = `bold 16px sans-serif`;
+        const textWidth = ctx.measureText('CE').width;
+        ctx.fillText('CE', badgeX + (CE_BADGE_W - textWidth) / 2, y - 2);
+      }
 
       y += ROW_HEIGHT;
     }

--- a/src/functions/guild-info/updateAchievements.ts
+++ b/src/functions/guild-info/updateAchievements.ts
@@ -165,7 +165,7 @@ function buildManualSections(rows: AchievementsManualRow[]): AchievementSection[
         const isCE = r.result.includes('CE');
         const result = r.result.replace(/\*\*/g, '').replace(/^CE\s*/, '').trim();
         return { raid: r.raid, progress: r.progress, result, isCE };
-      }).reverse(),
+      }).reverse(), // DB rows are in sort_order (oldest first); display is newest-first within each expansion
     });
   }
 

--- a/src/functions/loot/addLootPost.ts
+++ b/src/functions/loot/addLootPost.ts
@@ -1,5 +1,6 @@
 import type { TextChannel } from 'discord.js';
 import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
 import { generateLootPost } from './generateLootPost.js';
 
 export interface Boss {
@@ -22,4 +23,6 @@ export async function addLootPost(channel: TextChannel, boss: Boss): Promise<voi
   db.prepare(
     'INSERT INTO loot_posts (boss_id, boss_name, boss_url, channel_id, message_id) VALUES (?, ?, ?, ?, ?)',
   ).run(boss.id, boss.name, boss.url ?? null, channel.id, message.id);
+
+  logger.info('Loot', `Created loot post for boss "${boss.name}" (id=${boss.id}) in channel ${channel.id}`);
 }

--- a/src/functions/loot/checkRaidExpansions.ts
+++ b/src/functions/loot/checkRaidExpansions.ts
@@ -84,6 +84,8 @@ export async function checkRaidExpansions(client: Client): Promise<void> {
           });
         }
 
+        logger.info('Loot', `Raid expansion check complete: created ${currentRaid.encounters.length} loot posts for "${currentRaid.name}"`);
+
         // Found and processed the current raid, we're done
         done = true;
       }

--- a/src/functions/loot/deleteLootPost.ts
+++ b/src/functions/loot/deleteLootPost.ts
@@ -29,4 +29,6 @@ export async function deleteLootPost(client: Client, bossId: number): Promise<vo
   // Delete from DB (responses first due to FK, then post)
   db.prepare('DELETE FROM loot_responses WHERE loot_post_id = ?').run(lootPost.id);
   db.prepare('DELETE FROM loot_posts WHERE boss_id = ?').run(bossId);
+
+  logger.info('Loot', `Deleted loot post for boss_id ${bossId} (post_id=${lootPost.id})`);
 }

--- a/src/functions/loot/updateLootPost.ts
+++ b/src/functions/loot/updateLootPost.ts
@@ -63,6 +63,7 @@ export async function updateLootPost(client: Client, bossId: number): Promise<vo
 
     const message = await channel.messages.fetch(lootPost.message_id);
     await message.edit(postData);
+    logger.info('Loot', `Updated loot post for boss_id ${bossId} with ${responses.length} responses`);
   } catch (error) {
     logger.error('Loot', `Failed to update loot post for boss_id ${bossId}`, error as Error);
   }

--- a/src/functions/loot/updateLootResponse.ts
+++ b/src/functions/loot/updateLootResponse.ts
@@ -31,6 +31,8 @@ export async function updateLootResponse(
 
   txn();
 
+  logger.info('Loot', `Recorded ${responseType} response from user ${userId} for boss_id ${bossId}`);
+
   await updateLootPost(client, bossId);
 
   return '';

--- a/src/functions/pagination.ts
+++ b/src/functions/pagination.ts
@@ -1,0 +1,129 @@
+import {
+  EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  type MessageActionRowComponentBuilder,
+} from 'discord.js';
+import { createEmbed } from '../utils.js';
+
+const DEFAULT_MAX_CHARS = 1800;
+
+/**
+ * Split an array of lines into pages that each fit within maxChars.
+ * Returns ['No results.'] for empty input.
+ */
+export function paginateLines(lines: string[], maxChars = DEFAULT_MAX_CHARS): string[] {
+  if (lines.length === 0) return ['No results.'];
+
+  const pages: string[] = [];
+  let current = '';
+
+  for (const line of lines) {
+    const candidate = current ? current + '\n' + line : line;
+    if (candidate.length > maxChars) {
+      if (current) pages.push(current);
+      current = line;
+    } else {
+      current = candidate;
+    }
+  }
+
+  if (current) pages.push(current);
+  return pages;
+}
+
+/**
+ * Build a standard green embed for one page of results.
+ * Adds "Page X/Y" footer text when totalPages > 1.
+ */
+export function buildPageEmbed(
+  title: string,
+  content: string,
+  page: number,
+  totalPages: number,
+): EmbedBuilder {
+  const embed = createEmbed(title).setDescription(content);
+  if (totalPages > 1) {
+    embed.setFooter({ text: `Page ${page}/${totalPages} | SeriouslyCasualBot` });
+  }
+  return embed;
+}
+
+/**
+ * Build Previous/Next navigation buttons for paginated results.
+ * Custom IDs follow the pattern: page:{commandName}:{targetPage}:{totalPages}
+ * Returns null when totalPages <= 1 (no navigation needed).
+ */
+export function buildPageButtons(
+  commandName: string,
+  currentPage: number,
+  totalPages: number,
+): ActionRowBuilder<MessageActionRowComponentBuilder> | null {
+  if (totalPages <= 1) return null;
+
+  const prevPage = currentPage - 1;
+  const nextPage = currentPage + 1;
+
+  const prevButton = new ButtonBuilder()
+    .setCustomId(`page:${commandName}:${prevPage}:${totalPages}`)
+    .setLabel('Previous')
+    .setStyle(ButtonStyle.Secondary)
+    .setDisabled(currentPage <= 1);
+
+  const nextButton = new ButtonBuilder()
+    .setCustomId(`page:${commandName}:${nextPage}:${totalPages}`)
+    .setLabel('Next')
+    .setStyle(ButtonStyle.Secondary)
+    .setDisabled(currentPage >= totalPages);
+
+  return new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
+    prevButton,
+    nextButton,
+  );
+}
+
+/** Shape of a cached pagination entry. */
+interface CacheEntry {
+  title: string;
+  pages: string[];
+  expiresAt: number;
+}
+
+const paginationCache = new Map<string, CacheEntry>();
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Store paginated data in the in-memory cache with a 5-minute TTL.
+ */
+export function cachePaginatedData(key: string, title: string, pages: string[]): void {
+  paginationCache.set(key, {
+    title,
+    pages,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  });
+}
+
+/**
+ * Retrieve a page from the cache.
+ * Returns null if the entry has expired, the key does not exist, or the page is out of range.
+ * Pages are 1-indexed.
+ */
+export function getCachedPage(
+  key: string,
+  page: number,
+): { title: string; content: string; totalPages: number } | null {
+  const entry = paginationCache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    paginationCache.delete(key);
+    return null;
+  }
+  const index = page - 1;
+  if (index < 0 || index >= entry.pages.length) return null;
+  return {
+    title: entry.title,
+    content: entry.pages[index],
+    totalPages: entry.pages.length,
+  };
+}

--- a/src/functions/pagination.ts
+++ b/src/functions/pagination.ts
@@ -1,11 +1,11 @@
 import {
   EmbedBuilder,
+  Colors,
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
   type MessageActionRowComponentBuilder,
 } from 'discord.js';
-import { createEmbed } from '../utils.js';
 
 const DEFAULT_MAX_CHARS = 1800;
 
@@ -43,7 +43,12 @@ export function buildPageEmbed(
   page: number,
   totalPages: number,
 ): EmbedBuilder {
-  const embed = createEmbed(title).setDescription(content);
+  const embed = new EmbedBuilder()
+    .setColor(Colors.Green)
+    .setTimestamp()
+    .setFooter({ text: 'SeriouslyCasualBot' })
+    .setTitle(title)
+    .setDescription(content);
   if (totalPages > 1) {
     embed.setFooter({ text: `Page ${page}/${totalPages} | SeriouslyCasualBot` });
   }

--- a/src/functions/pagination.ts
+++ b/src/functions/pagination.ts
@@ -11,7 +11,10 @@ const DEFAULT_MAX_CHARS = 1800;
 
 /**
  * Split an array of lines into pages that each fit within maxChars.
- * Returns ['No results.'] for empty input.
+ *
+ * Empty input returns `['No results.']` as a single-page fallback so callers
+ * don't need to special-case the empty state when building embeds. Callers
+ * that want different empty-state handling should check `lines.length` first.
  */
 export function paginateLines(lines: string[], maxChars = DEFAULT_MAX_CHARS): string[] {
   if (lines.length === 0) return ['No results.'];
@@ -97,11 +100,33 @@ interface CacheEntry {
 
 const paginationCache = new Map<string, CacheEntry>();
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_CACHE_SIZE = 100;
+
+/** Remove expired entries. Called on each write to prevent unbounded growth. */
+function sweepExpired(): void {
+  const now = Date.now();
+  for (const [k, v] of paginationCache) {
+    if (now > v.expiresAt) paginationCache.delete(k);
+  }
+}
 
 /**
  * Store paginated data in the in-memory cache with a 5-minute TTL.
+ * Evicts expired entries on every write; hard-caps at 100 entries.
  */
 export function cachePaginatedData(key: string, title: string, pages: string[]): void {
+  sweepExpired();
+
+  // If still over capacity after sweep, drop oldest entries
+  if (paginationCache.size >= MAX_CACHE_SIZE) {
+    const toRemove = paginationCache.size - MAX_CACHE_SIZE + 1;
+    const iter = paginationCache.keys();
+    for (let i = 0; i < toRemove; i++) {
+      const oldest = iter.next().value;
+      if (oldest) paginationCache.delete(oldest);
+    }
+  }
+
   paginationCache.set(key, {
     title,
     pages,

--- a/src/functions/testdata/resetData.ts
+++ b/src/functions/testdata/resetData.ts
@@ -47,6 +47,8 @@ export function resetData(db: Database.Database): void {
 
   tx();
 
-  // Re-seed defaults (seedDatabase checks if data already exists; since we just cleared, it will seed)
+  // Re-seed defaults outside the delete transaction. If seedDatabase throws, the
+  // tables will be empty — acceptable for a dev-only command since /testdata reset
+  // can simply be re-run, but worth knowing if you're debugging a half-seeded state.
   seedDatabase(db);
 }

--- a/src/functions/testdata/resetData.ts
+++ b/src/functions/testdata/resetData.ts
@@ -1,0 +1,52 @@
+import type Database from 'better-sqlite3';
+import { seedDatabase } from '../../database/seed.js';
+
+/**
+ * Wipes all data from all tables in correct FK order (children before parents),
+ * then re-seeds defaults via seedDatabase().
+ */
+export function resetData(db: Database.Database): void {
+  const tx = db.transaction(() => {
+    // Children first to satisfy FK constraints
+    db.prepare('DELETE FROM application_answers').run();
+    db.prepare('DELETE FROM application_votes').run();
+    db.prepare('DELETE FROM applications').run();
+    db.prepare('DELETE FROM application_questions').run();
+
+    db.prepare('DELETE FROM trial_alerts').run();
+    db.prepare('DELETE FROM promote_alerts').run();
+    db.prepare('DELETE FROM trials').run();
+
+    db.prepare('DELETE FROM loot_responses').run();
+    db.prepare('DELETE FROM loot_posts').run();
+
+    db.prepare('DELETE FROM epgp_loot_history').run();
+    db.prepare('DELETE FROM epgp_effort_points').run();
+    db.prepare('DELETE FROM epgp_gear_points').run();
+    db.prepare('DELETE FROM epgp_upload_history').run();
+    db.prepare('DELETE FROM epgp_config').run();
+
+    db.prepare('DELETE FROM raiders').run();
+    db.prepare('DELETE FROM raider_identity_map').run();
+    db.prepare('DELETE FROM overlords').run();
+    db.prepare('DELETE FROM ignored_characters').run();
+
+    db.prepare('DELETE FROM guild_info_messages').run();
+    db.prepare('DELETE FROM guild_info_content').run();
+    db.prepare('DELETE FROM guild_info_links').run();
+
+    db.prepare('DELETE FROM schedule_days').run();
+    db.prepare('DELETE FROM schedule_config').run();
+
+    db.prepare('DELETE FROM achievements_manual').run();
+    db.prepare('DELETE FROM signup_messages').run();
+    db.prepare('DELETE FROM default_messages').run();
+    db.prepare('DELETE FROM settings').run();
+    db.prepare('DELETE FROM config').run();
+  });
+
+  tx();
+
+  // Re-seed defaults (seedDatabase checks if data already exists; since we just cleared, it will seed)
+  seedDatabase(db);
+}

--- a/src/functions/testdata/seedApplication.ts
+++ b/src/functions/testdata/seedApplication.ts
@@ -1,0 +1,65 @@
+import type Database from 'better-sqlite3';
+
+const DEFAULT_QUESTIONS = [
+  { question: 'What is your character name, realm, and class/spec?', sort_order: 1 },
+  { question: 'Tell us about your raiding experience and previous guilds.', sort_order: 2 },
+  { question: 'What logs do you have available? Please provide a WarcraftLogs link.', sort_order: 3 },
+  { question: 'What is your raid availability and can you commit to our schedule?', sort_order: 4 },
+  { question: 'Is there anything else you would like to tell us?', sort_order: 5 },
+];
+
+const MOCK_ANSWERS = [
+  'Testcharacter, Silvermoon-EU, Warrior (Arms)',
+  'I have been raiding since Wrath of the Lich King. Most recently I was in <Eternal Radiance> on Silvermoon where we achieved Cutting Edge in the previous tier.',
+  'https://www.warcraftlogs.com/character/eu/silvermoon/testcharacter — 95th percentile parses across the board.',
+  'Yes, Wednesday and Sunday evenings suit me perfectly. I have no foreseeable schedule conflicts.',
+  'I am a quick learner, bring my own consumables, and always come prepared with boss research done in advance.',
+];
+
+export interface SeedApplicationResult {
+  applicationId: number;
+  questionCount: number;
+}
+
+/**
+ * Seeds 1 mock application with answers and 2 votes.
+ * Inserts 5 default questions if none exist.
+ * Returns the new application ID.
+ */
+export function seedApplication(db: Database.Database): SeedApplicationResult {
+  const tx = db.transaction((): SeedApplicationResult => {
+    // Ensure questions exist
+    const existing = db.prepare('SELECT COUNT(*) as count FROM application_questions').get() as { count: number };
+    if (existing.count === 0) {
+      const insertQ = db.prepare('INSERT INTO application_questions (question, sort_order) VALUES (@question, @sort_order)');
+      for (const q of DEFAULT_QUESTIONS) {
+        insertQ.run(q);
+      }
+    }
+
+    const questions = db.prepare('SELECT id, question, sort_order FROM application_questions ORDER BY sort_order').all() as Array<{ id: number; question: string; sort_order: number }>;
+
+    // Insert application
+    const appResult = db.prepare(`
+      INSERT INTO applications (character_name, applicant_user_id, status, submitted_at, started_at)
+      VALUES (?, ?, 'submitted', datetime('now'), datetime('now', '-10 minutes'))
+    `).run('Testcharacter', 'mock-user-id-001');
+
+    const applicationId = appResult.lastInsertRowid as number;
+
+    // Insert answers (one per question, cycling through mock answers)
+    const insertAnswer = db.prepare('INSERT INTO application_answers (application_id, question_id, answer) VALUES (?, ?, ?)');
+    for (let i = 0; i < questions.length; i++) {
+      const answer = MOCK_ANSWERS[i % MOCK_ANSWERS.length];
+      insertAnswer.run(applicationId, questions[i].id, answer);
+    }
+
+    // Insert 2 votes
+    db.prepare('INSERT INTO application_votes (application_id, user_id, vote_type) VALUES (?, ?, ?)').run(applicationId, 'mock-officer-id-001', 'for');
+    db.prepare('INSERT INTO application_votes (application_id, user_id, vote_type) VALUES (?, ?, ?)').run(applicationId, 'mock-officer-id-002', 'neutral');
+
+    return { applicationId, questionCount: questions.length };
+  });
+
+  return tx();
+}

--- a/src/functions/testdata/seedApplication.ts
+++ b/src/functions/testdata/seedApplication.ts
@@ -1,19 +1,27 @@
 import type Database from 'better-sqlite3';
 
 const DEFAULT_QUESTIONS = [
-  { question: 'What is your character name, realm, and class/spec?', sort_order: 1 },
-  { question: 'Tell us about your raiding experience and previous guilds.', sort_order: 2 },
-  { question: 'What logs do you have available? Please provide a WarcraftLogs link.', sort_order: 3 },
-  { question: 'What is your raid availability and can you commit to our schedule?', sort_order: 4 },
-  { question: 'Is there anything else you would like to tell us?', sort_order: 5 },
+  { question: "What class and (if you're a multi-role class) spec are you applying as?", sort_order: 1 },
+  { question: 'Please link your Raider.IO profile of the character you wish to apply with', sort_order: 2 },
+  { question: 'Tell us about yourself, this should include your age, location and any other aspects about your life that you are willing to share', sort_order: 3 },
+  { question: 'How did you find us and what made you want to apply to SeriouslyCasual? (Include any known SeriouslyCasual members here)', sort_order: 4 },
+  { question: 'What is your current and past experience in raiding at the highest level? This should only address MYTHIC progression obtained whilst the content was current! Please include logs where applicable and available', sort_order: 5 },
+  { question: 'We aim to achieve Cutting Edge in every raid tier. If you have not done this before, please include anything here that showcases your in game ability to a similar level (e.g. mythic plus logs, PvP achievements, notable heroic logs or any other challenging content)', sort_order: 6 },
+  { question: 'Could you commit to both a Wednesday and Sunday raid each week, and is there anything that might interfere with our raid schedule?', sort_order: 7 },
+  { question: "Do you have an offspec or any other classes you'd be able to play and willing to raid as? If so please provide logs (Mythic logs preferred)", sort_order: 8 },
+  { question: 'Would you like to include any further information to support your application? This is the final question after which you can submit all answers provided.', sort_order: 9 },
 ];
 
 const MOCK_ANSWERS = [
-  'Testcharacter, Silvermoon-EU, Warrior (Arms)',
-  'I have been raiding since Wrath of the Lich King. Most recently I was in <Eternal Radiance> on Silvermoon where we achieved Cutting Edge in the previous tier.',
-  'https://www.warcraftlogs.com/character/eu/silvermoon/testcharacter — 95th percentile parses across the board.',
-  'Yes, Wednesday and Sunday evenings suit me perfectly. I have no foreseeable schedule conflicts.',
-  'I am a quick learner, bring my own consumables, and always come prepared with boss research done in advance.',
+  'Warrior (Arms)',
+  'https://raider.io/characters/eu/silvermoon/testcharacter',
+  "I'm 28, based in the UK, work in software, and enjoy hiking on weekends.",
+  "Found you via Raider.IO recruitment listings. A friend who used to raid with you (Someguy) spoke highly of the guild's atmosphere.",
+  'Cutting Edge Mythic Queen Ansurek (Nerub-ar Palace), 6/8M Aberrus while current. Logs: https://www.warcraftlogs.com/character/eu/silvermoon/testcharacter',
+  "I've pushed 3.2k+ M+ rating this season and have heroic logs sitting at 90th+ percentile on most bosses.",
+  'Yes, both evenings work reliably. No known conflicts with the raid schedule.',
+  'I can swap to Protection for off-tank duties and have a geared resto druid alt (mythic logs available on request).',
+  "Thanks for considering my application — I'm keen to contribute and learn from the team.",
 ];
 
 export interface SeedApplicationResult {

--- a/src/functions/testdata/seedEpgp.ts
+++ b/src/functions/testdata/seedEpgp.ts
@@ -38,7 +38,8 @@ export function seedEpgp(db: Database.Database): SeedEpgpResult {
     let gpCount = 0;
 
     // 3 EP entries per raider, one per week going back
-    for (const raider of raiders) {
+    for (let idx = 0; idx < raiders.length; idx++) {
+      const raider = raiders[idx];
       for (let week = 0; week < 3; week++) {
         const weeksAgo = week + 1;
         const ts = new Date();
@@ -49,7 +50,6 @@ export function seedEpgp(db: Database.Database): SeedEpgpResult {
       }
 
       // GP entries for first half of raiders only (simulates varied loot history)
-      const idx = raiders.indexOf(raider);
       if (idx < Math.ceil(raiders.length / 2)) {
         const ts = new Date();
         ts.setUTCDate(ts.getUTCDate() - 14);

--- a/src/functions/testdata/seedEpgp.ts
+++ b/src/functions/testdata/seedEpgp.ts
@@ -1,0 +1,90 @@
+import type Database from 'better-sqlite3';
+
+export interface SeedEpgpResult {
+  raiderCount: number;
+  effortPointsInserted: number;
+  gearPointsInserted: number;
+  lootHistoryInserted: number;
+  uploadHistoryInserted: number;
+}
+
+const MOCK_ITEMS = [
+  { item_id: '212001', item_string: 'item:212001::::::::80::::', gear_points: 150 },
+  { item_id: '212002', item_string: 'item:212002::::::::80::::', gear_points: 200 },
+  { item_id: '212003', item_string: 'item:212003::::::::80::::', gear_points: 100 },
+  { item_id: '212004', item_string: 'item:212004::::::::80::::', gear_points: 175 },
+  { item_id: '212005', item_string: 'item:212005::::::::80::::', gear_points: 225 },
+];
+
+/**
+ * Seeds EPGP data for existing raiders.
+ * Throws if no raiders are found (run seed_raiders first).
+ * Inserts 3 EP entries per raider (over 3 weeks), GP for a subset, and
+ * 5 loot history entries spread across raiders.
+ */
+export function seedEpgp(db: Database.Database): SeedEpgpResult {
+  const raiders = db.prepare('SELECT id, character_name FROM raiders').all() as Array<{ id: number; character_name: string }>;
+
+  if (raiders.length === 0) {
+    throw new Error('No raiders found. Run seed_raiders first.');
+  }
+
+  const tx = db.transaction((): SeedEpgpResult => {
+    const insertEP = db.prepare('INSERT INTO epgp_effort_points (raider_id, points, timestamp) VALUES (?, ?, ?)');
+    const insertGP = db.prepare('INSERT INTO epgp_gear_points (raider_id, points, timestamp) VALUES (?, ?, ?)');
+    const insertLoot = db.prepare('INSERT INTO epgp_loot_history (raider_id, item_id, item_string, gear_points, looted_at) VALUES (?, ?, ?, ?, ?)');
+
+    let epCount = 0;
+    let gpCount = 0;
+
+    // 3 EP entries per raider, one per week going back
+    for (const raider of raiders) {
+      for (let week = 0; week < 3; week++) {
+        const weeksAgo = week + 1;
+        const ts = new Date();
+        ts.setUTCDate(ts.getUTCDate() - weeksAgo * 7);
+        const timestamp = ts.toISOString().replace('T', ' ').slice(0, 19);
+        insertEP.run(raider.id, 100 + (week * 25), timestamp);
+        epCount++;
+      }
+
+      // GP entries for first half of raiders only (simulates varied loot history)
+      const idx = raiders.indexOf(raider);
+      if (idx < Math.ceil(raiders.length / 2)) {
+        const ts = new Date();
+        ts.setUTCDate(ts.getUTCDate() - 14);
+        const timestamp = ts.toISOString().replace('T', ' ').slice(0, 19);
+        insertGP.run(raider.id, 150 + (idx * 10), timestamp);
+        gpCount++;
+      }
+    }
+
+    // 5 loot history entries spread across first 5 raiders (or fewer if less raiders)
+    let lootCount = 0;
+    const lootRaiders = raiders.slice(0, 5);
+    for (let i = 0; i < lootRaiders.length; i++) {
+      const item = MOCK_ITEMS[i % MOCK_ITEMS.length];
+      const ts = new Date();
+      ts.setUTCDate(ts.getUTCDate() - (i + 1) * 3);
+      const lootedAt = ts.toISOString().replace('T', ' ').slice(0, 19);
+      insertLoot.run(lootRaiders[i].id, item.item_id, item.item_string, item.gear_points, lootedAt);
+      lootCount++;
+    }
+
+    // 1 upload history record
+    db.prepare(`
+      INSERT INTO epgp_upload_history (timestamp, decay_percent, uploaded_content)
+      VALUES (datetime('now', '-7 days'), 10, 'Mock EPGP upload content for testing')
+    `).run();
+
+    return {
+      raiderCount: raiders.length,
+      effortPointsInserted: epCount,
+      gearPointsInserted: gpCount,
+      lootHistoryInserted: lootCount,
+      uploadHistoryInserted: 1,
+    };
+  });
+
+  return tx();
+}

--- a/src/functions/testdata/seedLoot.ts
+++ b/src/functions/testdata/seedLoot.ts
@@ -1,0 +1,51 @@
+import type Database from 'better-sqlite3';
+
+export interface SeedLootResult {
+  postsInserted: number;
+}
+
+const MOCK_LOOT_POSTS = [
+  {
+    boss_id: 99901,
+    boss_name: 'Mock Boss Alpha',
+    boss_url: 'https://www.wowhead.com/npc/99901/mock-boss-alpha',
+    channel_id: 'mock-channel-id',
+    message_id: 'mock-message-id-1',
+  },
+  {
+    boss_id: 99902,
+    boss_name: 'Mock Boss Beta',
+    boss_url: 'https://www.wowhead.com/npc/99902/mock-boss-beta',
+    channel_id: 'mock-channel-id',
+    message_id: 'mock-message-id-2',
+  },
+  {
+    boss_id: 99903,
+    boss_name: 'Mock Boss Gamma',
+    boss_url: null,
+    channel_id: 'mock-channel-id',
+    message_id: 'mock-message-id-3',
+  },
+];
+
+/**
+ * Seeds 3 mock loot_posts with unique boss_ids (99901–99903).
+ * Idempotent: uses INSERT OR IGNORE.
+ */
+export function seedLoot(db: Database.Database): SeedLootResult {
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO loot_posts (boss_id, boss_name, boss_url, channel_id, message_id)
+    VALUES (@boss_id, @boss_name, @boss_url, @channel_id, @message_id)
+  `);
+
+  const insertMany = db.transaction((): SeedLootResult => {
+    let inserted = 0;
+    for (const post of MOCK_LOOT_POSTS) {
+      const result = insert.run(post);
+      if (result.changes > 0) inserted++;
+    }
+    return { postsInserted: inserted };
+  });
+
+  return insertMany();
+}

--- a/src/functions/testdata/seedRaiders.ts
+++ b/src/functions/testdata/seedRaiders.ts
@@ -1,0 +1,46 @@
+import type Database from 'better-sqlite3';
+
+interface MockRaider {
+  character_name: string;
+  realm: string;
+  region: string;
+  rank: number;
+  class: string;
+}
+
+const MOCK_RAIDERS: MockRaider[] = [
+  { character_name: 'Azerothian',    realm: 'silvermoon',    region: 'eu', rank: 1, class: 'Warrior'      },
+  { character_name: 'Brightmane',    realm: 'silvermoon',    region: 'eu', rank: 2, class: 'Paladin'      },
+  { character_name: 'Coldwhisper',   realm: 'silvermoon',    region: 'eu', rank: 3, class: 'Hunter'       },
+  { character_name: 'Duskweaver',    realm: 'argent-dawn',   region: 'eu', rank: 3, class: 'Rogue'        },
+  { character_name: 'Emberstrike',   realm: 'argent-dawn',   region: 'eu', rank: 3, class: 'Priest'       },
+  { character_name: 'Frostmantle',   realm: 'stormscale',    region: 'eu', rank: 3, class: 'Death Knight' },
+  { character_name: 'Galehowl',      realm: 'stormscale',    region: 'eu', rank: 3, class: 'Shaman'       },
+  { character_name: 'Hollowsong',    realm: 'ravencrest',    region: 'eu', rank: 3, class: 'Mage'         },
+  { character_name: 'Ironveil',      realm: 'ravencrest',    region: 'eu', rank: 3, class: 'Warlock'      },
+  { character_name: 'Jadestrike',    realm: 'silvermoon',    region: 'eu', rank: 3, class: 'Monk'         },
+  { character_name: 'Kael\'threx',   realm: 'silvermoon',    region: 'eu', rank: 3, class: 'Druid'        },
+  { character_name: 'Lunéshadow',    realm: 'argent-dawn',   region: 'eu', rank: 3, class: 'Demon Hunter' },
+  { character_name: 'Moonsváler',    realm: 'stormscale',    region: 'eu', rank: 3, class: 'Evoker'       },
+  { character_name: 'Nightshiver',   realm: 'silvermoon',    region: 'eu', rank: 4, class: 'Warrior'      },
+  { character_name: 'Oathbinder',    realm: 'silvermoon',    region: 'eu', rank: 4, class: 'Paladin'      },
+];
+
+/**
+ * Seed the raiders table with 15 mock raiders.
+ * Idempotent: uses INSERT OR IGNORE so re-running is safe.
+ */
+export function seedRaiders(db: Database.Database): void {
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO raiders (character_name, realm, region, rank, class)
+    VALUES (@character_name, @realm, @region, @rank, @class)
+  `);
+
+  const insertMany = db.transaction((raiders: MockRaider[]) => {
+    for (const raider of raiders) {
+      insert.run(raider);
+    }
+  });
+
+  insertMany(MOCK_RAIDERS);
+}

--- a/src/functions/testdata/seedTrial.ts
+++ b/src/functions/testdata/seedTrial.ts
@@ -1,0 +1,47 @@
+import type Database from 'better-sqlite3';
+
+export interface SeedTrialResult {
+  trialId: number;
+  alertCount: number;
+}
+
+/**
+ * Seeds 1 mock trial with start_date 7 days ago and 3 trial alerts:
+ *   - 7-day  (today, alerted=0)
+ *   - 14-day (7 days from now)
+ *   - 28-day (21 days from now)
+ */
+export function seedTrial(db: Database.Database): SeedTrialResult {
+  const tx = db.transaction((): SeedTrialResult => {
+    // start_date is 7 days ago
+    const trialResult = db.prepare(`
+      INSERT INTO trials (character_name, role, start_date, status)
+      VALUES (?, ?, date('now', '-7 days'), 'active')
+    `).run('Testcharacter', 'DPS');
+
+    const trialId = trialResult.lastInsertRowid as number;
+
+    // Compute alert dates in JS to store real date strings
+    const now = new Date();
+    const addDays = (d: Date, days: number): string => {
+      const result = new Date(d);
+      result.setUTCDate(result.getUTCDate() + days);
+      return result.toISOString().slice(0, 10);
+    };
+
+    const insertAlert = db.prepare(`
+      INSERT INTO trial_alerts (trial_id, alert_name, alert_date, alerted) VALUES (?, ?, ?, ?)
+    `);
+
+    // 7-day alert: start + 7 days = today
+    insertAlert.run(trialId, '7-day review',  addDays(now, 0),  0);
+    // 14-day alert: start + 14 days = 7 days from now
+    insertAlert.run(trialId, '14-day review', addDays(now, 7),  0);
+    // 28-day alert: start + 28 days = 21 days from now
+    insertAlert.run(trialId, '28-day review', addDays(now, 21), 0);
+
+    return { trialId, alertCount: 3 };
+  });
+
+  return tx();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,23 +37,34 @@ client.commands = new Collection();
 // ─── Load Commands ───────────────────────────────────────────
 
 const commandsPath = join(__dirname, 'commands');
+let commandFiles: string[];
 try {
-  const commandFiles = readdirSync(commandsPath).filter((f) => f.endsWith('.js') || f.endsWith('.ts'));
+  commandFiles = readdirSync(commandsPath).filter((f) => f.endsWith('.js') || f.endsWith('.ts'));
+} catch {
+  logger.warn('bot', 'No commands directory found');
+  commandFiles = [];
+}
 
-  for (const file of commandFiles) {
+for (const file of commandFiles) {
+  try {
     const filePath = join(commandsPath, file);
     const module = await import(pathToFileURL(filePath).href);
     const command = module.default as Command;
 
-    if (!command?.data || !command?.execute) continue;
+    if (!command?.data || !command?.execute) {
+      logger.warn('bot', `Skipping ${file}: missing data or execute`);
+      continue;
+    }
     if (command.devOnly && config.isProduction) continue;
 
     client.commands.set(command.data.name, command);
-    logger.debug('bot', `Loaded command: ${command.data.name}`);
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    logger.error('bot', `Failed to load command ${file}: ${err.message}`, err);
   }
-} catch {
-  logger.warn('bot', 'No commands directory found');
 }
+
+logger.info('bot', `Loaded ${client.commands.size} commands`);
 
 // ─── Load Events ─────────────────────────────────────────────
 

--- a/src/services/statusTracker.ts
+++ b/src/services/statusTracker.ts
@@ -1,0 +1,15 @@
+interface TaskStatus {
+  lastRun: Date | null;
+  success: boolean;
+  message?: string;
+}
+
+const taskStatuses = new Map<string, TaskStatus>();
+
+export function recordTaskRun(taskName: string, success: boolean, message?: string): void {
+  taskStatuses.set(taskName, { lastRun: new Date(), success, message });
+}
+
+export function getTaskStatus(taskName: string): TaskStatus | undefined {
+  return taskStatuses.get(taskName);
+}

--- a/tests/unit/pagination.test.ts
+++ b/tests/unit/pagination.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { paginateLines, buildPageEmbed, buildPageButtons } from '../../src/functions/pagination.js';
+
+describe('paginateLines', () => {
+  it('returns ["No results."] for empty input', () => {
+    const result = paginateLines([]);
+    expect(result).toEqual(['No results.']);
+  });
+
+  it('returns single page when all lines fit within maxChars', () => {
+    const lines = ['line one', 'line two', 'line three'];
+    const result = paginateLines(lines);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe('line one\nline two\nline three');
+  });
+
+  it('splits into multiple pages when lines exceed maxChars', () => {
+    // Each line is 100 chars, maxChars is 250 - so 2 lines fit per page, 3rd starts new page
+    const longLine = 'A'.repeat(100);
+    const lines = [longLine, longLine, longLine, longLine, longLine];
+    const result = paginateLines(lines, 250);
+    expect(result.length).toBeGreaterThan(1);
+  });
+
+  it('respects custom maxChars parameter', () => {
+    const lines = ['short', 'short', 'short'];
+    // With maxChars=10, only one "short" fits per page (5 chars + newline)
+    const result = paginateLines(lines, 10);
+    expect(result.length).toBeGreaterThan(1);
+  });
+
+  it('each page does not exceed maxChars', () => {
+    const longLine = 'X'.repeat(200);
+    const lines = Array.from({ length: 20 }, () => longLine);
+    const maxChars = 1800;
+    const result = paginateLines(lines, maxChars);
+    for (const page of result) {
+      expect(page.length).toBeLessThanOrEqual(maxChars);
+    }
+  });
+
+  it('puts all lines on one page if total is exactly maxChars', () => {
+    // 3 lines of 5 chars each + 2 newlines = 17 chars total
+    const lines = ['12345', '12345', '12345'];
+    const result = paginateLines(lines, 17);
+    expect(result).toHaveLength(1);
+  });
+
+  it('handles a single line that fits on a page', () => {
+    const result = paginateLines(['hello world']);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe('hello world');
+  });
+});
+
+describe('buildPageEmbed', () => {
+  it('sets the title on the embed', () => {
+    const embed = buildPageEmbed('My Title', 'content here', 1, 1);
+    expect(embed.data.title).toBe('My Title');
+  });
+
+  it('sets the description to the content', () => {
+    const embed = buildPageEmbed('Title', 'page content', 1, 1);
+    expect(embed.data.description).toBe('page content');
+  });
+
+  it('does not add page footer for single-page results', () => {
+    const embed = buildPageEmbed('Title', 'content', 1, 1);
+    // Should have the standard SeriouslyCasualBot footer, not "Page X/Y"
+    expect(embed.data.footer?.text).not.toMatch(/Page \d+\/\d+/);
+  });
+
+  it('adds Page X/Y footer for multi-page results', () => {
+    const embed = buildPageEmbed('Title', 'content', 2, 5);
+    expect(embed.data.footer?.text).toContain('Page 2/5');
+  });
+
+  it('has a green color (Colors.Green = 5763719)', () => {
+    const embed = buildPageEmbed('Title', 'content', 1, 3);
+    expect(embed.data.color).toBe(5763719);
+  });
+
+  it('has a timestamp', () => {
+    const embed = buildPageEmbed('Title', 'content', 1, 1);
+    expect(embed.data.timestamp).toBeDefined();
+  });
+});
+
+describe('buildPageButtons', () => {
+  it('returns null when totalPages is 1', () => {
+    const result = buildPageButtons('raiders', 1, 1);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when totalPages is 0', () => {
+    const result = buildPageButtons('raiders', 1, 0);
+    expect(result).toBeNull();
+  });
+
+  it('returns an action row with 2 buttons for multi-page', () => {
+    const row = buildPageButtons('raiders', 1, 3);
+    expect(row).not.toBeNull();
+    expect(row!.components).toHaveLength(2);
+  });
+
+  it('uses correct custom IDs with page target and total', () => {
+    const row = buildPageButtons('raiders', 2, 5);
+    const [prev, next] = row!.components;
+    expect(prev.data).toMatchObject({ custom_id: 'page:raiders:1:5' });
+    expect(next.data).toMatchObject({ custom_id: 'page:raiders:3:5' });
+  });
+
+  it('disables Previous button on first page', () => {
+    const row = buildPageButtons('mycommand', 1, 3);
+    const [prev] = row!.components;
+    expect(prev.data).toMatchObject({ disabled: true });
+  });
+
+  it('disables Next button on last page', () => {
+    const row = buildPageButtons('mycommand', 3, 3);
+    const [, next] = row!.components;
+    expect(next.data).toMatchObject({ disabled: true });
+  });
+
+  it('enables both buttons on a middle page', () => {
+    const row = buildPageButtons('mycommand', 2, 4);
+    const [prev, next] = row!.components;
+    expect(prev.data).toMatchObject({ disabled: false });
+    expect(next.data).toMatchObject({ disabled: false });
+  });
+
+  it('labels buttons as Previous and Next', () => {
+    const row = buildPageButtons('test', 2, 3);
+    const [prev, next] = row!.components;
+    expect(prev.data).toMatchObject({ label: 'Previous' });
+    expect(next.data).toMatchObject({ label: 'Next' });
+  });
+});

--- a/tests/unit/testdata.test.ts
+++ b/tests/unit/testdata.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { createTables } from '../../src/database/schema.js';
+import { seedDatabase } from '../../src/database/seed.js';
 import { seedRaiders } from '../../src/functions/testdata/seedRaiders.js';
+import { seedApplication } from '../../src/functions/testdata/seedApplication.js';
+import { seedTrial } from '../../src/functions/testdata/seedTrial.js';
+import { seedEpgp } from '../../src/functions/testdata/seedEpgp.js';
+import { seedLoot } from '../../src/functions/testdata/seedLoot.js';
+import { resetData } from '../../src/functions/testdata/resetData.js';
 
 let db: Database.Database;
 
@@ -13,6 +19,8 @@ beforeEach(() => {
 afterEach(() => {
   db.close();
 });
+
+// ─── seedRaiders ─────────────────────────────────────────────────────────────
 
 describe('seedRaiders', () => {
   it('inserts 15 mock raiders into the database', () => {
@@ -83,5 +91,345 @@ describe('seedRaiders', () => {
       expect(typeof row.rank).toBe('number');
       expect(row.class).toBeTruthy();
     }
+  });
+});
+
+// ─── seedApplication ─────────────────────────────────────────────────────────
+
+describe('seedApplication', () => {
+  it('inserts 1 application with status submitted', () => {
+    const result = seedApplication(db);
+
+    const app = db.prepare('SELECT * FROM applications WHERE id = ?').get(result.applicationId) as {
+      status: string;
+      character_name: string;
+    };
+
+    expect(app).toBeDefined();
+    expect(app.status).toBe('submitted');
+    expect(app.character_name).toBe('Testcharacter');
+  });
+
+  it('returns the applicationId and questionCount', () => {
+    const result = seedApplication(db);
+
+    expect(typeof result.applicationId).toBe('number');
+    expect(result.applicationId).toBeGreaterThan(0);
+    expect(result.questionCount).toBeGreaterThan(0);
+  });
+
+  it('inserts default questions when none exist', () => {
+    seedApplication(db);
+
+    const count = (db.prepare('SELECT COUNT(*) as count FROM application_questions').get() as { count: number }).count;
+    expect(count).toBe(5);
+  });
+
+  it('inserts one answer per question', () => {
+    const result = seedApplication(db);
+
+    const answers = db.prepare('SELECT * FROM application_answers WHERE application_id = ?').all(result.applicationId);
+    expect(answers).toHaveLength(result.questionCount);
+  });
+
+  it('inserts 2 votes for the application', () => {
+    const result = seedApplication(db);
+
+    const votes = db.prepare('SELECT * FROM application_votes WHERE application_id = ?').all(result.applicationId) as Array<{
+      vote_type: string;
+    }>;
+
+    expect(votes).toHaveLength(2);
+    const types = votes.map((v) => v.vote_type);
+    expect(types).toContain('for');
+    expect(types).toContain('neutral');
+  });
+
+  it('does not re-insert questions when they already exist', () => {
+    seedApplication(db);
+    seedApplication(db);
+
+    const count = (db.prepare('SELECT COUNT(*) as count FROM application_questions').get() as { count: number }).count;
+    expect(count).toBe(5);
+  });
+
+  it('creates a second application without error when questions already exist', () => {
+    const r1 = seedApplication(db);
+    const r2 = seedApplication(db);
+
+    expect(r2.applicationId).toBeGreaterThan(r1.applicationId);
+  });
+});
+
+// ─── seedTrial ────────────────────────────────────────────────────────────────
+
+describe('seedTrial', () => {
+  it('inserts 1 active trial', () => {
+    const result = seedTrial(db);
+
+    const trial = db.prepare('SELECT * FROM trials WHERE id = ?').get(result.trialId) as {
+      status: string;
+      role: string;
+      character_name: string;
+      start_date: string;
+    };
+
+    expect(trial).toBeDefined();
+    expect(trial.status).toBe('active');
+    expect(trial.role).toBe('DPS');
+    expect(trial.character_name).toBe('Testcharacter');
+  });
+
+  it('returns trialId and alertCount of 3', () => {
+    const result = seedTrial(db);
+
+    expect(typeof result.trialId).toBe('number');
+    expect(result.trialId).toBeGreaterThan(0);
+    expect(result.alertCount).toBe(3);
+  });
+
+  it('inserts 3 trial alerts for the trial', () => {
+    const result = seedTrial(db);
+
+    const alerts = db.prepare('SELECT * FROM trial_alerts WHERE trial_id = ?').all(result.trialId) as Array<{
+      alert_name: string;
+      alert_date: string;
+      alerted: number;
+    }>;
+
+    expect(alerts).toHaveLength(3);
+  });
+
+  it('alert names are 7-day, 14-day, and 28-day review', () => {
+    const result = seedTrial(db);
+
+    const alerts = db.prepare('SELECT alert_name FROM trial_alerts WHERE trial_id = ? ORDER BY alert_date').all(result.trialId) as Array<{ alert_name: string }>;
+    const names = alerts.map((a) => a.alert_name);
+
+    expect(names).toContain('7-day review');
+    expect(names).toContain('14-day review');
+    expect(names).toContain('28-day review');
+  });
+
+  it('all alerts start with alerted = 0', () => {
+    const result = seedTrial(db);
+
+    const alerts = db.prepare('SELECT alerted FROM trial_alerts WHERE trial_id = ?').all(result.trialId) as Array<{ alerted: number }>;
+
+    for (const alert of alerts) {
+      expect(alert.alerted).toBe(0);
+    }
+  });
+
+  it('trial start_date is 7 days ago', () => {
+    const result = seedTrial(db);
+
+    const trial = db.prepare('SELECT start_date FROM trials WHERE id = ?').get(result.trialId) as { start_date: string };
+
+    const startDate = new Date(trial.start_date);
+    const expected = new Date();
+    expected.setUTCDate(expected.getUTCDate() - 7);
+
+    // Allow 1 day of tolerance
+    const diffDays = Math.abs((expected.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
+    expect(diffDays).toBeLessThan(1.5);
+  });
+
+  it('14-day and 28-day alerts are in the future', () => {
+    const result = seedTrial(db);
+
+    const alerts = db.prepare('SELECT alert_name, alert_date FROM trial_alerts WHERE trial_id = ?').all(result.trialId) as Array<{
+      alert_name: string;
+      alert_date: string;
+    }>;
+
+    const today = new Date().toISOString().slice(0, 10);
+    const futureAlerts = alerts.filter((a) => a.alert_name !== '7-day review');
+
+    for (const alert of futureAlerts) {
+      expect(alert.alert_date > today).toBe(true);
+    }
+  });
+});
+
+// ─── seedEpgp ────────────────────────────────────────────────────────────────
+
+describe('seedEpgp', () => {
+  beforeEach(() => {
+    seedRaiders(db);
+  });
+
+  it('throws if no raiders exist', () => {
+    const emptyDb = new Database(':memory:');
+    createTables(emptyDb);
+    expect(() => seedEpgp(emptyDb)).toThrow('No raiders found');
+    emptyDb.close();
+  });
+
+  it('returns a result object with counts', () => {
+    const result = seedEpgp(db);
+
+    expect(result.raiderCount).toBe(15);
+    expect(result.effortPointsInserted).toBe(45); // 15 raiders × 3 weeks
+    expect(result.gearPointsInserted).toBeGreaterThan(0);
+    expect(result.lootHistoryInserted).toBe(5);
+    expect(result.uploadHistoryInserted).toBe(1);
+  });
+
+  it('inserts 3 EP entries per raider', () => {
+    seedEpgp(db);
+
+    const total = (db.prepare('SELECT COUNT(*) as count FROM epgp_effort_points').get() as { count: number }).count;
+    expect(total).toBe(45);
+  });
+
+  it('inserts GP entries for roughly half the raiders', () => {
+    seedEpgp(db);
+
+    const total = (db.prepare('SELECT COUNT(*) as count FROM epgp_gear_points').get() as { count: number }).count;
+    expect(total).toBeGreaterThan(0);
+    expect(total).toBeLessThanOrEqual(15);
+  });
+
+  it('inserts 5 loot history entries', () => {
+    seedEpgp(db);
+
+    const total = (db.prepare('SELECT COUNT(*) as count FROM epgp_loot_history').get() as { count: number }).count;
+    expect(total).toBe(5);
+  });
+
+  it('inserts 1 upload history record', () => {
+    seedEpgp(db);
+
+    const total = (db.prepare('SELECT COUNT(*) as count FROM epgp_upload_history').get() as { count: number }).count;
+    expect(total).toBe(1);
+  });
+
+  it('loot history entries have valid item_string and gear_points', () => {
+    seedEpgp(db);
+
+    const rows = db.prepare('SELECT item_string, gear_points FROM epgp_loot_history').all() as Array<{
+      item_string: string;
+      gear_points: number;
+    }>;
+
+    for (const row of rows) {
+      expect(row.item_string).toBeTruthy();
+      expect(row.gear_points).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ─── seedLoot ────────────────────────────────────────────────────────────────
+
+describe('seedLoot', () => {
+  it('inserts 3 mock loot posts', () => {
+    const result = seedLoot(db);
+
+    expect(result.postsInserted).toBe(3);
+
+    const rows = db.prepare('SELECT * FROM loot_posts').all();
+    expect(rows).toHaveLength(3);
+  });
+
+  it('uses boss_ids 99901, 99902, 99903', () => {
+    seedLoot(db);
+
+    const rows = db.prepare('SELECT boss_id FROM loot_posts ORDER BY boss_id').all() as Array<{ boss_id: number }>;
+    const ids = rows.map((r) => r.boss_id);
+
+    expect(ids).toEqual([99901, 99902, 99903]);
+  });
+
+  it('all posts have valid boss_name, channel_id, and message_id', () => {
+    seedLoot(db);
+
+    const rows = db.prepare('SELECT * FROM loot_posts').all() as Array<{
+      boss_name: string;
+      channel_id: string;
+      message_id: string;
+    }>;
+
+    for (const row of rows) {
+      expect(row.boss_name).toBeTruthy();
+      expect(row.channel_id).toBe('mock-channel-id');
+      expect(row.message_id).toBeTruthy();
+    }
+  });
+
+  it('third post has null boss_url', () => {
+    seedLoot(db);
+
+    const row = db.prepare('SELECT boss_url FROM loot_posts WHERE boss_id = 99903').get() as { boss_url: string | null };
+    expect(row.boss_url).toBeNull();
+  });
+
+  it('is idempotent — calling twice does not duplicate posts', () => {
+    seedLoot(db);
+    seedLoot(db);
+
+    const rows = db.prepare('SELECT * FROM loot_posts').all();
+    expect(rows).toHaveLength(3);
+  });
+});
+
+// ─── resetData ───────────────────────────────────────────────────────────────
+
+describe('resetData', () => {
+  it('clears all data and re-seeds defaults', () => {
+    // Seed some data first
+    seedDatabase(db);
+    seedRaiders(db);
+    seedApplication(db);
+    seedTrial(db);
+    seedLoot(db);
+
+    // Verify data exists
+    expect((db.prepare('SELECT COUNT(*) as count FROM raiders').get() as { count: number }).count).toBeGreaterThan(0);
+    expect((db.prepare('SELECT COUNT(*) as count FROM loot_posts').get() as { count: number }).count).toBeGreaterThan(0);
+
+    // Reset
+    resetData(db);
+
+    // All user data cleared
+    expect((db.prepare('SELECT COUNT(*) as count FROM raiders').get() as { count: number }).count).toBe(0);
+    expect((db.prepare('SELECT COUNT(*) as count FROM loot_posts').get() as { count: number }).count).toBe(0);
+    expect((db.prepare('SELECT COUNT(*) as count FROM applications').get() as { count: number }).count).toBe(0);
+    expect((db.prepare('SELECT COUNT(*) as count FROM trials').get() as { count: number }).count).toBe(0);
+    expect((db.prepare('SELECT COUNT(*) as count FROM trial_alerts').get() as { count: number }).count).toBe(0);
+  });
+
+  it('re-seeds default guild_info_content after reset', () => {
+    resetData(db);
+
+    const count = (db.prepare('SELECT COUNT(*) as count FROM guild_info_content').get() as { count: number }).count;
+    expect(count).toBeGreaterThan(0);
+  });
+
+  it('re-seeds schedule defaults after reset', () => {
+    resetData(db);
+
+    const days = (db.prepare('SELECT COUNT(*) as count FROM schedule_days').get() as { count: number }).count;
+    expect(days).toBeGreaterThan(0);
+  });
+
+  it('re-seeds default_messages after reset', () => {
+    resetData(db);
+
+    const msgs = (db.prepare('SELECT COUNT(*) as count FROM default_messages').get() as { count: number }).count;
+    expect(msgs).toBeGreaterThan(0);
+  });
+
+  it('can be called on an already-empty database', () => {
+    expect(() => resetData(db)).not.toThrow();
+  });
+
+  it('allows seeding data again after reset', () => {
+    seedRaiders(db);
+    resetData(db);
+    expect(() => seedRaiders(db)).not.toThrow();
+
+    const count = (db.prepare('SELECT COUNT(*) as count FROM raiders').get() as { count: number }).count;
+    expect(count).toBe(15);
   });
 });

--- a/tests/unit/testdata.test.ts
+++ b/tests/unit/testdata.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { createTables } from '../../src/database/schema.js';
+import { seedRaiders } from '../../src/functions/testdata/seedRaiders.js';
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  createTables(db);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe('seedRaiders', () => {
+  it('inserts 15 mock raiders into the database', () => {
+    seedRaiders(db);
+
+    const rows = db.prepare('SELECT * FROM raiders').all() as Array<{
+      character_name: string;
+      realm: string;
+      region: string;
+      rank: number;
+      class: string;
+    }>;
+
+    expect(rows).toHaveLength(15);
+  });
+
+  it('raiders have varied realms', () => {
+    seedRaiders(db);
+
+    const rows = db.prepare('SELECT DISTINCT realm FROM raiders').all() as Array<{ realm: string }>;
+    const realms = rows.map((r) => r.realm);
+
+    expect(realms.length).toBeGreaterThan(1);
+  });
+
+  it('raiders have varied classes', () => {
+    seedRaiders(db);
+
+    const rows = db.prepare('SELECT DISTINCT class FROM raiders').all() as Array<{ class: string }>;
+    const classes = rows.map((r) => r.class);
+
+    expect(classes.length).toBeGreaterThan(1);
+  });
+
+  it('at least one raider has a special character in their name', () => {
+    seedRaiders(db);
+
+    const rows = db.prepare('SELECT character_name FROM raiders').all() as Array<{
+      character_name: string;
+    }>;
+
+    const hasSpecialChar = rows.some((r) => /[àáâãäåæçèéêëìíîïðñòóôõöùúûüýþÿ']/i.test(r.character_name));
+    expect(hasSpecialChar).toBe(true);
+  });
+
+  it('is idempotent — calling twice does not duplicate raiders', () => {
+    seedRaiders(db);
+    seedRaiders(db);
+
+    const rows = db.prepare('SELECT * FROM raiders').all();
+    expect(rows).toHaveLength(15);
+  });
+
+  it('all raiders have valid rank, realm, and region', () => {
+    seedRaiders(db);
+
+    const rows = db.prepare('SELECT * FROM raiders').all() as Array<{
+      character_name: string;
+      realm: string;
+      region: string;
+      rank: number;
+      class: string;
+    }>;
+
+    for (const row of rows) {
+      expect(row.realm).toBeTruthy();
+      expect(row.region).toBeTruthy();
+      expect(typeof row.rank).toBe('number');
+      expect(row.class).toBeTruthy();
+    }
+  });
+});

--- a/tests/unit/testdata.test.ts
+++ b/tests/unit/testdata.test.ts
@@ -122,7 +122,7 @@ describe('seedApplication', () => {
     seedApplication(db);
 
     const count = (db.prepare('SELECT COUNT(*) as count FROM application_questions').get() as { count: number }).count;
-    expect(count).toBe(5);
+    expect(count).toBe(9);
   });
 
   it('inserts one answer per question', () => {
@@ -150,7 +150,7 @@ describe('seedApplication', () => {
     seedApplication(db);
 
     const count = (db.prepare('SELECT COUNT(*) as count FROM application_questions').get() as { count: number }).count;
-    expect(count).toBe(5);
+    expect(count).toBe(9);
   });
 
   it('creates a second application without error when questions already exist', () => {


### PR DESCRIPTION
## Summary
- Daily database backup scheduler (4 AM cron, 7-day retention, auto-cleanup)
- StatusTracker service recording task runs, wired into `/status` with last sync times, DB size, EPGP last upload
- Resume in-progress DM questionnaires on bot restart via `resumeSessions()`
- Application thread keep-alive in `threadUpdate.ts` alongside existing trial thread handling
- Pagination applied to `/applications view_pending` and `/trials get_current_trials`
- EPGP display body splits into multiple Discord messages when exceeding 2000-char limit (stores body message IDs as JSON array in `epgp_config`)
- Various fixes across application, EPGP, loot, and guild-info modules

## Test plan
- [ ] `npm run build` passes cleanly
- [ ] All 189 unit tests pass (`npx vitest run`)
- [ ] `/status` shows new fields (last roster sync, last achievements, DB size, EPGP last upload)
- [ ] `/applications view_pending` paginates when many applications exist
- [ ] `/trials get_current_trials` paginates when many trials exist
- [ ] `/epgp create_post` handles large rosters by splitting body into multiple messages
- [ ] Bot restart resumes in-progress DM questionnaire sessions
- [ ] Application threads are unarchived when auto-archived by Discord
- [ ] Backup file appears in `backups/` directory after 4 AM cron fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)