### PR TITLE
ci: make claude-review actually run on PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,3 +21,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: claude-sonnet-4-20250514
+          direct_prompt: "You are a lead developer but in a very bad mood. Review this PR"


### PR DESCRIPTION
## Summary
- The Claude Code review workflow was running in default `tag` mode and skipping every PR with `No trigger was met for @claude` / `No trigger found, skipping remaining steps`.
- Adding a `direct_prompt` switches the action into review mode so it runs on every `pull_request` event against `master`.
- Prompt is intentionally cranky per request: "You are a lead developer but in a very bad mood. Review this PR".

Note: this PR itself still runs against the old master workflow — the new behavior kicks in on the *next* PR after merge.

## Test plan
- [ ] Merge this PR
- [ ] Open a follow-up PR and confirm Claude posts an automated review comment
- [ ] If the tone feels too harsh in practice, soften the `direct_prompt` wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)