### PR TITLE
feat(testdata): reset tears down Discord artifacts with rollback (#30)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,20 @@ jobs:
         run: npm run typecheck
 
       - name: Unit tests
+        # Stub required env vars so config.ts module load succeeds. These
+        # are only used if a test actually hits a code path that reads them;
+        # the values are intentionally unusable so any accidental production
+        # call fails loudly.
+        env:
+          DISCORD_TOKEN: test-stub
+          CLIENT_ID: test-stub
+          GUILD_ID: test-stub
+          OFFICER_ROLE_ID: test-stub
+          WOWAUDIT_API_SECRET: test-stub
+          WARCRAFTLOGS_CLIENT_ID: test-stub
+          WARCRAFTLOGS_CLIENT_SECRET: test-stub
+          WARCRAFTLOGS_GUILD_ID: '0'
+          RAIDERIO_GUILD_IDS: '0'
         run: npm test
 
       - name: Build

--- a/src/commands/testdata.ts
+++ b/src/commands/testdata.ts
@@ -12,7 +12,7 @@ import { seedApplicationVariety } from '../functions/testdata/seedApplicationVar
 import { seedTrial } from '../functions/testdata/seedTrial.js';
 import { seedEpgp } from '../functions/testdata/seedEpgp.js';
 import { seedLoot } from '../functions/testdata/seedLoot.js';
-import { resetData } from '../functions/testdata/resetData.js';
+import { resetData, ResetDiscordError } from '../functions/testdata/resetData.js';
 import { seedAll } from '../functions/testdata/seedAll.js';
 import { seedRaidersDiscord } from '../functions/testdata/discord/seedRaidersDiscord.js';
 import { seedApplicationDiscord } from '../functions/testdata/discord/seedApplicationDiscord.js';
@@ -183,8 +183,34 @@ async function runSubcommand(
       if (!confirm) {
         return 'Pass `confirm:true` to actually wipe data.';
       }
-      resetData(db);
-      return 'All data wiped and defaults (including application questions) re-seeded.';
+      try {
+        const result = await resetData(db, interaction.client);
+        const lines = ['All data wiped and defaults (including application questions) re-seeded.'];
+        if (result.discord) {
+          lines.push(
+            `Discord cleanup: **${result.discord.deleted}** deleted, **${result.discord.alreadyMissing}** already gone.`,
+          );
+        }
+        return lines.join('\n');
+      } catch (err) {
+        if (err instanceof ResetDiscordError) {
+          const failedList = err.result.errors
+            .slice(0, 10)
+            .map((e) => `• \`${e.kind}\` \`${e.id}\`: ${e.message}`)
+            .join('\n');
+          const more = err.result.errors.length > 10 ? `\n_(+${err.result.errors.length - 10} more)_` : '';
+          return [
+            `**Reset aborted — database was NOT wiped.**`,
+            `Discord cleanup failed for ${err.result.errors.length} artifact(s) ` +
+              `(${err.result.deleted} deleted, ${err.result.alreadyMissing} already gone before the failure).`,
+            '',
+            failedList + more,
+            '',
+            '_Fix the underlying issue and re-run. Artifacts already deleted won\'t be retried — their DB rows still exist and will short-circuit as "already missing" on the next attempt._',
+          ].join('\n');
+        }
+        throw err;
+      }
     }
     default:
       return `Unknown subcommand: ${sub}`;

--- a/src/functions/testdata/resetData.ts
+++ b/src/functions/testdata/resetData.ts
@@ -1,12 +1,50 @@
+import type { Client } from 'discord.js';
 import type Database from 'better-sqlite3';
 import { seedDatabase } from '../../database/seed.js';
 import { seedApplicationQuestions } from './seedApplicationQuestions.js';
+import { resetDiscordArtifacts, type ResetArtifactsResult } from './resetDiscordArtifacts.js';
+
+export class ResetDiscordError extends Error {
+  readonly result: ResetArtifactsResult;
+  constructor(result: ResetArtifactsResult) {
+    const summary = result.errors
+      .slice(0, 5)
+      .map((e) => `${e.kind}(${e.id}): ${e.message}`)
+      .join('; ');
+    const more = result.errors.length > 5 ? ` (+${result.errors.length - 5} more)` : '';
+    super(`Discord cleanup failed for ${result.errors.length} artifact(s): ${summary}${more}`);
+    this.name = 'ResetDiscordError';
+    this.result = result;
+  }
+}
+
+export interface ResetDataResult {
+  discord: ResetArtifactsResult | null;
+}
 
 /**
  * Wipes all data from all tables in correct FK order (children before parents),
  * then re-seeds defaults via seedDatabase() and the 9 default application questions.
+ *
+ * When `client` is provided, Discord artifacts (forum threads, per-app channels,
+ * loot messages, linking messages, guild-info messages) are torn down FIRST.
+ * If Discord cleanup reports any real errors (anything other than 404-style
+ * "already gone"), the DB wipe is aborted and ResetDiscordError is thrown —
+ * this preserves the "consistent state" invariant from #30: we never leave
+ * the DB wiped with Discord artifacts still dangling.
  */
-export function resetData(db: Database.Database): void {
+export async function resetData(
+  db: Database.Database,
+  client?: Client,
+): Promise<ResetDataResult> {
+  let discord: ResetArtifactsResult | null = null;
+  if (client) {
+    discord = await resetDiscordArtifacts(client, db);
+    if (discord.errors.length > 0) {
+      throw new ResetDiscordError(discord);
+    }
+  }
+
   const tx = db.transaction(() => {
     // Children first to satisfy FK constraints.
     // trials.application_id → applications.id, so the whole trial chain
@@ -59,4 +97,6 @@ export function resetData(db: Database.Database): void {
   // changes, consolidate into one call site to avoid two sources of truth.
   seedDatabase(db);
   seedApplicationQuestions(db);
+
+  return { discord };
 }

--- a/src/functions/testdata/resetDiscordArtifacts.ts
+++ b/src/functions/testdata/resetDiscordArtifacts.ts
@@ -46,29 +46,34 @@ interface ArtifactRow {
 function collectArtifactIds(db: Database.Database): ArtifactRow[] {
   const rows: ArtifactRow[] = [];
 
-  // Per-applicant text channels (app-{name} under Applications category).
-  for (const r of db
-    .prepare(`SELECT channel_id FROM applications WHERE channel_id IS NOT NULL`)
-    .all() as { channel_id: string }[]) {
-    rows.push({ kind: 'application:channel', id: r.channel_id });
-  }
+  // One query for all three application-owned references, filtering out
+  // rows that have nothing to clean.
+  const applications = db
+    .prepare(
+      `SELECT channel_id, forum_post_id, thread_id
+         FROM applications
+        WHERE channel_id IS NOT NULL OR forum_post_id IS NOT NULL OR thread_id IS NOT NULL`,
+    )
+    .all() as {
+    channel_id: string | null;
+    forum_post_id: string | null;
+    thread_id: string | null;
+  }[];
 
-  // Forum threads (applications log).
-  for (const r of db
-    .prepare(`SELECT forum_post_id FROM applications WHERE forum_post_id IS NOT NULL`)
-    .all() as { forum_post_id: string }[]) {
-    rows.push({ kind: 'application:forum_thread', id: r.forum_post_id });
-  }
-
-  // thread_id for applications is usually the same as forum_post_id (the
-  // initial forum thread is the post). Include distinct values only so we
-  // don't issue a duplicate delete.
-  const seenForumIds = new Set(rows.filter((x) => x.kind === 'application:forum_thread').map((x) => x.id));
-  for (const r of db
-    .prepare(`SELECT thread_id FROM applications WHERE thread_id IS NOT NULL`)
-    .all() as { thread_id: string }[]) {
-    if (!seenForumIds.has(r.thread_id)) {
-      rows.push({ kind: 'application:thread', id: r.thread_id });
+  const seenForumIds = new Set<string>();
+  for (const app of applications) {
+    if (app.channel_id) {
+      rows.push({ kind: 'application:channel', id: app.channel_id });
+    }
+    if (app.forum_post_id) {
+      rows.push({ kind: 'application:forum_thread', id: app.forum_post_id });
+      seenForumIds.add(app.forum_post_id);
+    }
+    // thread_id on applications is usually the same value as forum_post_id
+    // (the initial thread of a forum post is the post). Dedupe so we don't
+    // issue two deletes for the same channel id.
+    if (app.thread_id && !seenForumIds.has(app.thread_id)) {
+      rows.push({ kind: 'application:thread', id: app.thread_id });
     }
   }
 
@@ -124,16 +129,10 @@ async function deleteChannelOrThread(
   guild: Guild,
   id: string,
 ): Promise<'deleted' | 'missing'> {
-  let channel: GuildBasedChannel | null;
+  // guild.channels.delete(id) hits Discord's DELETE endpoint directly — no
+  // need to fetch-then-delete. Missing channels just come back as 10003.
   try {
-    channel = await guild.channels.fetch(id);
-  } catch (err) {
-    if (isMissing(err)) return 'missing';
-    throw err;
-  }
-  if (!channel) return 'missing';
-  try {
-    await channel.delete();
+    await guild.channels.delete(id);
     return 'deleted';
   } catch (err) {
     if (isMissing(err)) return 'missing';
@@ -153,10 +152,9 @@ async function deleteMessage(
     if (isMissing(err)) return 'missing';
     throw err;
   }
-  if (!parent || !('messages' in parent)) return 'missing';
+  if (!parent || !parent.isTextBased()) return 'missing';
   try {
-    const msg = await parent.messages.fetch(messageId);
-    await msg.delete();
+    await parent.messages.delete(messageId);
     return 'deleted';
   } catch (err) {
     if (isMissing(err)) return 'missing';

--- a/src/functions/testdata/resetDiscordArtifacts.ts
+++ b/src/functions/testdata/resetDiscordArtifacts.ts
@@ -1,0 +1,221 @@
+import {
+  type Client,
+  type Guild,
+  type GuildBasedChannel,
+  DiscordAPIError,
+  RESTJSONErrorCodes,
+} from 'discord.js';
+import type Database from 'better-sqlite3';
+import { config } from '../../config.js';
+import { logger } from '../../services/logger.js';
+
+export interface ArtifactError {
+  kind: string;
+  id: string;
+  message: string;
+}
+
+export interface ResetArtifactsResult {
+  deleted: number;
+  alreadyMissing: number;
+  errors: ArtifactError[];
+}
+
+// Treat 404-ish errors as "already gone" so a partial earlier run or
+// manual cleanup doesn't block the reset. Everything else is a real
+// failure that must stop us before we wipe the DB (per #30: consistent
+// state + rollback on error).
+const MISSING_CODES = new Set<number>([
+  RESTJSONErrorCodes.UnknownChannel,
+  RESTJSONErrorCodes.UnknownMessage,
+  RESTJSONErrorCodes.UnknownGuild,
+]);
+
+function isMissing(err: unknown): boolean {
+  return err instanceof DiscordAPIError && typeof err.code === 'number' && MISSING_CODES.has(err.code);
+}
+
+interface ArtifactRow {
+  kind: string;
+  // A channel/thread/message reference to delete. `parentId` lets us fetch
+  // a message by its parent channel (messages can't be fetched by id alone).
+  id: string;
+  parentId?: string;
+}
+
+function collectArtifactIds(db: Database.Database): ArtifactRow[] {
+  const rows: ArtifactRow[] = [];
+
+  // Per-applicant text channels (app-{name} under Applications category).
+  for (const r of db
+    .prepare(`SELECT channel_id FROM applications WHERE channel_id IS NOT NULL`)
+    .all() as { channel_id: string }[]) {
+    rows.push({ kind: 'application:channel', id: r.channel_id });
+  }
+
+  // Forum threads (applications log).
+  for (const r of db
+    .prepare(`SELECT forum_post_id FROM applications WHERE forum_post_id IS NOT NULL`)
+    .all() as { forum_post_id: string }[]) {
+    rows.push({ kind: 'application:forum_thread', id: r.forum_post_id });
+  }
+
+  // thread_id for applications is usually the same as forum_post_id (the
+  // initial forum thread is the post). Include distinct values only so we
+  // don't issue a duplicate delete.
+  const seenForumIds = new Set(rows.filter((x) => x.kind === 'application:forum_thread').map((x) => x.id));
+  for (const r of db
+    .prepare(`SELECT thread_id FROM applications WHERE thread_id IS NOT NULL`)
+    .all() as { thread_id: string }[]) {
+    if (!seenForumIds.has(r.thread_id)) {
+      rows.push({ kind: 'application:thread', id: r.thread_id });
+    }
+  }
+
+  // Trial review threads + promotion-decision threads (both live in the
+  // trial_reviews_forum, so each is a deletable channel).
+  for (const r of db
+    .prepare(`SELECT thread_id FROM trials WHERE thread_id IS NOT NULL`)
+    .all() as { thread_id: string }[]) {
+    rows.push({ kind: 'trial:thread', id: r.thread_id });
+  }
+  for (const r of db
+    .prepare(`SELECT thread_id FROM promote_alerts WHERE thread_id IS NOT NULL`)
+    .all() as { thread_id: string }[]) {
+    rows.push({ kind: 'promote_alert:thread', id: r.thread_id });
+  }
+
+  // Loot post messages (parent channel lookup needed to delete).
+  for (const r of db
+    .prepare(`SELECT channel_id, message_id FROM loot_posts WHERE message_id IS NOT NULL`)
+    .all() as { channel_id: string; message_id: string }[]) {
+    rows.push({ kind: 'loot:message', id: r.message_id, parentId: r.channel_id });
+  }
+
+  // Raider linking messages (parent is raider-setup channel from config).
+  const raiderSetup = db
+    .prepare(`SELECT value FROM config WHERE key = 'raider_setup_channel_id'`)
+    .get() as { value: string } | undefined;
+  if (raiderSetup) {
+    for (const r of db
+      .prepare(`SELECT message_id FROM raiders WHERE message_id IS NOT NULL`)
+      .all() as { message_id: string }[]) {
+      rows.push({ kind: 'raider:link_message', id: r.message_id, parentId: raiderSetup.value });
+    }
+  }
+
+  // Guild-info messages (About Us / Schedule / Recruitment), posted to the
+  // guild_info channel.
+  const guildInfo = db
+    .prepare(`SELECT value FROM config WHERE key = 'guild_info_channel_id'`)
+    .get() as { value: string } | undefined;
+  if (guildInfo) {
+    for (const r of db
+      .prepare(`SELECT message_id FROM guild_info_messages`)
+      .all() as { message_id: string }[]) {
+      rows.push({ kind: 'guild_info:message', id: r.message_id, parentId: guildInfo.value });
+    }
+  }
+
+  return rows;
+}
+
+async function deleteChannelOrThread(
+  guild: Guild,
+  id: string,
+): Promise<'deleted' | 'missing'> {
+  let channel: GuildBasedChannel | null;
+  try {
+    channel = await guild.channels.fetch(id);
+  } catch (err) {
+    if (isMissing(err)) return 'missing';
+    throw err;
+  }
+  if (!channel) return 'missing';
+  try {
+    await channel.delete();
+    return 'deleted';
+  } catch (err) {
+    if (isMissing(err)) return 'missing';
+    throw err;
+  }
+}
+
+async function deleteMessage(
+  guild: Guild,
+  messageId: string,
+  parentChannelId: string,
+): Promise<'deleted' | 'missing'> {
+  let parent: GuildBasedChannel | null;
+  try {
+    parent = await guild.channels.fetch(parentChannelId);
+  } catch (err) {
+    if (isMissing(err)) return 'missing';
+    throw err;
+  }
+  if (!parent || !('messages' in parent)) return 'missing';
+  try {
+    const msg = await parent.messages.fetch(messageId);
+    await msg.delete();
+    return 'deleted';
+  } catch (err) {
+    if (isMissing(err)) return 'missing';
+    throw err;
+  }
+}
+
+/**
+ * Tears down Discord artifacts that correspond to rows in the DB, so that a
+ * subsequent DB wipe + re-seed leaves Discord in sync with the database.
+ *
+ * Strategy (#30):
+ *   1. Snapshot all artifact IDs from the DB before deleting anything.
+ *   2. Delete each artifact, swallowing 404-ish errors (Unknown Channel,
+ *      Unknown Message) — those mean the item is already gone, which is
+ *      the desired end state anyway.
+ *   3. Accumulate real errors (permissions, rate limits, transport) and
+ *      return them. Caller is expected to abort the DB wipe when
+ *      `errors.length > 0`, so we don't end up with DB rows gone but
+ *      Discord artifacts still dangling.
+ *
+ * Artifacts NOT touched:
+ *   - Auto-created infrastructure channels (bot-logs, raider-setup, the
+ *     applications category itself). Those are ops-level, not seed-level.
+ *   - Anything the bot didn't record an ID for.
+ */
+export async function resetDiscordArtifacts(
+  client: Client,
+  db: Database.Database,
+): Promise<ResetArtifactsResult> {
+  const result: ResetArtifactsResult = { deleted: 0, alreadyMissing: 0, errors: [] };
+
+  const guild = await client.guilds.fetch(config.guildId).catch(() => null);
+  if (!guild) {
+    result.errors.push({
+      kind: 'guild',
+      id: config.guildId,
+      message: `Could not fetch guild ${config.guildId}`,
+    });
+    return result;
+  }
+
+  const artifacts = collectArtifactIds(db);
+  logger.info('TestData', `Cleaning up ${artifacts.length} Discord artifacts before DB wipe`);
+
+  for (const art of artifacts) {
+    try {
+      const outcome = art.parentId
+        ? await deleteMessage(guild, art.id, art.parentId)
+        : await deleteChannelOrThread(guild, art.id);
+      if (outcome === 'deleted') result.deleted++;
+      else result.alreadyMissing++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      result.errors.push({ kind: art.kind, id: art.id, message });
+      // Keep going so a single bad artifact doesn't hide systemic issues
+      // from the summary. The caller still aborts the DB wipe if errors > 0.
+    }
+  }
+
+  return result;
+}

--- a/tests/unit/testdata.test.ts
+++ b/tests/unit/testdata.test.ts
@@ -10,7 +10,7 @@ import { seedTrial } from '../../src/functions/testdata/seedTrial.js';
 import { seedEpgp } from '../../src/functions/testdata/seedEpgp.js';
 import { seedLoot } from '../../src/functions/testdata/seedLoot.js';
 import { seedLootDiscord } from '../../src/functions/testdata/discord/seedLootDiscord.js';
-import { resetData } from '../../src/functions/testdata/resetData.js';
+import { resetData, ResetDiscordError } from '../../src/functions/testdata/resetData.js';
 import type { Client } from 'discord.js';
 
 let db: Database.Database;
@@ -517,7 +517,7 @@ describe('seedLootDiscord (graceful degradation)', () => {
 // ─── resetData ───────────────────────────────────────────────────────────────
 
 describe('resetData', () => {
-  it('clears all data and re-seeds defaults', () => {
+  it('clears all data and re-seeds defaults', async () => {
     // Seed some data first
     seedDatabase(db);
     seedRaiders(db);
@@ -529,8 +529,8 @@ describe('resetData', () => {
     expect((db.prepare('SELECT COUNT(*) as count FROM raiders').get() as { count: number }).count).toBeGreaterThan(0);
     expect((db.prepare('SELECT COUNT(*) as count FROM loot_posts').get() as { count: number }).count).toBeGreaterThan(0);
 
-    // Reset
-    resetData(db);
+    // Reset (no client → DB-only path)
+    await resetData(db);
 
     // All user data cleared
     expect((db.prepare('SELECT COUNT(*) as count FROM raiders').get() as { count: number }).count).toBe(0);
@@ -540,51 +540,51 @@ describe('resetData', () => {
     expect((db.prepare('SELECT COUNT(*) as count FROM trial_alerts').get() as { count: number }).count).toBe(0);
   });
 
-  it('re-seeds default guild_info_content after reset', () => {
-    resetData(db);
+  it('re-seeds default guild_info_content after reset', async () => {
+    await resetData(db);
 
     const count = (db.prepare('SELECT COUNT(*) as count FROM guild_info_content').get() as { count: number }).count;
     expect(count).toBeGreaterThan(0);
   });
 
-  it('re-seeds schedule defaults after reset', () => {
-    resetData(db);
+  it('re-seeds schedule defaults after reset', async () => {
+    await resetData(db);
 
     const days = (db.prepare('SELECT COUNT(*) as count FROM schedule_days').get() as { count: number }).count;
     expect(days).toBeGreaterThan(0);
   });
 
-  it('re-seeds default_messages after reset', () => {
-    resetData(db);
+  it('re-seeds default_messages after reset', async () => {
+    await resetData(db);
 
     const msgs = (db.prepare('SELECT COUNT(*) as count FROM default_messages').get() as { count: number }).count;
     expect(msgs).toBeGreaterThan(0);
   });
 
-  it('re-seeds the 9 default application questions after reset', () => {
+  it('re-seeds the 9 default application questions after reset', async () => {
     // Pollute the DB first so we know the count didn't just carry over
     seedApplication(db);
 
-    resetData(db);
+    await resetData(db);
 
     const count = (db.prepare('SELECT COUNT(*) as count FROM application_questions').get() as { count: number }).count;
     expect(count).toBe(9);
   });
 
-  it('can be called on an already-empty database', () => {
-    expect(() => resetData(db)).not.toThrow();
+  it('can be called on an already-empty database', async () => {
+    await expect(resetData(db)).resolves.toBeDefined();
   });
 
-  it('allows seeding data again after reset', () => {
+  it('allows seeding data again after reset', async () => {
     seedRaiders(db);
-    resetData(db);
+    await resetData(db);
     expect(() => seedRaiders(db)).not.toThrow();
 
     const count = (db.prepare('SELECT COUNT(*) as count FROM raiders').get() as { count: number }).count;
     expect(count).toBe(15);
   });
 
-  it('does not trip FK constraints when a trial references an application', () => {
+  it('does not trip FK constraints when a trial references an application', async () => {
     // Production turns foreign_keys ON (see src/database/db.ts). The default
     // test DB does not, which is why #39 slipped past the existing tests.
     // Build a fresh DB with FKs enabled and reproduce the seed_all shape:
@@ -596,7 +596,7 @@ describe('resetData', () => {
     const app = seedApplication(fkDb, { status: 'accepted' });
     seedTrial(fkDb, { applicationId: app.applicationId });
 
-    expect(() => resetData(fkDb)).not.toThrow();
+    await expect(resetData(fkDb)).resolves.toBeDefined();
 
     expect(
       (fkDb.prepare('SELECT COUNT(*) as count FROM trials').get() as { count: number }).count,
@@ -607,5 +607,71 @@ describe('resetData', () => {
     ).toBe(0);
 
     fkDb.close();
+  });
+
+  it('returns { discord: null } when no client is provided', async () => {
+    const result = await resetData(db);
+    expect(result.discord).toBeNull();
+  });
+
+  it('does NOT wipe the DB when Discord cleanup errors (rollback)', async () => {
+    // Seed some data that should survive the aborted reset.
+    seedRaiders(db);
+    seedApplication(db);
+    const raidersBefore = (db.prepare('SELECT COUNT(*) as count FROM raiders').get() as { count: number }).count;
+    const appsBefore = (db.prepare('SELECT COUNT(*) as count FROM applications').get() as { count: number }).count;
+    expect(raidersBefore).toBeGreaterThan(0);
+    expect(appsBefore).toBeGreaterThan(0);
+
+    // Pretend there's a loot_posts row so there's at least one artifact to
+    // try to delete. resetDiscordArtifacts will fail to fetch the parent
+    // channel and that failure will surface as a real error (not a 404),
+    // which should abort the reset.
+    db.prepare(`INSERT INTO loot_posts (boss_id, boss_name, channel_id, message_id) VALUES (?, ?, ?, ?)`)
+      .run(99999, 'mock', 'parent-channel-id', 'some-message-id');
+
+    // Minimal mock: guild.fetch resolves, guild.channels.fetch rejects with a
+    // non-404 error.
+    const mockGuild = {
+      channels: {
+        fetch: async () => {
+          throw new Error('simulated rate limit or permission error');
+        },
+      },
+    };
+    const mockClient = {
+      guilds: {
+        fetch: async () => mockGuild,
+      },
+    } as unknown as Client;
+
+    await expect(resetData(db, mockClient)).rejects.toBeInstanceOf(ResetDiscordError);
+
+    // DB state should be untouched.
+    const raidersAfter = (db.prepare('SELECT COUNT(*) as count FROM raiders').get() as { count: number }).count;
+    const appsAfter = (db.prepare('SELECT COUNT(*) as count FROM applications').get() as { count: number }).count;
+    expect(raidersAfter).toBe(raidersBefore);
+    expect(appsAfter).toBe(appsBefore);
+    expect(
+      (db.prepare('SELECT COUNT(*) as count FROM loot_posts').get() as { count: number }).count,
+    ).toBe(1);
+  });
+
+  it('wipes the DB when Discord cleanup succeeds (empty artifact set)', async () => {
+    seedRaiders(db);
+
+    // Mock client that successfully fetches a guild with no artifacts to
+    // delete (there are no rows referencing Discord IDs).
+    const mockClient = {
+      guilds: { fetch: async () => ({ channels: { fetch: async () => null } }) },
+    } as unknown as Client;
+
+    const result = await resetData(db, mockClient);
+
+    expect(result.discord).not.toBeNull();
+    expect(result.discord?.errors).toEqual([]);
+    expect(
+      (db.prepare('SELECT COUNT(*) as count FROM raiders').get() as { count: number }).count,
+    ).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #30.

## Summary
`/testdata reset` now cleans up the Discord artifacts created by seed commands (forum threads, per-applicant channels, voting embeds, loot messages, linking messages, guild-info messages) *before* wiping the DB, so the guild matches the database after reseed.

If Discord cleanup errors with anything other than a 404, the DB wipe is **aborted** and a `ResetDiscordError` is thrown — we never leave the DB wiped with Discord artifacts still dangling.

## Answers to the issue's open questions
- **Safety guard (always delete vs flag)?** → **Always delete.** Per user direction, reset should always produce a consistent Discord+DB state. No `purge_discord` flag.
- **Scope (seed-level vs also infra)?** → **Seed-level only.** Infrastructure channels (bot-logs, raider-setup, application-log forum, Applications category) are NOT deleted. Only artifacts that have an ID recorded in the DB.
- **Error handling?** → **Rollback on error.** 404-ish errors (Unknown Channel/Guild/Message) are treated as "already gone" and counted separately. Every other Discord API error (permissions, rate limit, transport) blocks the DB wipe.

## Changes
- New `src/functions/testdata/resetDiscordArtifacts.ts`: snapshots IDs from the DB, deletes each, accumulates errors, returns `{ deleted, alreadyMissing, errors }`. Continues past a single failure so systemic issues aren't hidden.
- `resetData` is now `async` and takes an optional `client`. Throws `ResetDiscordError` (exported) when Discord cleanup has non-404 errors; the DB stays untouched.
- `/testdata reset` handler passes `interaction.client`, surfaces per-artifact failures in the abort message so the operator can see what went wrong without grepping logs.
- Unit tests migrated to await; added a rollback test (verifies DB is preserved when cleanup fails) and a happy-path test (empty artifact set via mock client).

## What gets cleaned
| Table | Column | Artifact |
|---|---|---|
| `applications` | `channel_id` | `app-{name}` text channel |
| `applications` | `forum_post_id`, `thread_id` | application-log forum thread |
| `trials` | `thread_id` | trial-reviews forum thread |
| `promote_alerts` | `thread_id` | promotion-decision thread |
| `loot_posts` | `channel_id` + `message_id` | loot-channel message |
| `raiders` | `message_id` | linking message in raider-setup |
| `guild_info_messages` | `message_id` | About Us / Schedule / Recruitment posts |

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 238/238 pass (2 new: rollback + empty-artifact-set via mock client)
- [ ] Chrome/dev-guild: `/testdata seed_all discord:True` then `/testdata reset confirm:True` → guild is actually clean
- [ ] Force a cleanup error (e.g. revoke Manage Channels, seed, then reset) → DB remains intact, reset reports per-artifact failures

## Follow-ups
- Depends on #43 (FK delete order) for the repro scenario where a seeded trial references a seeded application. If #43 merges first, this PR rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)