### PR TITLE
feat(setup): support forum and category channels in /setup set_channel

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -28,11 +28,14 @@ const CHANNEL_CONFIG: Record<string, { label: string; type: ConfigurableChannelT
   applications_category_id: { label: 'Applications Category', type: ChannelType.GuildCategory },
 };
 
-const CHANNEL_TYPE_LABEL: Partial<Record<ChannelType, string>> = {
-  [ChannelType.GuildText]: 'text channel',
-  [ChannelType.GuildForum]: 'forum channel',
-  [ChannelType.GuildCategory]: 'category',
-};
+function channelTypeLabel(type: ChannelType): string {
+  switch (type) {
+    case ChannelType.GuildText: return 'text channel';
+    case ChannelType.GuildForum: return 'forum channel';
+    case ChannelType.GuildCategory: return 'category';
+    default: return 'different channel type';
+  }
+}
 
 const CHANNEL_CHOICES = Object.entries(CHANNEL_CONFIG).map(([value, { label }]) => ({
   name: label,
@@ -116,7 +119,7 @@ export default {
 
       if (channel.type !== expected.type) {
         await interaction.reply({
-          content: `**${expected.label}** must be a ${CHANNEL_TYPE_LABEL[expected.type] ?? 'specified type'}, but ${channel} is a ${CHANNEL_TYPE_LABEL[channel.type] ?? 'different channel type'}.`,
+          content: `**${expected.label}** must be a ${channelTypeLabel(expected.type)}, but ${channel} is a ${channelTypeLabel(channel.type)}.`,
           flags: MessageFlags.Ephemeral,
         });
         return;

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -9,7 +9,12 @@ import { getDatabase } from '../database/db.js';
 import { requireOfficer } from '../utils.js';
 import { audit } from '../services/auditLog.js';
 
-const CHANNEL_CONFIG: Record<string, { label: string; type: ChannelType }> = {
+type ConfigurableChannelType =
+  | ChannelType.GuildText
+  | ChannelType.GuildForum
+  | ChannelType.GuildCategory;
+
+const CHANNEL_CONFIG: Record<string, { label: string; type: ConfigurableChannelType }> = {
   guild_info_channel_id: { label: 'Guild Info', type: ChannelType.GuildText },
   bot_logs_channel_id: { label: 'Bot Logs', type: ChannelType.GuildText },
   bot_audit_channel_id: { label: 'Bot Audit', type: ChannelType.GuildText },
@@ -36,7 +41,7 @@ const CHANNEL_CHOICES = Object.entries(CHANNEL_CONFIG).map(([value, { label }]) 
 
 const ALLOWED_CHANNEL_TYPES = [
   ...new Set(Object.values(CHANNEL_CONFIG).map((c) => c.type)),
-] as (ChannelType.GuildText | ChannelType.GuildForum | ChannelType.GuildCategory)[];
+];
 
 export default {
   data: new SlashCommandBuilder()
@@ -92,7 +97,7 @@ export default {
 
       if (channel.type !== expected.type) {
         await interaction.reply({
-          content: `**${key}** must be a ${CHANNEL_TYPE_LABEL[expected.type]}, but ${channel} is a ${CHANNEL_TYPE_LABEL[channel.type] ?? 'different channel type'}.`,
+          content: `**${expected.label}** must be a ${CHANNEL_TYPE_LABEL[expected.type] ?? 'specified type'}, but ${channel} is a ${CHANNEL_TYPE_LABEL[channel.type] ?? 'different channel type'}.`,
           flags: MessageFlags.Ephemeral,
         });
         return;

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -9,6 +9,26 @@ import { getDatabase } from '../database/db.js';
 import { requireOfficer } from '../utils.js';
 import { audit } from '../services/auditLog.js';
 
+const EXPECTED_CHANNEL_TYPE: Record<string, ChannelType> = {
+  guild_info_channel_id: ChannelType.GuildText,
+  bot_logs_channel_id: ChannelType.GuildText,
+  bot_audit_channel_id: ChannelType.GuildText,
+  raider_setup_channel_id: ChannelType.GuildText,
+  weekly_check_channel_id: ChannelType.GuildText,
+  epgp_rankings_channel_id: ChannelType.GuildText,
+  loot_channel_id: ChannelType.GuildText,
+  raiders_lounge_channel_id: ChannelType.GuildText,
+  application_log_forum_id: ChannelType.GuildForum,
+  trial_reviews_forum_id: ChannelType.GuildForum,
+  applications_category_id: ChannelType.GuildCategory,
+};
+
+const CHANNEL_TYPE_LABEL: Record<number, string> = {
+  [ChannelType.GuildText]: 'text channel',
+  [ChannelType.GuildForum]: 'forum channel',
+  [ChannelType.GuildCategory]: 'category',
+};
+
 export default {
   data: new SlashCommandBuilder()
     .setName('setup')
@@ -32,6 +52,9 @@ export default {
               { name: 'EPGP Rankings', value: 'epgp_rankings_channel_id' },
               { name: 'Loot', value: 'loot_channel_id' },
               { name: 'Raiders Lounge', value: 'raiders_lounge_channel_id' },
+              { name: 'Application Log Forum', value: 'application_log_forum_id' },
+              { name: 'Trial Reviews Forum', value: 'trial_reviews_forum_id' },
+              { name: 'Applications Category', value: 'applications_category_id' },
             ),
         )
         .addChannelOption((opt) =>
@@ -39,7 +62,11 @@ export default {
             .setName('channel')
             .setDescription('The channel')
             .setRequired(true)
-            .addChannelTypes(ChannelType.GuildText),
+            .addChannelTypes(
+              ChannelType.GuildText,
+              ChannelType.GuildForum,
+              ChannelType.GuildCategory,
+            ),
         ),
     )
     .addSubcommand((sub) =>
@@ -68,6 +95,15 @@ export default {
     if (subcommand === 'set_channel') {
       const key = interaction.options.getString('key', true);
       const channel = interaction.options.getChannel('channel', true);
+
+      const expectedType = EXPECTED_CHANNEL_TYPE[key];
+      if (channel.type !== expectedType) {
+        await interaction.reply({
+          content: `**${key}** must be a ${CHANNEL_TYPE_LABEL[expectedType]}, but ${channel} is a ${CHANNEL_TYPE_LABEL[channel.type] ?? 'different channel type'}.`,
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
 
       db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(key, channel.id);
       await audit(interaction.user, 'configured channel', `${key} = #${channel.name}`);

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -43,6 +43,14 @@ const ALLOWED_CHANNEL_TYPES = [
   ...new Set(Object.values(CHANNEL_CONFIG).map((c) => c.type)),
 ];
 
+// Discord caps slash-command choices at 25 per option. Fail fast at module load
+// rather than at command registration if CHANNEL_CONFIG grows past that.
+if (CHANNEL_CHOICES.length > 25) {
+  throw new Error(
+    `CHANNEL_CONFIG has ${CHANNEL_CHOICES.length} entries but Discord allows max 25 choices per option; switch to autocomplete.`,
+  );
+}
+
 export default {
   data: new SlashCommandBuilder()
     .setName('setup')
@@ -94,6 +102,17 @@ export default {
       const key = interaction.options.getString('key', true);
       const channel = interaction.options.getChannel('channel', true);
       const expected = CHANNEL_CONFIG[key];
+
+      // Discord validates `key` against CHANNEL_CHOICES (derived from CHANNEL_CONFIG),
+      // so `expected` is structurally non-undefined. Guard anyway in case registration
+      // ever drifts (e.g. partial redeploy).
+      if (!expected) {
+        await interaction.reply({
+          content: 'Invalid configuration key.',
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
 
       if (channel.type !== expected.type) {
         await interaction.reply({

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -9,25 +9,34 @@ import { getDatabase } from '../database/db.js';
 import { requireOfficer } from '../utils.js';
 import { audit } from '../services/auditLog.js';
 
-const EXPECTED_CHANNEL_TYPE: Record<string, ChannelType> = {
-  guild_info_channel_id: ChannelType.GuildText,
-  bot_logs_channel_id: ChannelType.GuildText,
-  bot_audit_channel_id: ChannelType.GuildText,
-  raider_setup_channel_id: ChannelType.GuildText,
-  weekly_check_channel_id: ChannelType.GuildText,
-  epgp_rankings_channel_id: ChannelType.GuildText,
-  loot_channel_id: ChannelType.GuildText,
-  raiders_lounge_channel_id: ChannelType.GuildText,
-  application_log_forum_id: ChannelType.GuildForum,
-  trial_reviews_forum_id: ChannelType.GuildForum,
-  applications_category_id: ChannelType.GuildCategory,
+const CHANNEL_CONFIG: Record<string, { label: string; type: ChannelType }> = {
+  guild_info_channel_id: { label: 'Guild Info', type: ChannelType.GuildText },
+  bot_logs_channel_id: { label: 'Bot Logs', type: ChannelType.GuildText },
+  bot_audit_channel_id: { label: 'Bot Audit', type: ChannelType.GuildText },
+  raider_setup_channel_id: { label: 'Raider Setup', type: ChannelType.GuildText },
+  weekly_check_channel_id: { label: 'Weekly Check', type: ChannelType.GuildText },
+  epgp_rankings_channel_id: { label: 'EPGP Rankings', type: ChannelType.GuildText },
+  loot_channel_id: { label: 'Loot', type: ChannelType.GuildText },
+  raiders_lounge_channel_id: { label: 'Raiders Lounge', type: ChannelType.GuildText },
+  application_log_forum_id: { label: 'Application Log Forum', type: ChannelType.GuildForum },
+  trial_reviews_forum_id: { label: 'Trial Reviews Forum', type: ChannelType.GuildForum },
+  applications_category_id: { label: 'Applications Category', type: ChannelType.GuildCategory },
 };
 
-const CHANNEL_TYPE_LABEL: Record<number, string> = {
+const CHANNEL_TYPE_LABEL: Partial<Record<ChannelType, string>> = {
   [ChannelType.GuildText]: 'text channel',
   [ChannelType.GuildForum]: 'forum channel',
   [ChannelType.GuildCategory]: 'category',
 };
+
+const CHANNEL_CHOICES = Object.entries(CHANNEL_CONFIG).map(([value, { label }]) => ({
+  name: label,
+  value,
+}));
+
+const ALLOWED_CHANNEL_TYPES = [
+  ...new Set(Object.values(CHANNEL_CONFIG).map((c) => c.type)),
+] as (ChannelType.GuildText | ChannelType.GuildForum | ChannelType.GuildCategory)[];
 
 export default {
   data: new SlashCommandBuilder()
@@ -43,30 +52,14 @@ export default {
             .setName('key')
             .setDescription('Channel purpose')
             .setRequired(true)
-            .addChoices(
-              { name: 'Guild Info', value: 'guild_info_channel_id' },
-              { name: 'Bot Logs', value: 'bot_logs_channel_id' },
-              { name: 'Bot Audit', value: 'bot_audit_channel_id' },
-              { name: 'Raider Setup', value: 'raider_setup_channel_id' },
-              { name: 'Weekly Check', value: 'weekly_check_channel_id' },
-              { name: 'EPGP Rankings', value: 'epgp_rankings_channel_id' },
-              { name: 'Loot', value: 'loot_channel_id' },
-              { name: 'Raiders Lounge', value: 'raiders_lounge_channel_id' },
-              { name: 'Application Log Forum', value: 'application_log_forum_id' },
-              { name: 'Trial Reviews Forum', value: 'trial_reviews_forum_id' },
-              { name: 'Applications Category', value: 'applications_category_id' },
-            ),
+            .addChoices(...CHANNEL_CHOICES),
         )
         .addChannelOption((opt) =>
           opt
             .setName('channel')
             .setDescription('The channel')
             .setRequired(true)
-            .addChannelTypes(
-              ChannelType.GuildText,
-              ChannelType.GuildForum,
-              ChannelType.GuildCategory,
-            ),
+            .addChannelTypes(...ALLOWED_CHANNEL_TYPES),
         ),
     )
     .addSubcommand((sub) =>
@@ -95,11 +88,11 @@ export default {
     if (subcommand === 'set_channel') {
       const key = interaction.options.getString('key', true);
       const channel = interaction.options.getChannel('channel', true);
+      const expected = CHANNEL_CONFIG[key];
 
-      const expectedType = EXPECTED_CHANNEL_TYPE[key];
-      if (channel.type !== expectedType) {
+      if (channel.type !== expected.type) {
         await interaction.reply({
-          content: `**${key}** must be a ${CHANNEL_TYPE_LABEL[expectedType]}, but ${channel} is a ${CHANNEL_TYPE_LABEL[channel.type] ?? 'different channel type'}.`,
+          content: `**${key}** must be a ${CHANNEL_TYPE_LABEL[expected.type]}, but ${channel} is a ${CHANNEL_TYPE_LABEL[channel.type] ?? 'different channel type'}.`,
           flags: MessageFlags.Ephemeral,
         });
         return;


### PR DESCRIPTION
## Summary
- Extends `/setup set_channel` to accept `Application Log Forum`, `Trial Reviews Forum`, and `Applications Category` choices, so officers can point `application_log_forum_id`, `trial_reviews_forum_id`, and `applications_category_id` at existing channels instead of relying on the auto-create-on-first-use path.
- Widens the channel option to accept `GuildForum` and `GuildCategory` in addition to `GuildText`.
- Adds runtime validation that rejects mismatches (e.g., picking a text channel for a forum key) with a clear ephemeral error.

## Test plan
- [ ] `/setup set_channel key:"Application Log Forum" channel:<forum>` succeeds and persists to `application_log_forum_id`
- [ ] `/setup set_channel key:"Trial Reviews Forum" channel:<forum>` succeeds and persists to `trial_reviews_forum_id`
- [ ] `/setup set_channel key:"Applications Category" channel:<category>` succeeds and persists to `applications_category_id`
- [ ] Picking a text channel for a forum key returns the mismatch error and does not write to DB
- [ ] Existing text-channel keys still work unchanged
- [ ] `/setup get_config` shows the newly set IDs
- [ ] After setting, next `/apply` submit posts into the configured forum (not auto-created), and next accepted application creates the trial review thread in the configured forum (relies on `getOrCreateChannel` from #31)

🤖 Generated with [Claude Code](https://claude.com/claude-code)