### PR TITLE
feat(testdata): add Discord-variant seeds, variety, seed_all, reset confirm

### DIFF
--- a/src/commands/testdata.ts
+++ b/src/commands/testdata.ts
@@ -8,10 +8,16 @@ import { requireOfficer } from '../utils.js';
 import { getDatabase } from '../database/db.js';
 import { seedRaiders } from '../functions/testdata/seedRaiders.js';
 import { seedApplication } from '../functions/testdata/seedApplication.js';
+import { seedApplicationVariety } from '../functions/testdata/seedApplicationVariety.js';
 import { seedTrial } from '../functions/testdata/seedTrial.js';
 import { seedEpgp } from '../functions/testdata/seedEpgp.js';
 import { seedLoot } from '../functions/testdata/seedLoot.js';
 import { resetData } from '../functions/testdata/resetData.js';
+import { seedAll } from '../functions/testdata/seedAll.js';
+import { seedRaidersDiscord } from '../functions/testdata/discord/seedRaidersDiscord.js';
+import { seedApplicationDiscord } from '../functions/testdata/discord/seedApplicationDiscord.js';
+import { seedTrialDiscord } from '../functions/testdata/discord/seedTrialDiscord.js';
+import { seedLootDiscord } from '../functions/testdata/discord/seedLootDiscord.js';
 import { logger } from '../services/logger.js';
 
 export default {
@@ -21,70 +27,59 @@ export default {
     .setDescription('Dev-only: seed or reset test data in the database')
     .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
     .addSubcommand((sub) =>
-      sub.setName('seed_raiders').setDescription('Insert 15 mock raiders into the database'),
+      sub
+        .setName('seed_raiders')
+        .setDescription('Insert 15 mock raiders into the database')
+        .addBooleanOption((o) => o.setName('discord').setDescription('Also post linking messages in raider-setup')),
     )
     .addSubcommand((sub) =>
-      sub.setName('seed_application').setDescription('Insert a mock application with answers and votes'),
+      sub
+        .setName('seed_application')
+        .setDescription('Insert a mock application with answers and votes')
+        .addBooleanOption((o) => o.setName('discord').setDescription('Also create a forum post with voting buttons')),
     )
     .addSubcommand((sub) =>
-      sub.setName('seed_trial').setDescription('Insert a mock trial with 3 scheduled alerts'),
+      sub.setName('seed_application_variety').setDescription('Insert 5 applications covering all statuses'),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('seed_trial')
+        .setDescription('Insert a mock trial with 3 scheduled alerts')
+        .addBooleanOption((o) => o.setName('discord').setDescription('Also create a trial-review forum thread')),
     )
     .addSubcommand((sub) =>
       sub.setName('seed_epgp').setDescription('Insert mock EPGP data for existing raiders'),
     )
     .addSubcommand((sub) =>
-      sub.setName('seed_loot').setDescription('Insert 3 mock loot posts'),
+      sub
+        .setName('seed_loot')
+        .setDescription('Insert 3 mock loot posts')
+        .addBooleanOption((o) => o.setName('discord').setDescription('Also post real messages in the configured loot channel')),
     )
     .addSubcommand((sub) =>
-      sub.setName('reset').setDescription('Wipe all test data and re-seed defaults'),
+      sub
+        .setName('seed_all')
+        .setDescription('Run all seeds in order')
+        .addBooleanOption((o) => o.setName('discord').setDescription('Also create Discord artifacts for each seed')),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('reset')
+        .setDescription('Wipe all test data and re-seed defaults')
+        .addBooleanOption((o) => o.setName('confirm').setDescription('Must be true to actually wipe data').setRequired(true)),
     ),
 
   async execute(interaction: ChatInputCommandInteraction): Promise<void> {
-    if (!requireOfficer(interaction)) return;
+    if (!(await requireOfficer(interaction))) return;
 
     const sub = interaction.options.getSubcommand();
     const db = getDatabase();
-
-    const handlers: Record<string, () => string> = {
-      seed_raiders: () => {
-        seedRaiders(db);
-        return 'Seeded 15 mock raiders into the database.';
-      },
-      seed_application: () => {
-        const r = seedApplication(db);
-        return `Seeded 1 mock application (ID: ${r.applicationId}) with ${r.questionCount} answers and 2 votes.`;
-      },
-      seed_trial: () => {
-        const r = seedTrial(db);
-        return `Seeded 1 mock trial (ID: ${r.trialId}) with ${r.alertCount} trial alerts.`;
-      },
-      seed_epgp: () => {
-        const r = seedEpgp(db);
-        return [
-          `Seeded EPGP data for **${r.raiderCount}** raiders:`,
-          `• ${r.effortPointsInserted} effort point entries`,
-          `• ${r.gearPointsInserted} gear point entries`,
-          `• ${r.lootHistoryInserted} loot history entries`,
-          `• ${r.uploadHistoryInserted} upload history record`,
-        ].join('\n');
-      },
-      seed_loot: () => {
-        const r = seedLoot(db);
-        return `Seeded ${r.postsInserted} mock loot posts (boss IDs 99901-99903).`;
-      },
-      reset: () => {
-        resetData(db);
-        return 'All data wiped and defaults re-seeded successfully.';
-      },
-    };
-
-    const handler = handlers[sub];
-    if (!handler) return;
+    const discord = interaction.options.getBoolean('discord') ?? false;
 
     await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
     try {
-      const message = handler();
+      const message = await runSubcommand(sub, db, interaction, discord);
       logger.info('TestData', `${sub}: ${message}`);
       await interaction.editReply({ content: message });
     } catch (err) {
@@ -94,3 +89,107 @@ export default {
     }
   },
 };
+
+async function runSubcommand(
+  sub: string,
+  db: ReturnType<typeof getDatabase>,
+  interaction: ChatInputCommandInteraction,
+  discord: boolean,
+): Promise<string> {
+  switch (sub) {
+    case 'seed_raiders': {
+      if (discord) {
+        const r = await seedRaidersDiscord(interaction.client, db);
+        return formatLines(
+          `Seeded raiders: **${r.raidersSeeded}** total in DB.`,
+          `Linking messages requested: **${r.linkingMessagesRequested}**.`,
+          r.skippedReason ? `_Discord skipped: ${r.skippedReason}_` : null,
+        );
+      }
+      seedRaiders(db);
+      return 'Seeded 15 mock raiders into the database.';
+    }
+    case 'seed_application': {
+      if (discord) {
+        const r = await seedApplicationDiscord(interaction.client, db);
+        return formatLines(
+          `Seeded application **#${r.applicationId}**.`,
+          r.forumPostId ? `Forum post created: \`${r.forumPostId}\` (thread \`${r.threadId}\`).` : null,
+          r.skippedReason ? `_Discord skipped: ${r.skippedReason}_` : null,
+        );
+      }
+      const r = seedApplication(db);
+      return `Seeded 1 mock application (ID: ${r.applicationId}) with ${r.answersInserted} answers and ${r.votesInserted} votes.`;
+    }
+    case 'seed_application_variety': {
+      const r = seedApplicationVariety(db);
+      const byStatus = Object.entries(r.byStatus)
+        .filter(([, count]) => count > 0)
+        .map(([status, count]) => `${status}: ${count}`)
+        .join(', ');
+      return `Seeded ${r.applicationIds.length} applications (${byStatus}).`;
+    }
+    case 'seed_trial': {
+      if (discord) {
+        const r = await seedTrialDiscord(interaction.client);
+        return formatLines(
+          r.trialId ? `Seeded trial **#${r.trialId}** with 3 alerts and forum thread \`${r.threadId}\`.` : 'Trial seeding failed.',
+          r.skippedReason ? `_Discord skipped: ${r.skippedReason}_` : null,
+        );
+      }
+      const r = seedTrial(db);
+      return `Seeded 1 mock trial (ID: ${r.trialId}) with ${r.alertCount} trial alerts.`;
+    }
+    case 'seed_epgp': {
+      const r = seedEpgp(db);
+      return [
+        `Seeded EPGP data for **${r.raiderCount}** raiders:`,
+        `• ${r.effortPointsInserted} effort point entries`,
+        `• ${r.gearPointsInserted} gear point entries`,
+        `• ${r.lootHistoryInserted} loot history entries`,
+        `• ${r.uploadHistoryInserted} upload history record`,
+      ].join('\n');
+    }
+    case 'seed_loot': {
+      if (discord) {
+        const r = await seedLootDiscord(interaction.client, db);
+        return formatLines(
+          `Loot posts created: **${r.postsCreated}** of **${r.postsAttempted}** attempted.`,
+          r.skippedReason ? `_Discord skipped: ${r.skippedReason}_` : null,
+        );
+      }
+      const r = seedLoot(db);
+      return `Seeded ${r.postsInserted} mock loot posts (boss IDs 99901-99903).`;
+    }
+    case 'seed_all': {
+      const r = await seedAll(db, discord ? { client: interaction.client } : {});
+      const lines = [
+        `**seed_all** (${r.discord ? 'with Discord' : 'DB only'}):`,
+        `• Raiders in DB: **${r.raidersSeeded}**`,
+        `• Application: **#${r.applicationId ?? 'n/a'}**`,
+        `• Trial: **#${r.trialId ?? 'n/a'}**`,
+        `• EPGP seeded: ${r.epgpSeeded ? 'yes' : 'no'}`,
+        `• Loot posts created: **${r.lootPostsCreated}**`,
+      ];
+      if (r.skipped.length > 0) {
+        lines.push('', '_Skipped:_');
+        for (const s of r.skipped) lines.push(`• ${s}`);
+      }
+      return lines.join('\n');
+    }
+    case 'reset': {
+      const confirm = interaction.options.getBoolean('confirm', true);
+      if (!confirm) {
+        return 'Pass `confirm:true` to actually wipe data.';
+      }
+      resetData(db);
+      return 'All data wiped and defaults (including application questions) re-seeded.';
+    }
+    default:
+      return `Unknown subcommand: ${sub}`;
+  }
+}
+
+function formatLines(...lines: Array<string | null | undefined>): string {
+  return lines.filter((l): l is string => typeof l === 'string' && l.length > 0).join('\n');
+}

--- a/src/commands/testdata.ts
+++ b/src/commands/testdata.ts
@@ -154,7 +154,8 @@ async function runSubcommand(
       if (discord) {
         const r = await seedLootDiscord(interaction.client, db);
         return formatLines(
-          `Loot posts created: **${r.postsCreated}** of **${r.postsAttempted}** attempted.`,
+          `DB loot_posts inserted: **${r.dbPostsInserted}**.`,
+          `Discord messages posted: **${r.postsCreated}** of **${r.postsAttempted}** attempted.`,
           r.skippedReason ? `_Discord skipped: ${r.skippedReason}_` : null,
         );
       }
@@ -169,7 +170,7 @@ async function runSubcommand(
         `• Application: **#${r.applicationId ?? 'n/a'}**`,
         `• Trial: **#${r.trialId ?? 'n/a'}**`,
         `• EPGP seeded: ${r.epgpSeeded ? 'yes' : 'no'}`,
-        `• Loot posts created: **${r.lootPostsCreated}**`,
+        `• Loot posts in DB: **${r.lootPostsInDb}**` + (r.discord ? `, Discord messages: **${r.lootDiscordMessagesPosted}**` : ''),
       ];
       if (r.skipped.length > 0) {
         lines.push('', '_Skipped:_');

--- a/src/functions/applications/buildQAText.ts
+++ b/src/functions/applications/buildQAText.ts
@@ -1,0 +1,26 @@
+import type { User } from 'discord.js';
+
+export interface AnswerWithQuestion {
+  question: string;
+  answer: string;
+}
+
+/**
+ * Builds the Q&A body posted to the application channel and forum thread.
+ * Shared by submitApplication (real applicant) and the testdata seed.
+ */
+export function buildQAText(
+  answers: AnswerWithQuestion[],
+  user: User,
+  characterName: string,
+): string {
+  let text = `**Application: ${characterName}**\n`;
+  text += `Applicant: ${user} (${user.tag})\n`;
+  text += `Date: ${new Date().toISOString().split('T')[0]}\n\n`;
+
+  for (let i = 0; i < answers.length; i++) {
+    text += `**${i + 1}. ${answers[i].question}**\n${answers[i].answer}\n\n`;
+  }
+
+  return text;
+}

--- a/src/functions/applications/createForumPost.ts
+++ b/src/functions/applications/createForumPost.ts
@@ -1,0 +1,139 @@
+import {
+  type User,
+  type ForumChannel,
+  type Guild,
+  ChannelType,
+  ThreadAutoArchiveDuration,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} from 'discord.js';
+import { getDatabase } from '../../database/db.js';
+import { logger } from '../../services/logger.js';
+import { generateVotingEmbed } from './generateVotingEmbed.js';
+import { splitMessage } from './splitMessage.js';
+
+export interface CreateForumPostResult {
+  forumPost: { id: string } | null;
+  threadId: string | null;
+}
+
+export async function createForumPost(
+  guild: Guild,
+  characterName: string,
+  applicant: User,
+  qaText: string,
+  applicationId: number,
+): Promise<CreateForumPostResult> {
+  const db = getDatabase();
+
+  let forumId = (
+    db.prepare('SELECT value FROM config WHERE key = ?').get('application_log_forum_id') as
+      | { value: string }
+      | undefined
+  )?.value;
+
+  let forum: ForumChannel | null = null;
+
+  if (forumId) {
+    try {
+      const existing = guild.channels.cache.get(forumId) ?? await guild.channels.fetch(forumId).catch(() => null);
+      if (existing && existing.type === ChannelType.GuildForum) {
+        forum = existing as ForumChannel;
+      } else {
+        logger.info('Applications', `Application-log forum ${forumId} no longer exists or is wrong type, creating a new one`);
+      }
+    } catch {
+      logger.info('Applications', `Failed to fetch application-log forum ${forumId}, creating a new one`);
+    }
+  }
+
+  if (!forum) {
+    try {
+      forum = (await guild.channels.create({
+        name: 'application-log',
+        type: ChannelType.GuildForum,
+      })) as ForumChannel;
+      forumId = forum.id;
+      db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(
+        'application_log_forum_id',
+        forumId,
+      );
+      logger.info('Applications', `Created application-log forum: ${forumId}`);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      throw new Error(`Failed to create application-log forum channel (does the bot have Manage Channels permission?): ${error.message}`);
+    }
+  }
+
+  try {
+    const existingTags = forum.availableTags;
+    const requiredTags = ['Active', 'Accepted', 'Rejected'];
+    const missingTags = requiredTags.filter(
+      (tag) => !existingTags.some((t) => t.name === tag),
+    );
+
+    if (missingTags.length > 0) {
+      const newTags = [
+        ...existingTags,
+        ...missingTags.map((name) => ({ name })),
+      ];
+      await forum.setAvailableTags(newTags);
+      const updatedForum = (await forum.fetch()) as ForumChannel;
+      forum = updatedForum;
+    }
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    logger.warn('Applications', `Failed to set forum tags for application-log: ${error.message}`);
+  }
+
+  const activeTag = forum.availableTags.find((t) => t.name === 'Active');
+
+  const messages = splitMessage(qaText);
+
+  const threadName = characterName.substring(0, 100);
+
+  let thread;
+  try {
+    thread = await forum.threads.create({
+      name: threadName,
+      autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
+      message: { content: messages[0] },
+      appliedTags: activeTag ? [activeTag.id] : [],
+    });
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    throw new Error(`Failed to create forum thread for "${threadName}": ${error.message}`);
+  }
+
+  for (let i = 1; i < messages.length; i++) {
+    await thread.send(messages[i]);
+  }
+
+  try {
+    const votingData = generateVotingEmbed(applicationId);
+    await thread.send(votingData);
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    logger.warn('Applications', `Failed to send voting embed for application #${applicationId}: ${error.message}`);
+  }
+
+  try {
+    const decisionRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`application:accept:${applicationId}`)
+        .setLabel('Accept')
+        .setStyle(ButtonStyle.Success),
+      new ButtonBuilder()
+        .setCustomId(`application:reject:${applicationId}`)
+        .setLabel('Reject')
+        .setStyle(ButtonStyle.Danger),
+    );
+    await thread.send({ components: [decisionRow] });
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    logger.warn('Applications', `Failed to send decision buttons for application #${applicationId}: ${error.message}`);
+  }
+
+  return { forumPost: { id: forum.id }, threadId: thread.id };
+}

--- a/src/functions/applications/createForumPost.ts
+++ b/src/functions/applications/createForumPost.ts
@@ -14,8 +14,8 @@ import { generateVotingEmbed } from './generateVotingEmbed.js';
 import { splitMessage } from './splitMessage.js';
 
 export interface CreateForumPostResult {
-  forumPost: { id: string } | null;
-  threadId: string | null;
+  forumPost: { id: string };
+  threadId: string;
 }
 
 export async function createForumPost(
@@ -91,7 +91,8 @@ export async function createForumPost(
 
   const messages = splitMessage(qaText);
 
-  const threadName = characterName.substring(0, 100);
+  // Truncate by code points rather than UTF-16 units so we never slice a surrogate pair.
+  const threadName = Array.from(characterName).slice(0, 100).join('');
 
   let thread;
   try {

--- a/src/functions/applications/splitMessage.ts
+++ b/src/functions/applications/splitMessage.ts
@@ -1,0 +1,21 @@
+export function splitMessage(content: string, maxLength = 2000): string[] {
+  if (content.length <= maxLength) return [content];
+
+  const parts: string[] = [];
+  let remaining = content;
+
+  while (remaining.length > maxLength) {
+    let splitAt = remaining.lastIndexOf('\n', maxLength);
+    if (splitAt === -1 || splitAt < maxLength / 2) {
+      splitAt = maxLength;
+    }
+    parts.push(remaining.substring(0, splitAt));
+    remaining = remaining.substring(splitAt).trimStart();
+  }
+
+  if (remaining.length > 0) {
+    parts.push(remaining);
+  }
+
+  return parts;
+}

--- a/src/functions/applications/submitApplication.ts
+++ b/src/functions/applications/submitApplication.ts
@@ -2,19 +2,15 @@ import {
   type Client,
   type User,
   type TextChannel,
-  type ForumChannel,
   type Guild,
   ChannelType,
   PermissionFlagsBits,
-  ThreadAutoArchiveDuration,
-  ActionRowBuilder,
-  ButtonBuilder,
-  ButtonStyle,
 } from 'discord.js';
 import { getDatabase } from '../../database/db.js';
 import { logger } from '../../services/logger.js';
 import { config } from '../../config.js';
-import { generateVotingEmbed } from './generateVotingEmbed.js';
+import { createForumPost } from './createForumPost.js';
+import { splitMessage } from './splitMessage.js';
 import { getOverlords } from '../raids/overlords.js';
 import type { ApplicationRow } from '../../types/index.js';
 
@@ -241,140 +237,6 @@ async function createApplicationChannel(
   return channel;
 }
 
-// ─── Forum Post Creation ──────────────────────────────────────
-
-async function createForumPost(
-  guild: Guild,
-  characterName: string,
-  applicant: User,
-  qaText: string,
-  applicationId: number,
-): Promise<{ forumPost: { id: string } | null; threadId: string | null }> {
-  const db = getDatabase();
-
-  // Get or create application-log forum
-  let forumId = (
-    db.prepare('SELECT value FROM config WHERE key = ?').get('application_log_forum_id') as
-      | { value: string }
-      | undefined
-  )?.value;
-
-  let forum: ForumChannel | null = null;
-
-  if (forumId) {
-    // Check cache first, then try fetching from API
-    try {
-      const existing = guild.channels.cache.get(forumId) ?? await guild.channels.fetch(forumId).catch(() => null);
-      if (existing && existing.type === ChannelType.GuildForum) {
-        forum = existing as ForumChannel;
-      } else {
-        logger.info('Applications', `Application-log forum ${forumId} no longer exists or is wrong type, creating a new one`);
-      }
-    } catch {
-      logger.info('Applications', `Failed to fetch application-log forum ${forumId}, creating a new one`);
-    }
-  }
-
-  if (!forum) {
-    try {
-      forum = (await guild.channels.create({
-        name: 'application-log',
-        type: ChannelType.GuildForum,
-      })) as ForumChannel;
-      forumId = forum.id;
-      db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(
-        'application_log_forum_id',
-        forumId,
-      );
-      logger.info('Applications', `Created application-log forum: ${forumId}`);
-    } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      throw new Error(`Failed to create application-log forum channel (does the bot have Manage Channels permission?): ${error.message}`);
-    }
-  }
-
-  // Ensure tags exist (Active, Accepted, Rejected)
-  try {
-    const existingTags = forum.availableTags;
-    const requiredTags = ['Active', 'Accepted', 'Rejected'];
-    const missingTags = requiredTags.filter(
-      (tag) => !existingTags.some((t) => t.name === tag),
-    );
-
-    if (missingTags.length > 0) {
-      const newTags = [
-        ...existingTags,
-        ...missingTags.map((name) => ({ name })),
-      ];
-      await forum.setAvailableTags(newTags);
-      // Re-fetch to get the updated tag IDs
-      const updatedForum = (await forum.fetch()) as ForumChannel;
-      forum = updatedForum;
-    }
-  } catch (err) {
-    const error = err instanceof Error ? err : new Error(String(err));
-    logger.warn('Applications', `Failed to set forum tags for application-log: ${error.message}`);
-    // Non-fatal - we can still create the thread without tags
-  }
-
-  // Find Active tag
-  const activeTag = forum.availableTags.find((t) => t.name === 'Active');
-
-  // Split Q&A for the first message
-  const messages = splitMessage(qaText);
-
-  // Truncate thread name to Discord's 100-character limit
-  const threadName = characterName.substring(0, 100);
-
-  // Create the forum thread
-  let thread;
-  try {
-    thread = await forum.threads.create({
-      name: threadName,
-      autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
-      message: { content: messages[0] },
-      appliedTags: activeTag ? [activeTag.id] : [],
-    });
-  } catch (err) {
-    const error = err instanceof Error ? err : new Error(String(err));
-    throw new Error(`Failed to create forum thread for "${threadName}": ${error.message}`);
-  }
-
-  // Send remaining Q&A messages if split
-  for (let i = 1; i < messages.length; i++) {
-    await thread.send(messages[i]);
-  }
-
-  // Voting embed with buttons
-  try {
-    const votingData = generateVotingEmbed(applicationId);
-    await thread.send(votingData);
-  } catch (err) {
-    const error = err instanceof Error ? err : new Error(String(err));
-    logger.warn('Applications', `Failed to send voting embed for application #${applicationId}: ${error.message}`);
-  }
-
-  // Accept/Reject buttons
-  try {
-    const decisionRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setCustomId(`application:accept:${applicationId}`)
-        .setLabel('Accept')
-        .setStyle(ButtonStyle.Success),
-      new ButtonBuilder()
-        .setCustomId(`application:reject:${applicationId}`)
-        .setLabel('Reject')
-        .setStyle(ButtonStyle.Danger),
-    );
-    await thread.send({ components: [decisionRow] });
-  } catch (err) {
-    const error = err instanceof Error ? err : new Error(String(err));
-    logger.warn('Applications', `Failed to send decision buttons for application #${applicationId}: ${error.message}`);
-  }
-
-  return { forumPost: { id: forum.id }, threadId: thread.id };
-}
-
 // ─── Overlord Notification ────────────────────────────────────
 
 async function notifyOverlords(
@@ -409,26 +271,3 @@ async function notifyOverlords(
   );
 }
 
-// ─── Helpers ──────────────────────────────────────────────────
-
-function splitMessage(content: string, maxLength = 2000): string[] {
-  if (content.length <= maxLength) return [content];
-
-  const parts: string[] = [];
-  let remaining = content;
-
-  while (remaining.length > maxLength) {
-    let splitAt = remaining.lastIndexOf('\n', maxLength);
-    if (splitAt === -1 || splitAt < maxLength / 2) {
-      splitAt = maxLength;
-    }
-    parts.push(remaining.substring(0, splitAt));
-    remaining = remaining.substring(splitAt).trimStart();
-  }
-
-  if (remaining.length > 0) {
-    parts.push(remaining);
-  }
-
-  return parts;
-}

--- a/src/functions/applications/submitApplication.ts
+++ b/src/functions/applications/submitApplication.ts
@@ -11,6 +11,7 @@ import { logger } from '../../services/logger.js';
 import { config } from '../../config.js';
 import { createForumPost } from './createForumPost.js';
 import { splitMessage } from './splitMessage.js';
+import { buildQAText } from './buildQAText.js';
 import { getOverlords } from '../raids/overlords.js';
 import type { ApplicationRow } from '../../types/index.js';
 
@@ -123,20 +124,6 @@ export async function submitApplication(
     'Applications',
     `Application #${applicationId} submitted by ${user.tag} (${characterName}) - channel: ${channel.id}`,
   );
-}
-
-// ─── Q&A Text Builder ─────────────────────────────────────────
-
-function buildQAText(answers: AnswerWithQuestion[], user: User, characterName: string): string {
-  let text = `**Application: ${characterName}**\n`;
-  text += `Applicant: ${user} (${user.tag})\n`;
-  text += `Date: ${new Date().toISOString().split('T')[0]}\n\n`;
-
-  for (let i = 0; i < answers.length; i++) {
-    text += `**${i + 1}. ${answers[i].question}**\n${answers[i].answer}\n\n`;
-  }
-
-  return text;
 }
 
 // ─── Channel Creation ─────────────────────────────────────────

--- a/src/functions/testdata/discord/seedApplicationDiscord.ts
+++ b/src/functions/testdata/discord/seedApplicationDiscord.ts
@@ -1,9 +1,10 @@
-import type { Client, User } from 'discord.js';
+import type { Client } from 'discord.js';
 import type Database from 'better-sqlite3';
 import { logger } from '../../../services/logger.js';
 import { config } from '../../../config.js';
 import { seedApplication, type SeedApplicationOptions } from '../seedApplication.js';
 import { createForumPost } from '../../applications/createForumPost.js';
+import { buildQAText, type AnswerWithQuestion } from '../../applications/buildQAText.js';
 
 export interface SeedApplicationDiscordResult {
   applicationId: number;
@@ -12,25 +13,10 @@ export interface SeedApplicationDiscordResult {
   skippedReason?: string;
 }
 
-interface AnswerWithQuestion {
-  question: string;
-  answer: string;
-}
-
-function buildQAText(answers: AnswerWithQuestion[], user: User, characterName: string): string {
-  let text = `**Application: ${characterName}**\n`;
-  text += `Applicant: ${user} (${user.tag})\n`;
-  text += `Date: ${new Date().toISOString().split('T')[0]}\n\n`;
-  for (let i = 0; i < answers.length; i++) {
-    text += `**${i + 1}. ${answers[i].question}**\n${answers[i].answer}\n\n`;
-  }
-  return text;
-}
-
 /**
  * DB-only seedApplication + creates the applications forum post (Active tag + voting buttons + accept/reject buttons).
  * The forum channel is auto-created if not configured.
- * Mock "applicant" is the bot user itself.
+ * Mock "applicant" is the bot user itself (ClientUser is a structural subtype of User).
  */
 export async function seedApplicationDiscord(
   client: Client,
@@ -70,28 +56,26 @@ export async function seedApplicationDiscord(
     )
     .all(seedResult.applicationId) as AnswerWithQuestion[];
 
-  const qaText = buildQAText(answers, client.user as unknown as User, characterName);
+  const qaText = buildQAText(answers, client.user, characterName);
 
   try {
     const { forumPost, threadId } = await createForumPost(
       guild,
       characterName,
-      client.user as unknown as User,
+      client.user,
       qaText,
       seedResult.applicationId,
     );
 
-    if (forumPost) {
-      db.prepare('UPDATE applications SET forum_post_id = ?, thread_id = ? WHERE id = ?').run(
-        forumPost.id,
-        threadId,
-        seedResult.applicationId,
-      );
-    }
+    db.prepare('UPDATE applications SET forum_post_id = ?, thread_id = ? WHERE id = ?').run(
+      forumPost.id,
+      threadId,
+      seedResult.applicationId,
+    );
 
     return {
       applicationId: seedResult.applicationId,
-      forumPostId: forumPost?.id ?? null,
+      forumPostId: forumPost.id,
       threadId,
     };
   } catch (error) {

--- a/src/functions/testdata/discord/seedApplicationDiscord.ts
+++ b/src/functions/testdata/discord/seedApplicationDiscord.ts
@@ -1,0 +1,106 @@
+import type { Client, User } from 'discord.js';
+import type Database from 'better-sqlite3';
+import { logger } from '../../../services/logger.js';
+import { config } from '../../../config.js';
+import { seedApplication, type SeedApplicationOptions } from '../seedApplication.js';
+import { createForumPost } from '../../applications/createForumPost.js';
+
+export interface SeedApplicationDiscordResult {
+  applicationId: number;
+  forumPostId: string | null;
+  threadId: string | null;
+  skippedReason?: string;
+}
+
+interface AnswerWithQuestion {
+  question: string;
+  answer: string;
+}
+
+function buildQAText(answers: AnswerWithQuestion[], user: User, characterName: string): string {
+  let text = `**Application: ${characterName}**\n`;
+  text += `Applicant: ${user} (${user.tag})\n`;
+  text += `Date: ${new Date().toISOString().split('T')[0]}\n\n`;
+  for (let i = 0; i < answers.length; i++) {
+    text += `**${i + 1}. ${answers[i].question}**\n${answers[i].answer}\n\n`;
+  }
+  return text;
+}
+
+/**
+ * DB-only seedApplication + creates the applications forum post (Active tag + voting buttons + accept/reject buttons).
+ * The forum channel is auto-created if not configured.
+ * Mock "applicant" is the bot user itself.
+ */
+export async function seedApplicationDiscord(
+  client: Client,
+  db: Database.Database,
+  options: SeedApplicationOptions = {},
+): Promise<SeedApplicationDiscordResult> {
+  const seedResult = seedApplication(db, options);
+
+  const guild = client.guilds.cache.get(config.guildId);
+  if (!guild) {
+    return {
+      applicationId: seedResult.applicationId,
+      forumPostId: null,
+      threadId: null,
+      skippedReason: 'guild not found in client cache',
+    };
+  }
+
+  if (!client.user) {
+    return {
+      applicationId: seedResult.applicationId,
+      forumPostId: null,
+      threadId: null,
+      skippedReason: 'bot user not available',
+    };
+  }
+
+  const characterName = options.characterName ?? 'Testcharacter';
+
+  const answers = db
+    .prepare(
+      `SELECT aq.question, aa.answer
+       FROM application_answers aa
+       JOIN application_questions aq ON aa.question_id = aq.id
+       WHERE aa.application_id = ?
+       ORDER BY aq.sort_order`,
+    )
+    .all(seedResult.applicationId) as AnswerWithQuestion[];
+
+  const qaText = buildQAText(answers, client.user as unknown as User, characterName);
+
+  try {
+    const { forumPost, threadId } = await createForumPost(
+      guild,
+      characterName,
+      client.user as unknown as User,
+      qaText,
+      seedResult.applicationId,
+    );
+
+    if (forumPost) {
+      db.prepare('UPDATE applications SET forum_post_id = ?, thread_id = ? WHERE id = ?').run(
+        forumPost.id,
+        threadId,
+        seedResult.applicationId,
+      );
+    }
+
+    return {
+      applicationId: seedResult.applicationId,
+      forumPostId: forumPost?.id ?? null,
+      threadId,
+    };
+  } catch (error) {
+    logger.error('TestData', 'Failed to create forum post for seeded application', error as Error);
+    return {
+      applicationId: seedResult.applicationId,
+      forumPostId: null,
+      threadId: null,
+      skippedReason: `forum post failed: ${(error as Error).message}`,
+    };
+  }
+}

--- a/src/functions/testdata/discord/seedLootDiscord.ts
+++ b/src/functions/testdata/discord/seedLootDiscord.ts
@@ -1,0 +1,72 @@
+import type { Client, TextChannel } from 'discord.js';
+import { ChannelType } from 'discord.js';
+import type Database from 'better-sqlite3';
+import { logger } from '../../../services/logger.js';
+import { addLootPost, type Boss } from '../../loot/addLootPost.js';
+
+const MOCK_BOSSES: Boss[] = [
+  { id: 99901, name: 'Mock Boss Alpha', url: 'https://www.wowhead.com/npc/99901/mock-boss-alpha' },
+  { id: 99902, name: 'Mock Boss Beta',  url: 'https://www.wowhead.com/npc/99902/mock-boss-beta' },
+  { id: 99903, name: 'Mock Boss Gamma' },
+];
+
+export interface SeedLootDiscordResult {
+  postsAttempted: number;
+  postsCreated: number;
+  skippedReason?: string;
+}
+
+/**
+ * Posts 3 mock loot-post messages to the configured loot channel. Each call to addLootPost
+ * inserts a row into loot_posts with the real channel_id and message_id. Skips the whole
+ * operation gracefully if loot_channel_id is not configured.
+ */
+export async function seedLootDiscord(
+  client: Client,
+  db: Database.Database,
+): Promise<SeedLootDiscordResult> {
+  const row = db
+    .prepare('SELECT value FROM config WHERE key = ?')
+    .get('loot_channel_id') as { value: string } | undefined;
+
+  if (!row) {
+    return {
+      postsAttempted: 0,
+      postsCreated: 0,
+      skippedReason: 'loot_channel_id not configured — run /setup set_channel key:loot_channel_id first',
+    };
+  }
+
+  let channel: TextChannel;
+  try {
+    const fetched = await client.channels.fetch(row.value);
+    if (!fetched || fetched.type !== ChannelType.GuildText) {
+      return {
+        postsAttempted: 0,
+        postsCreated: 0,
+        skippedReason: 'loot_channel_id points to a non-text channel',
+      };
+    }
+    channel = fetched as TextChannel;
+  } catch (error) {
+    return {
+      postsAttempted: 0,
+      postsCreated: 0,
+      skippedReason: `could not fetch loot channel: ${(error as Error).message}`,
+    };
+  }
+
+  let created = 0;
+  for (const boss of MOCK_BOSSES) {
+    const existing = db.prepare('SELECT id FROM loot_posts WHERE boss_id = ?').get(boss.id);
+    if (existing) continue;
+    try {
+      await addLootPost(channel, boss);
+      created++;
+    } catch (error) {
+      logger.warn('TestData', `Failed to post loot for boss ${boss.id}: ${(error as Error).message}`);
+    }
+  }
+
+  return { postsAttempted: MOCK_BOSSES.length, postsCreated: created };
+}

--- a/src/functions/testdata/discord/seedLootDiscord.ts
+++ b/src/functions/testdata/discord/seedLootDiscord.ts
@@ -2,6 +2,7 @@ import type { Client, TextChannel } from 'discord.js';
 import { ChannelType } from 'discord.js';
 import type Database from 'better-sqlite3';
 import { logger } from '../../../services/logger.js';
+import { seedLoot } from '../seedLoot.js';
 import { addLootPost, type Boss } from '../../loot/addLootPost.js';
 
 const MOCK_BOSSES: Boss[] = [
@@ -11,26 +12,31 @@ const MOCK_BOSSES: Boss[] = [
 ];
 
 export interface SeedLootDiscordResult {
+  dbPostsInserted: number;
   postsAttempted: number;
   postsCreated: number;
   skippedReason?: string;
 }
 
 /**
- * Posts 3 mock loot-post messages to the configured loot channel. Each call to addLootPost
- * inserts a row into loot_posts with the real channel_id and message_id. Skips the whole
- * operation gracefully if loot_channel_id is not configured.
+ * Seeds DB loot_posts rows (via seedLoot), then — if loot_channel_id is configured — also
+ * posts the 3 mock bosses to the channel and updates loot_posts with real channel/message IDs.
+ * If the channel isn't configured or can't be fetched, the DB rows remain (with placeholder
+ * channel/message IDs) and skippedReason is set.
  */
 export async function seedLootDiscord(
   client: Client,
   db: Database.Database,
 ): Promise<SeedLootDiscordResult> {
+  const dbResult = seedLoot(db);
+
   const row = db
     .prepare('SELECT value FROM config WHERE key = ?')
     .get('loot_channel_id') as { value: string } | undefined;
 
   if (!row) {
     return {
+      dbPostsInserted: dbResult.postsInserted,
       postsAttempted: 0,
       postsCreated: 0,
       skippedReason: 'loot_channel_id not configured — run /setup set_channel key:loot_channel_id first',
@@ -42,6 +48,7 @@ export async function seedLootDiscord(
     const fetched = await client.channels.fetch(row.value);
     if (!fetched || fetched.type !== ChannelType.GuildText) {
       return {
+        dbPostsInserted: dbResult.postsInserted,
         postsAttempted: 0,
         postsCreated: 0,
         skippedReason: 'loot_channel_id points to a non-text channel',
@@ -50,16 +57,22 @@ export async function seedLootDiscord(
     channel = fetched as TextChannel;
   } catch (error) {
     return {
+      dbPostsInserted: dbResult.postsInserted,
       postsAttempted: 0,
       postsCreated: 0,
       skippedReason: `could not fetch loot channel: ${(error as Error).message}`,
     };
   }
 
+  // For Discord variant we want real message IDs. Replace the placeholder DB rows that seedLoot
+  // just inserted with real ones by deleting them first, then calling addLootPost per boss.
+  const deleteStmt = db.prepare('DELETE FROM loot_posts WHERE boss_id = ?');
+  for (const boss of MOCK_BOSSES) {
+    deleteStmt.run(boss.id);
+  }
+
   let created = 0;
   for (const boss of MOCK_BOSSES) {
-    const existing = db.prepare('SELECT id FROM loot_posts WHERE boss_id = ?').get(boss.id);
-    if (existing) continue;
     try {
       await addLootPost(channel, boss);
       created++;
@@ -68,5 +81,9 @@ export async function seedLootDiscord(
     }
   }
 
-  return { postsAttempted: MOCK_BOSSES.length, postsCreated: created };
+  return {
+    dbPostsInserted: dbResult.postsInserted,
+    postsAttempted: MOCK_BOSSES.length,
+    postsCreated: created,
+  };
 }

--- a/src/functions/testdata/discord/seedRaidersDiscord.ts
+++ b/src/functions/testdata/discord/seedRaidersDiscord.ts
@@ -1,0 +1,45 @@
+import type { Client } from 'discord.js';
+import type Database from 'better-sqlite3';
+import type { RaiderRow } from '../../../types/index.js';
+import { logger } from '../../../services/logger.js';
+import { seedRaiders } from '../seedRaiders.js';
+import { sendAlertForRaidersWithNoUser } from '../../raids/sendAlertForRaidersWithNoUser.js';
+
+export interface SeedRaidersDiscordResult {
+  raidersSeeded: number;
+  linkingMessagesRequested: number;
+  skippedReason?: string;
+}
+
+/**
+ * DB-only seedRaiders + posts raider-setup linking messages for any unlinked
+ * raiders missing a message_id. The setup channel is auto-created if not configured.
+ */
+export async function seedRaidersDiscord(
+  client: Client,
+  db: Database.Database,
+): Promise<SeedRaidersDiscordResult> {
+  seedRaiders(db);
+
+  const unlinked = db
+    .prepare('SELECT * FROM raiders WHERE discord_user_id IS NULL AND message_id IS NULL')
+    .all() as RaiderRow[];
+
+  const raidersSeeded = (db.prepare('SELECT COUNT(*) as c FROM raiders').get() as { c: number }).c;
+
+  if (unlinked.length === 0) {
+    return { raidersSeeded, linkingMessagesRequested: 0, skippedReason: 'all raiders already linked or have messages' };
+  }
+
+  try {
+    await sendAlertForRaidersWithNoUser(client, unlinked, []);
+    return { raidersSeeded, linkingMessagesRequested: unlinked.length };
+  } catch (error) {
+    logger.error('TestData', 'Failed to send linking messages', error as Error);
+    return {
+      raidersSeeded,
+      linkingMessagesRequested: 0,
+      skippedReason: `linking messages failed: ${(error as Error).message}`,
+    };
+  }
+}

--- a/src/functions/testdata/discord/seedTrialDiscord.ts
+++ b/src/functions/testdata/discord/seedTrialDiscord.ts
@@ -1,0 +1,49 @@
+import type { Client } from 'discord.js';
+import { logger } from '../../../services/logger.js';
+import { createTrialReviewThread } from '../../trial-review/createTrialReviewThread.js';
+
+export interface SeedTrialDiscordOptions {
+  characterName?: string;
+  role?: string;
+  applicationId?: number;
+}
+
+export interface SeedTrialDiscordResult {
+  trialId: number | null;
+  threadId: string | null;
+  skippedReason?: string;
+}
+
+/**
+ * Creates a trial via createTrialReviewThread, which handles DB insert, 3 trial_alerts,
+ * forum thread creation, WarcraftLogs fetch, overlord invites, and alert scheduling.
+ * The trial-reviews forum is auto-created if not configured.
+ */
+export async function seedTrialDiscord(
+  client: Client,
+  options: SeedTrialDiscordOptions = {},
+): Promise<SeedTrialDiscordResult> {
+  const characterName = options.characterName ?? 'Testcharacter';
+  const role = options.role ?? 'DPS';
+
+  const startDate = new Date();
+  startDate.setUTCDate(startDate.getUTCDate() - 7);
+  const startDateStr = startDate.toISOString().slice(0, 10);
+
+  try {
+    const trial = await createTrialReviewThread(client, {
+      characterName,
+      role,
+      startDate: startDateStr,
+      applicationId: options.applicationId,
+    });
+    return { trialId: trial.id, threadId: trial.thread_id ?? null };
+  } catch (error) {
+    logger.error('TestData', 'Failed to create trial review thread', error as Error);
+    return {
+      trialId: null,
+      threadId: null,
+      skippedReason: `trial thread failed: ${(error as Error).message}`,
+    };
+  }
+}

--- a/src/functions/testdata/resetData.ts
+++ b/src/functions/testdata/resetData.ts
@@ -1,9 +1,10 @@
 import type Database from 'better-sqlite3';
 import { seedDatabase } from '../../database/seed.js';
+import { seedApplicationQuestions } from './seedApplicationQuestions.js';
 
 /**
  * Wipes all data from all tables in correct FK order (children before parents),
- * then re-seeds defaults via seedDatabase().
+ * then re-seeds defaults via seedDatabase() and the 9 default application questions.
  */
 export function resetData(db: Database.Database): void {
   const tx = db.transaction(() => {
@@ -51,4 +52,5 @@ export function resetData(db: Database.Database): void {
   // tables will be empty — acceptable for a dev-only command since /testdata reset
   // can simply be re-run, but worth knowing if you're debugging a half-seeded state.
   seedDatabase(db);
+  seedApplicationQuestions(db);
 }

--- a/src/functions/testdata/resetData.ts
+++ b/src/functions/testdata/resetData.ts
@@ -51,6 +51,10 @@ export function resetData(db: Database.Database): void {
   // Re-seed defaults outside the delete transaction. If seedDatabase throws, the
   // tables will be empty — acceptable for a dev-only command since /testdata reset
   // can simply be re-run, but worth knowing if you're debugging a half-seeded state.
+  //
+  // seedApplicationQuestions is idempotent; seedDatabase does not currently own the
+  // 9 default application questions, so we call this explicitly here. If that ever
+  // changes, consolidate into one call site to avoid two sources of truth.
   seedDatabase(db);
   seedApplicationQuestions(db);
 }

--- a/src/functions/testdata/seedAll.ts
+++ b/src/functions/testdata/seedAll.ts
@@ -1,0 +1,97 @@
+import type { Client } from 'discord.js';
+import type Database from 'better-sqlite3';
+import { logger } from '../../services/logger.js';
+import { seedRaiders } from './seedRaiders.js';
+import { seedApplicationQuestions } from './seedApplicationQuestions.js';
+import { seedApplication } from './seedApplication.js';
+import { seedTrial } from './seedTrial.js';
+import { seedEpgp } from './seedEpgp.js';
+import { seedLoot } from './seedLoot.js';
+import { seedRaidersDiscord } from './discord/seedRaidersDiscord.js';
+import { seedApplicationDiscord } from './discord/seedApplicationDiscord.js';
+import { seedTrialDiscord } from './discord/seedTrialDiscord.js';
+import { seedLootDiscord } from './discord/seedLootDiscord.js';
+
+export interface SeedAllOptions {
+  client?: Client;
+}
+
+export interface SeedAllResult {
+  discord: boolean;
+  raidersSeeded: number;
+  applicationId: number | null;
+  trialId: number | null;
+  epgpSeeded: boolean;
+  lootPostsCreated: number;
+  skipped: string[];
+}
+
+/**
+ * Runs all seeds in order. When options.client is provided, each sub-seed uses its
+ * Discord variant; otherwise the DB-only variants are used.
+ * The trial is linked to the seeded application via application_id.
+ */
+export async function seedAll(db: Database.Database, options: SeedAllOptions = {}): Promise<SeedAllResult> {
+  const discord = Boolean(options.client);
+  const skipped: string[] = [];
+
+  let raidersSeeded: number;
+  if (options.client) {
+    const r = await seedRaidersDiscord(options.client, db);
+    raidersSeeded = r.raidersSeeded;
+    if (r.skippedReason) skipped.push(`raiders: ${r.skippedReason}`);
+  } else {
+    seedRaiders(db);
+    raidersSeeded = (db.prepare('SELECT COUNT(*) as c FROM raiders').get() as { c: number }).c;
+  }
+
+  seedApplicationQuestions(db);
+
+  let applicationId: number | null = null;
+  if (options.client) {
+    const r = await seedApplicationDiscord(options.client, db);
+    applicationId = r.applicationId;
+    if (r.skippedReason) skipped.push(`application: ${r.skippedReason}`);
+  } else {
+    const r = seedApplication(db);
+    applicationId = r.applicationId;
+  }
+
+  let trialId: number | null = null;
+  if (options.client) {
+    const r = await seedTrialDiscord(options.client, { applicationId: applicationId ?? undefined });
+    trialId = r.trialId;
+    if (r.skippedReason) skipped.push(`trial: ${r.skippedReason}`);
+  } else {
+    const r = seedTrial(db, { applicationId: applicationId ?? undefined });
+    trialId = r.trialId;
+  }
+
+  try {
+    seedEpgp(db);
+  } catch (error) {
+    skipped.push(`epgp: ${(error as Error).message}`);
+  }
+
+  let lootPostsCreated: number;
+  if (options.client) {
+    const r = await seedLootDiscord(options.client, db);
+    lootPostsCreated = r.postsCreated;
+    if (r.skippedReason) skipped.push(`loot: ${r.skippedReason}`);
+  } else {
+    const r = seedLoot(db);
+    lootPostsCreated = r.postsInserted;
+  }
+
+  logger.info('TestData', `seedAll complete — discord=${discord}, skipped=${skipped.length}`);
+
+  return {
+    discord,
+    raidersSeeded,
+    applicationId,
+    trialId,
+    epgpSeeded: true,
+    lootPostsCreated,
+    skipped,
+  };
+}

--- a/src/functions/testdata/seedAll.ts
+++ b/src/functions/testdata/seedAll.ts
@@ -22,65 +22,93 @@ export interface SeedAllResult {
   applicationId: number | null;
   trialId: number | null;
   epgpSeeded: boolean;
-  lootPostsCreated: number;
+  lootPostsInDb: number;
+  lootDiscordMessagesPosted: number;
   skipped: string[];
 }
 
 /**
- * Runs all seeds in order. When options.client is provided, each sub-seed uses its
- * Discord variant; otherwise the DB-only variants are used.
- * The trial is linked to the seeded application via application_id.
+ * Runs all seeds in order, reporting per-step failures instead of aborting.
+ * When options.client is provided, each sub-seed uses its Discord variant.
+ * The trial is linked to the seeded application via application_id when both exist.
+ *
+ * Error model: fail-soft. Every step is caught individually; failures are recorded
+ * in `skipped`. A failure in one step does not prevent subsequent steps from running.
  */
 export async function seedAll(db: Database.Database, options: SeedAllOptions = {}): Promise<SeedAllResult> {
   const discord = Boolean(options.client);
   const skipped: string[] = [];
 
-  let raidersSeeded: number;
-  if (options.client) {
-    const r = await seedRaidersDiscord(options.client, db);
-    raidersSeeded = r.raidersSeeded;
-    if (r.skippedReason) skipped.push(`raiders: ${r.skippedReason}`);
-  } else {
-    seedRaiders(db);
-    raidersSeeded = (db.prepare('SELECT COUNT(*) as c FROM raiders').get() as { c: number }).c;
-  }
-
-  seedApplicationQuestions(db);
-
-  let applicationId: number | null = null;
-  if (options.client) {
-    const r = await seedApplicationDiscord(options.client, db);
-    applicationId = r.applicationId;
-    if (r.skippedReason) skipped.push(`application: ${r.skippedReason}`);
-  } else {
-    const r = seedApplication(db);
-    applicationId = r.applicationId;
-  }
-
-  let trialId: number | null = null;
-  if (options.client) {
-    const r = await seedTrialDiscord(options.client, { applicationId: applicationId ?? undefined });
-    trialId = r.trialId;
-    if (r.skippedReason) skipped.push(`trial: ${r.skippedReason}`);
-  } else {
-    const r = seedTrial(db, { applicationId: applicationId ?? undefined });
-    trialId = r.trialId;
+  let raidersSeeded = 0;
+  try {
+    if (options.client) {
+      const r = await seedRaidersDiscord(options.client, db);
+      raidersSeeded = r.raidersSeeded;
+      if (r.skippedReason) skipped.push(`raiders: ${r.skippedReason}`);
+    } else {
+      seedRaiders(db);
+      raidersSeeded = (db.prepare('SELECT COUNT(*) as c FROM raiders').get() as { c: number }).c;
+    }
+  } catch (error) {
+    skipped.push(`raiders: ${(error as Error).message}`);
   }
 
   try {
+    seedApplicationQuestions(db);
+  } catch (error) {
+    skipped.push(`application_questions: ${(error as Error).message}`);
+  }
+
+  let applicationId: number | null = null;
+  try {
+    if (options.client) {
+      const r = await seedApplicationDiscord(options.client, db);
+      applicationId = r.applicationId;
+      if (r.skippedReason) skipped.push(`application: ${r.skippedReason}`);
+    } else {
+      const r = seedApplication(db);
+      applicationId = r.applicationId;
+    }
+  } catch (error) {
+    skipped.push(`application: ${(error as Error).message}`);
+  }
+
+  let trialId: number | null = null;
+  try {
+    if (options.client) {
+      const r = await seedTrialDiscord(options.client, { applicationId: applicationId ?? undefined });
+      trialId = r.trialId;
+      if (r.skippedReason) skipped.push(`trial: ${r.skippedReason}`);
+    } else {
+      const r = seedTrial(db, { applicationId: applicationId ?? undefined });
+      trialId = r.trialId;
+    }
+  } catch (error) {
+    skipped.push(`trial: ${(error as Error).message}`);
+  }
+
+  let epgpSeeded = false;
+  try {
     seedEpgp(db);
+    epgpSeeded = true;
   } catch (error) {
     skipped.push(`epgp: ${(error as Error).message}`);
   }
 
-  let lootPostsCreated: number;
-  if (options.client) {
-    const r = await seedLootDiscord(options.client, db);
-    lootPostsCreated = r.postsCreated;
-    if (r.skippedReason) skipped.push(`loot: ${r.skippedReason}`);
-  } else {
-    const r = seedLoot(db);
-    lootPostsCreated = r.postsInserted;
+  let lootPostsInDb = 0;
+  let lootDiscordMessagesPosted = 0;
+  try {
+    if (options.client) {
+      const r = await seedLootDiscord(options.client, db);
+      lootPostsInDb = r.dbPostsInserted;
+      lootDiscordMessagesPosted = r.postsCreated;
+      if (r.skippedReason) skipped.push(`loot: ${r.skippedReason}`);
+    } else {
+      const r = seedLoot(db);
+      lootPostsInDb = r.postsInserted;
+    }
+  } catch (error) {
+    skipped.push(`loot: ${(error as Error).message}`);
   }
 
   logger.info('TestData', `seedAll complete — discord=${discord}, skipped=${skipped.length}`);
@@ -90,8 +118,9 @@ export async function seedAll(db: Database.Database, options: SeedAllOptions = {
     raidersSeeded,
     applicationId,
     trialId,
-    epgpSeeded: true,
-    lootPostsCreated,
+    epgpSeeded,
+    lootPostsInDb,
+    lootDiscordMessagesPosted,
     skipped,
   };
 }

--- a/src/functions/testdata/seedApplication.ts
+++ b/src/functions/testdata/seedApplication.ts
@@ -1,16 +1,5 @@
 import type Database from 'better-sqlite3';
-
-const DEFAULT_QUESTIONS = [
-  { question: "What class and (if you're a multi-role class) spec are you applying as?", sort_order: 1 },
-  { question: 'Please link your Raider.IO profile of the character you wish to apply with', sort_order: 2 },
-  { question: 'Tell us about yourself, this should include your age, location and any other aspects about your life that you are willing to share', sort_order: 3 },
-  { question: 'How did you find us and what made you want to apply to SeriouslyCasual? (Include any known SeriouslyCasual members here)', sort_order: 4 },
-  { question: 'What is your current and past experience in raiding at the highest level? This should only address MYTHIC progression obtained whilst the content was current! Please include logs where applicable and available', sort_order: 5 },
-  { question: 'We aim to achieve Cutting Edge in every raid tier. If you have not done this before, please include anything here that showcases your in game ability to a similar level (e.g. mythic plus logs, PvP achievements, notable heroic logs or any other challenging content)', sort_order: 6 },
-  { question: 'Could you commit to both a Wednesday and Sunday raid each week, and is there anything that might interfere with our raid schedule?', sort_order: 7 },
-  { question: "Do you have an offspec or any other classes you'd be able to play and willing to raid as? If so please provide logs (Mythic logs preferred)", sort_order: 8 },
-  { question: 'Would you like to include any further information to support your application? This is the final question after which you can submit all answers provided.', sort_order: 9 },
-];
+import { seedApplicationQuestions } from './seedApplicationQuestions.js';
 
 const MOCK_ANSWERS = [
   'Warrior (Arms)',
@@ -24,49 +13,75 @@ const MOCK_ANSWERS = [
   "Thanks for considering my application — I'm keen to contribute and learn from the team.",
 ];
 
+export type SeededApplicationStatus = 'in_progress' | 'submitted' | 'accepted' | 'rejected' | 'abandoned';
+
+export interface SeedApplicationOptions {
+  characterName?: string;
+  userId?: string;
+  status?: SeededApplicationStatus;
+  /** Number of answers to insert. Defaults to all questions. */
+  answerCount?: number;
+  /** Whether to insert the 2 mock votes. Defaults to true for `submitted`/`accepted`/`rejected`; false for `in_progress`/`abandoned`. */
+  includeVotes?: boolean;
+}
+
 export interface SeedApplicationResult {
   applicationId: number;
   questionCount: number;
+  answersInserted: number;
+  votesInserted: number;
 }
 
 /**
- * Seeds 1 mock application with answers and 2 votes.
- * Inserts 5 default questions if none exist.
+ * Seeds 1 mock application with answers and (optionally) votes.
+ * Delegates to seedApplicationQuestions to ensure the 9 default questions exist.
  * Returns the new application ID.
  */
-export function seedApplication(db: Database.Database): SeedApplicationResult {
+export function seedApplication(
+  db: Database.Database,
+  options: SeedApplicationOptions = {},
+): SeedApplicationResult {
+  const characterName = options.characterName ?? 'Testcharacter';
+  const userId = options.userId ?? 'mock-user-id-001';
+  const status = options.status ?? 'submitted';
+  const includeVotes = options.includeVotes ?? (status !== 'in_progress' && status !== 'abandoned');
+
   const tx = db.transaction((): SeedApplicationResult => {
-    // Ensure questions exist
-    const existing = db.prepare('SELECT COUNT(*) as count FROM application_questions').get() as { count: number };
-    if (existing.count === 0) {
-      const insertQ = db.prepare('INSERT INTO application_questions (question, sort_order) VALUES (@question, @sort_order)');
-      for (const q of DEFAULT_QUESTIONS) {
-        insertQ.run(q);
-      }
-    }
+    seedApplicationQuestions(db);
 
     const questions = db.prepare('SELECT id, question, sort_order FROM application_questions ORDER BY sort_order').all() as Array<{ id: number; question: string; sort_order: number }>;
 
-    // Insert application
+    const answerCount = Math.min(options.answerCount ?? questions.length, questions.length);
+
+    const submittedAtClause = status === 'in_progress' ? 'NULL' : "datetime('now')";
+    const startedAtClause = "datetime('now', '-10 minutes')";
+
     const appResult = db.prepare(`
       INSERT INTO applications (character_name, applicant_user_id, status, submitted_at, started_at)
-      VALUES (?, ?, 'submitted', datetime('now'), datetime('now', '-10 minutes'))
-    `).run('Testcharacter', 'mock-user-id-001');
+      VALUES (?, ?, ?, ${submittedAtClause}, ${startedAtClause})
+    `).run(characterName, userId, status);
 
     const applicationId = appResult.lastInsertRowid as number;
 
-    // Insert answers (one per question, cycling through mock answers)
     const insertAnswer = db.prepare('INSERT INTO application_answers (application_id, question_id, answer) VALUES (?, ?, ?)');
-    for (let i = 0; i < questions.length; i++) {
+    for (let i = 0; i < answerCount; i++) {
       const answer = MOCK_ANSWERS[i % MOCK_ANSWERS.length];
       insertAnswer.run(applicationId, questions[i].id, answer);
     }
 
-    // Insert 2 votes
-    db.prepare('INSERT INTO application_votes (application_id, user_id, vote_type) VALUES (?, ?, ?)').run(applicationId, 'mock-officer-id-001', 'for');
-    db.prepare('INSERT INTO application_votes (application_id, user_id, vote_type) VALUES (?, ?, ?)').run(applicationId, 'mock-officer-id-002', 'neutral');
+    let votesInserted = 0;
+    if (includeVotes) {
+      db.prepare('INSERT INTO application_votes (application_id, user_id, vote_type) VALUES (?, ?, ?)').run(applicationId, 'mock-officer-id-001', 'for');
+      db.prepare('INSERT INTO application_votes (application_id, user_id, vote_type) VALUES (?, ?, ?)').run(applicationId, 'mock-officer-id-002', 'neutral');
+      votesInserted = 2;
+    }
 
-    return { applicationId, questionCount: questions.length };
+    return {
+      applicationId,
+      questionCount: questions.length,
+      answersInserted: answerCount,
+      votesInserted,
+    };
   });
 
   return tx();

--- a/src/functions/testdata/seedApplicationQuestions.ts
+++ b/src/functions/testdata/seedApplicationQuestions.ts
@@ -1,0 +1,39 @@
+import type Database from 'better-sqlite3';
+
+const DEFAULT_QUESTIONS = [
+  { question: "What class and (if you're a multi-role class) spec are you applying as?", sort_order: 1 },
+  { question: 'Please link your Raider.IO profile of the character you wish to apply with', sort_order: 2 },
+  { question: 'Tell us about yourself, this should include your age, location and any other aspects about your life that you are willing to share', sort_order: 3 },
+  { question: 'How did you find us and what made you want to apply to SeriouslyCasual? (Include any known SeriouslyCasual members here)', sort_order: 4 },
+  { question: 'What is your current and past experience in raiding at the highest level? This should only address MYTHIC progression obtained whilst the content was current! Please include logs where applicable and available', sort_order: 5 },
+  { question: 'We aim to achieve Cutting Edge in every raid tier. If you have not done this before, please include anything here that showcases your in game ability to a similar level (e.g. mythic plus logs, PvP achievements, notable heroic logs or any other challenging content)', sort_order: 6 },
+  { question: 'Could you commit to both a Wednesday and Sunday raid each week, and is there anything that might interfere with our raid schedule?', sort_order: 7 },
+  { question: "Do you have an offspec or any other classes you'd be able to play and willing to raid as? If so please provide logs (Mythic logs preferred)", sort_order: 8 },
+  { question: 'Would you like to include any further information to support your application? This is the final question after which you can submit all answers provided.', sort_order: 9 },
+];
+
+export interface SeedApplicationQuestionsResult {
+  inserted: number;
+}
+
+/**
+ * Ensures the 9 default application questions exist. Idempotent: only inserts when the table is empty.
+ */
+export function seedApplicationQuestions(db: Database.Database): SeedApplicationQuestionsResult {
+  const existing = db.prepare('SELECT COUNT(*) as count FROM application_questions').get() as { count: number };
+  if (existing.count > 0) {
+    return { inserted: 0 };
+  }
+
+  const insertQ = db.prepare('INSERT INTO application_questions (question, sort_order) VALUES (@question, @sort_order)');
+  const tx = db.transaction((): number => {
+    for (const q of DEFAULT_QUESTIONS) {
+      insertQ.run(q);
+    }
+    return DEFAULT_QUESTIONS.length;
+  });
+
+  return { inserted: tx() };
+}
+
+export { DEFAULT_QUESTIONS };

--- a/src/functions/testdata/seedApplicationVariety.ts
+++ b/src/functions/testdata/seedApplicationVariety.ts
@@ -1,0 +1,50 @@
+import type Database from 'better-sqlite3';
+import { seedApplication, type SeededApplicationStatus } from './seedApplication.js';
+
+export interface SeedApplicationVarietyResult {
+  applicationIds: number[];
+  byStatus: Record<SeededApplicationStatus, number>;
+}
+
+interface VarietySpec {
+  status: SeededApplicationStatus;
+  characterName: string;
+  userId: string;
+  answerCount?: number;
+}
+
+const VARIETY: VarietySpec[] = [
+  { status: 'in_progress', characterName: 'InProgressChar', userId: 'mock-applicant-inprogress', answerCount: 3 },
+  { status: 'submitted',   characterName: 'SubmittedChar',  userId: 'mock-applicant-submitted' },
+  { status: 'accepted',    characterName: 'AcceptedChar',   userId: 'mock-applicant-accepted' },
+  { status: 'rejected',    characterName: 'RejectedChar',   userId: 'mock-applicant-rejected' },
+  { status: 'abandoned',   characterName: 'AbandonedChar',  userId: 'mock-applicant-abandoned' },
+];
+
+/**
+ * Seeds 5 applications — one per status (in_progress, submitted, accepted, rejected, abandoned).
+ * Useful for testing /applications view_pending, accept/reject flows, and DM resume.
+ */
+export function seedApplicationVariety(db: Database.Database): SeedApplicationVarietyResult {
+  const applicationIds: number[] = [];
+  const byStatus = {
+    in_progress: 0,
+    submitted: 0,
+    accepted: 0,
+    rejected: 0,
+    abandoned: 0,
+  } as Record<SeededApplicationStatus, number>;
+
+  for (const spec of VARIETY) {
+    const result = seedApplication(db, {
+      characterName: spec.characterName,
+      userId: spec.userId,
+      status: spec.status,
+      answerCount: spec.answerCount,
+    });
+    applicationIds.push(result.applicationId);
+    byStatus[spec.status] += 1;
+  }
+
+  return { applicationIds, byStatus };
+}

--- a/src/functions/testdata/seedTrial.ts
+++ b/src/functions/testdata/seedTrial.ts
@@ -1,5 +1,11 @@
 import type Database from 'better-sqlite3';
 
+export interface SeedTrialOptions {
+  characterName?: string;
+  role?: string;
+  applicationId?: number;
+}
+
 export interface SeedTrialResult {
   trialId: number;
   alertCount: number;
@@ -10,18 +16,21 @@ export interface SeedTrialResult {
  *   - 7-day  (today, alerted=0)
  *   - 14-day (7 days from now)
  *   - 28-day (21 days from now)
+ * Optionally links to an application via applicationId.
  */
-export function seedTrial(db: Database.Database): SeedTrialResult {
+export function seedTrial(db: Database.Database, options: SeedTrialOptions = {}): SeedTrialResult {
+  const characterName = options.characterName ?? 'Testcharacter';
+  const role = options.role ?? 'DPS';
+  const applicationId = options.applicationId ?? null;
+
   const tx = db.transaction((): SeedTrialResult => {
-    // start_date is 7 days ago
     const trialResult = db.prepare(`
-      INSERT INTO trials (character_name, role, start_date, status)
-      VALUES (?, ?, date('now', '-7 days'), 'active')
-    `).run('Testcharacter', 'DPS');
+      INSERT INTO trials (character_name, role, start_date, status, application_id)
+      VALUES (?, ?, date('now', '-7 days'), 'active', ?)
+    `).run(characterName, role, applicationId);
 
     const trialId = trialResult.lastInsertRowid as number;
 
-    // Compute alert dates in JS to store real date strings
     const now = new Date();
     const addDays = (d: Date, days: number): string => {
       const result = new Date(d);
@@ -33,11 +42,8 @@ export function seedTrial(db: Database.Database): SeedTrialResult {
       INSERT INTO trial_alerts (trial_id, alert_name, alert_date, alerted) VALUES (?, ?, ?, ?)
     `);
 
-    // 7-day alert: start + 7 days = today
     insertAlert.run(trialId, '7-day review',  addDays(now, 0),  0);
-    // 14-day alert: start + 14 days = 7 days from now
     insertAlert.run(trialId, '14-day review', addDays(now, 7),  0);
-    // 28-day alert: start + 28 days = 21 days from now
     insertAlert.run(trialId, '28-day review', addDays(now, 21), 0);
 
     return { trialId, alertCount: 3 };

--- a/tests/unit/testdata.test.ts
+++ b/tests/unit/testdata.test.ts
@@ -4,6 +4,8 @@ import { createTables } from '../../src/database/schema.js';
 import { seedDatabase } from '../../src/database/seed.js';
 import { seedRaiders } from '../../src/functions/testdata/seedRaiders.js';
 import { seedApplication } from '../../src/functions/testdata/seedApplication.js';
+import { seedApplicationQuestions } from '../../src/functions/testdata/seedApplicationQuestions.js';
+import { seedApplicationVariety } from '../../src/functions/testdata/seedApplicationVariety.js';
 import { seedTrial } from '../../src/functions/testdata/seedTrial.js';
 import { seedEpgp } from '../../src/functions/testdata/seedEpgp.js';
 import { seedLoot } from '../../src/functions/testdata/seedLoot.js';
@@ -94,6 +96,33 @@ describe('seedRaiders', () => {
   });
 });
 
+// ─── seedApplicationQuestions ────────────────────────────────────────────────
+
+describe('seedApplicationQuestions', () => {
+  it('inserts the 9 default questions when table is empty', () => {
+    const result = seedApplicationQuestions(db);
+    expect(result.inserted).toBe(9);
+
+    const count = (db.prepare('SELECT COUNT(*) as count FROM application_questions').get() as { count: number }).count;
+    expect(count).toBe(9);
+  });
+
+  it('is idempotent — does not insert again when questions already exist', () => {
+    seedApplicationQuestions(db);
+    const second = seedApplicationQuestions(db);
+
+    expect(second.inserted).toBe(0);
+    const count = (db.prepare('SELECT COUNT(*) as count FROM application_questions').get() as { count: number }).count;
+    expect(count).toBe(9);
+  });
+
+  it('questions are ordered by sort_order starting at 1', () => {
+    seedApplicationQuestions(db);
+    const rows = db.prepare('SELECT sort_order FROM application_questions ORDER BY sort_order').all() as Array<{ sort_order: number }>;
+    expect(rows.map((r) => r.sort_order)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+});
+
 // ─── seedApplication ─────────────────────────────────────────────────────────
 
 describe('seedApplication', () => {
@@ -158,6 +187,82 @@ describe('seedApplication', () => {
     const r2 = seedApplication(db);
 
     expect(r2.applicationId).toBeGreaterThan(r1.applicationId);
+  });
+
+  it('respects options.characterName, options.userId, and options.status', () => {
+    const result = seedApplication(db, {
+      characterName: 'CustomChar',
+      userId: 'custom-user-id',
+      status: 'accepted',
+    });
+
+    const app = db.prepare('SELECT * FROM applications WHERE id = ?').get(result.applicationId) as {
+      character_name: string;
+      applicant_user_id: string;
+      status: string;
+    };
+    expect(app.character_name).toBe('CustomChar');
+    expect(app.applicant_user_id).toBe('custom-user-id');
+    expect(app.status).toBe('accepted');
+  });
+
+  it('respects options.answerCount for partial answer lists', () => {
+    const result = seedApplication(db, { answerCount: 3 });
+    expect(result.answersInserted).toBe(3);
+
+    const answers = db.prepare('SELECT * FROM application_answers WHERE application_id = ?').all(result.applicationId);
+    expect(answers).toHaveLength(3);
+  });
+
+  it('skips votes for in_progress status by default', () => {
+    const result = seedApplication(db, { status: 'in_progress', answerCount: 2 });
+    expect(result.votesInserted).toBe(0);
+
+    const votes = db.prepare('SELECT * FROM application_votes WHERE application_id = ?').all(result.applicationId);
+    expect(votes).toHaveLength(0);
+  });
+
+  it('skips votes for abandoned status by default', () => {
+    const result = seedApplication(db, { status: 'abandoned' });
+    expect(result.votesInserted).toBe(0);
+  });
+});
+
+// ─── seedApplicationVariety ──────────────────────────────────────────────────
+
+describe('seedApplicationVariety', () => {
+  it('inserts 5 applications, one per status', () => {
+    const result = seedApplicationVariety(db);
+
+    expect(result.applicationIds).toHaveLength(5);
+
+    const rows = db.prepare('SELECT status, COUNT(*) as count FROM applications GROUP BY status').all() as Array<{ status: string; count: number }>;
+    const byStatus = Object.fromEntries(rows.map((r) => [r.status, r.count]));
+
+    expect(byStatus.in_progress).toBe(1);
+    expect(byStatus.submitted).toBe(1);
+    expect(byStatus.accepted).toBe(1);
+    expect(byStatus.rejected).toBe(1);
+    expect(byStatus.abandoned).toBe(1);
+  });
+
+  it('in_progress application has 3 answers and 0 votes', () => {
+    seedApplicationVariety(db);
+
+    const app = db.prepare("SELECT id FROM applications WHERE status = 'in_progress'").get() as { id: number };
+    const answers = db.prepare('SELECT * FROM application_answers WHERE application_id = ?').all(app.id);
+    const votes = db.prepare('SELECT * FROM application_votes WHERE application_id = ?').all(app.id);
+
+    expect(answers).toHaveLength(3);
+    expect(votes).toHaveLength(0);
+  });
+
+  it('abandoned application has 0 votes', () => {
+    seedApplicationVariety(db);
+
+    const app = db.prepare("SELECT id FROM applications WHERE status = 'abandoned'").get() as { id: number };
+    const votes = db.prepare('SELECT * FROM application_votes WHERE application_id = ?').all(app.id);
+    expect(votes).toHaveLength(0);
   });
 });
 
@@ -249,6 +354,22 @@ describe('seedTrial', () => {
     for (const alert of futureAlerts) {
       expect(alert.alert_date > today).toBe(true);
     }
+  });
+
+  it('stores application_id when provided', () => {
+    const appResult = seedApplication(db, { status: 'accepted' });
+
+    const trialResult = seedTrial(db, { applicationId: appResult.applicationId });
+
+    const trial = db.prepare('SELECT application_id FROM trials WHERE id = ?').get(trialResult.trialId) as { application_id: number };
+    expect(trial.application_id).toBe(appResult.applicationId);
+  });
+
+  it('application_id is NULL when not provided', () => {
+    const result = seedTrial(db);
+
+    const trial = db.prepare('SELECT application_id FROM trials WHERE id = ?').get(result.trialId) as { application_id: number | null };
+    expect(trial.application_id).toBeNull();
   });
 });
 
@@ -418,6 +539,16 @@ describe('resetData', () => {
 
     const msgs = (db.prepare('SELECT COUNT(*) as count FROM default_messages').get() as { count: number }).count;
     expect(msgs).toBeGreaterThan(0);
+  });
+
+  it('re-seeds the 9 default application questions after reset', () => {
+    // Pollute the DB first so we know the count didn't just carry over
+    seedApplication(db);
+
+    resetData(db);
+
+    const count = (db.prepare('SELECT COUNT(*) as count FROM application_questions').get() as { count: number }).count;
+    expect(count).toBe(9);
   });
 
   it('can be called on an already-empty database', () => {

--- a/tests/unit/testdata.test.ts
+++ b/tests/unit/testdata.test.ts
@@ -9,7 +9,9 @@ import { seedApplicationVariety } from '../../src/functions/testdata/seedApplica
 import { seedTrial } from '../../src/functions/testdata/seedTrial.js';
 import { seedEpgp } from '../../src/functions/testdata/seedEpgp.js';
 import { seedLoot } from '../../src/functions/testdata/seedLoot.js';
+import { seedLootDiscord } from '../../src/functions/testdata/discord/seedLootDiscord.js';
 import { resetData } from '../../src/functions/testdata/resetData.js';
+import type { Client } from 'discord.js';
 
 let db: Database.Database;
 
@@ -488,6 +490,24 @@ describe('seedLoot', () => {
   it('is idempotent — calling twice does not duplicate posts', () => {
     seedLoot(db);
     seedLoot(db);
+
+    const rows = db.prepare('SELECT * FROM loot_posts').all();
+    expect(rows).toHaveLength(3);
+  });
+});
+
+// ─── seedLootDiscord ─────────────────────────────────────────────────────────
+
+describe('seedLootDiscord (graceful degradation)', () => {
+  it('still inserts DB rows when loot_channel_id is not configured', async () => {
+    // No loot_channel_id in config — the Discord path will early-return.
+    const client = {} as Client;
+
+    const result = await seedLootDiscord(client, db);
+
+    expect(result.dbPostsInserted).toBe(3);
+    expect(result.postsCreated).toBe(0);
+    expect(result.skippedReason).toMatch(/loot_channel_id not configured/);
 
     const rows = db.prepare('SELECT * FROM loot_posts').all();
     expect(rows).toHaveLength(3);


### PR DESCRIPTION
## Summary
- Adds real Discord artifacts to every relevant `/testdata` seed via an opt-in `discord:true/false` flag. DB-only behavior is the default; opting in creates raider-setup linking messages, an application forum post with voting buttons, a trial-review forum thread, and loot-channel messages using existing helpers (`sendAlertForRaidersWithNoUser`, `createForumPost`, `createTrialReviewThread`, `addLootPost`).
- New subcommands: `seed_application_variety` (5 apps covering every status) and `seed_all` (runs every seed in order, threads the discord flag through, links the seeded trial to the seeded application).
- Hardens `/testdata reset` with a required `confirm:true` option and re-seeds the 9 default application questions so `/applications` works immediately after reset.
- Fixes a latent bug where `requireOfficer` was called without `await`, so the permission check never returned early in `/testdata`.
- Extracts `createForumPost` + `splitMessage` from `submitApplication.ts` so the application-log post path is reusable by the new seed.
- Parameterizes `seedApplication` with `{characterName, userId, status, answerCount, includeVotes}` and `seedTrial` with `{characterName, role, applicationId}` so `seed_application_variety` and `seed_all` can compose them.
- Each Discord-variant seed gracefully degrades when a required channel is not configured — it still does the DB work and surfaces a `skippedReason` in the reply.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 202 passed (51 in testdata.test.ts; +16 new assertions covering `seedApplicationQuestions`, parameterized `seedApplication`, `seedApplicationVariety`, `seedTrial` `application_id`, and `resetData` re-seeding questions)
- [x] Chrome verification on the test guild:
  - [x] `/testdata reset confirm:true` → DB wiped, `application_questions` re-seeded to 9
  - [x] `/testdata seed_raiders discord:true` → 15 raiders + 15 linking messages in the auto-created raider-setup channel
  - [x] `/testdata seed_application discord:true` → forum post with Q&A, Active tag, For/Neutral/Against/Kekw vote buttons, Accept/Reject buttons
  - [x] `/testdata seed_trial discord:true` → trial-reviews forum thread with schedule, 4 action buttons, WarcraftLogs attendance lookup
  - [x] `/testdata seed_epgp` → 45 EP / 8 GP / 5 loot / 1 upload, matching unit-test expectations
  - [x] `/testdata seed_loot discord:true` (with `loot_channel_id` unset) → graceful degradation: "Discord skipped: loot_channel_id not configured"
  - [x] `/testdata seed_application_variety` → 5 apps, one per status; in_progress has 3 answers and 0 votes; abandoned has 0 votes
  - [x] `/testdata seed_all discord:true` → end-to-end: raiders, application, linked trial, EPGP, loot gracefully skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)