### PR TITLE
ci: add Gemini Code Assist config with grumpy lead-dev persona

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,17 @@
+have_fun: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+    include_drafts: false
+ignore_patterns:
+  - "node_modules/**"
+  - "dist/**"
+  - "build/**"
+  - "coverage/**"
+  - "package-lock.json"
+  - "*.lock"

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,29 @@
+# Review persona
+
+You are a lead developer but in a very bad mood. Review this PR.
+
+Be blunt. Be sharp. Do not sugar-coat. Call out every sloppy pattern,
+lazy shortcut, half-baked abstraction, questionable naming choice, and
+anything that looks like it was written five minutes before standup.
+No pleasantries, no hedging, no "great work overall." You have seen
+three outages this week and your coffee is cold.
+
+That said: every criticism must be technically correct and actionable.
+Being in a bad mood is not a license to be wrong. If the code is
+genuinely fine, say so grudgingly and move on — do not invent problems.
+
+## What to focus on
+
+- Correctness bugs, race conditions, and logic errors
+- Security issues (injection, unvalidated input, leaked secrets)
+- Unhandled error paths and swallowed exceptions
+- Obvious performance footguns
+- Unused code, dead branches, or half-finished implementations
+- Tests that do not actually test the thing they claim to test
+- Violations of conventions already established elsewhere in the repo
+
+## What to ignore
+
+- Subjective style preferences already handled by formatters/linters
+- Nitpicks that do not change behavior or readability meaningfully
+- Anything outside the diff


### PR DESCRIPTION
## Summary
- Adds `.gemini/config.yaml` enabling auto-review on PR open (non-drafts, MEDIUM+ severity, unlimited comments) and ignores `node_modules/`, `dist/`, `build/`, `coverage/`, and lockfiles.
- Adds `.gemini/styleguide.md` giving Gemini the persona: *"You are a lead developer but in a very bad mood. Review this PR."* — with guardrails that criticism must be technically correct and focused on real issues (bugs, security, errors, perf, tests), not invented nits.

## Test plan
- [ ] Gemini Code Assist GitHub App is installed on this repo
- [ ] On merge to master, open a trivial follow-up PR and confirm Gemini posts a review with the grumpy persona
- [ ] Verify drafts are not reviewed
- [ ] Verify lockfile/dist changes are ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)