### PR TITLE
feat(test): /test command for manual trigger of scheduled work (#35)

### DIFF
--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -165,47 +165,48 @@ const TRIGGERS: Record<string, TriggerDef> = {
   },
 };
 
-// Discord caps slash-command choice names at 100 chars. Fail fast at module
-// load if a label ever drifts past that so the command doesn't silently fail
-// to register. Fix the label rather than silently slicing — a truncated name
-// can collide with another label's prefix.
-for (const [key, def] of Object.entries(TRIGGERS)) {
-  if (def.label.length > 100) {
-    throw new Error(
-      `/test trigger: label for "${key}" is ${def.label.length} chars (max 100). Shorten the label.`,
-    );
-  }
-}
-
-const TRIGGER_CHOICES = Object.entries(TRIGGERS).map(([value, def]) => ({
-  name: def.label,
-  value,
-}));
-
-// Hard-fail at module load if we ever drift past Discord's 25-choice limit.
-if (TRIGGER_CHOICES.length > 25) {
-  throw new Error(
-    `/test trigger has ${TRIGGER_CHOICES.length} choices but Discord allows max 25; switch to autocomplete.`,
-  );
-}
-
-// Fail fast on duplicate choice names — Discord rejects the registration
-// silently otherwise.
+// Build the choice list with graceful degradation. Each TRIGGERS entry must
+// satisfy Discord's constraints: name ≤ 100 chars, names unique, and ≤ 25
+// choices total. Previously the module threw on a violation, which crashed
+// the whole bot on startup for a single bad trigger. Now we warn and skip
+// the offending entry so the rest of the command still registers. Developers
+// see the warn and fix the TRIGGERS map; users see the still-working command.
+const TRIGGER_CHOICES: { name: string; value: string }[] = [];
 {
   const seenNames = new Set<string>();
-  for (const { name } of TRIGGER_CHOICES) {
-    if (seenNames.has(name)) {
-      throw new Error(`/test trigger choice name "${name}" is duplicated; tighten labels in TRIGGERS.`);
+  for (const [key, def] of Object.entries(TRIGGERS)) {
+    if (def.label.length > 100) {
+      logger.warn(
+        'TestTrigger',
+        `Skipping trigger "${key}": label is ${def.label.length} chars (Discord max 100). Shorten the label to register it.`,
+      );
+      continue;
     }
-    seenNames.add(name);
+    if (seenNames.has(def.label)) {
+      logger.warn(
+        'TestTrigger',
+        `Skipping trigger "${key}": duplicate label "${def.label}". Tighten labels in TRIGGERS.`,
+      );
+      continue;
+    }
+    if (TRIGGER_CHOICES.length >= 25) {
+      logger.warn(
+        'TestTrigger',
+        `Skipping trigger "${key}": Discord allows max 25 choices; switch to autocomplete instead of the choice list.`,
+      );
+      continue;
+    }
+    seenNames.add(def.label);
+    TRIGGER_CHOICES.push({ name: def.label, value: key });
   }
 }
 
-// Discord's code-block terminator is three backticks. If an error message
-// contains the same sequence, the reply's formatting breaks. Replace with a
-// visually similar but inert substitute.
+// Zero-width space between the three backticks neutralizes a triple-backtick
+// sequence inside an error message without visually mangling it the way
+// replacing with ''' does. The code block closes cleanly.
+const ZWSP = '\u200B';
 function sanitizeForCodeBlock(text: string): string {
-  return text.replace(/```/g, "'''");
+  return text.replace(/```/g, `\`\`${ZWSP}\``);
 }
 
 function formatDuration(ms: number): string {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -328,11 +328,13 @@ export default {
         const result = await fireTrialAlertsNow(interaction.client, trialId);
         const elapsed = formatDuration(Date.now() - started);
         await audit(interaction.user, 'fired trial alerts', `#${trialId} (${trial.character_name})`);
+        const total = result.reviewAlertsFired + result.promoteAlertsFired;
         const parts = [
-          `✓ Fired **${result.fired}** pending alert(s) for trial #${trialId} (${trial.character_name}) in ${elapsed}.`,
+          `✓ Fired **${total}** pending alert(s) for trial #${trialId} (${trial.character_name}) in ${elapsed}. ` +
+            `(${result.reviewAlertsFired} review, ${result.promoteAlertsFired} promote)`,
         ];
         if (result.alreadyFired > 0) {
-          parts.push(`_${result.alreadyFired} alert(s) had already fired previously and were not re-sent._`);
+          parts.push(`_${result.alreadyFired} review alert(s) had already fired previously and were not re-sent._`);
         }
         if (trial.status !== 'active') {
           parts.push(`_Note: trial status is \`${trial.status}\`; fireAlert short-circuits for non-active trials, so most alerts were likely no-ops._`);

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -85,9 +85,13 @@ const TRIGGERS: Record<string, TriggerDef> = {
   // ─── Dynamic / startup work ────────────────────────────────
   rescheduleAllAlerts: {
     label: 'Startup: rescheduleAllAlerts',
-    description: 'Rebuild in-memory timers for every pending trial alert.',
+    // rescheduleAllAlerts is synchronous but kicks off past-due alert fires
+    // in the background via void fireAlert(...). Flag that in the reply so
+    // the reported duration isn't mistaken for actual work done.
+    description: 'Rebuild in-memory timers for pending trial alerts. Past-due alerts fire asynchronously — the reported duration covers scheduling only.',
     handler: async (client) => {
       rescheduleAllAlerts(client);
+      return 'timers rebuilt; any past-due alerts are firing in the background';
     },
   },
   resumeSessions: {
@@ -144,26 +148,37 @@ const TRIGGERS: Record<string, TriggerDef> = {
   },
   warcraftlogsPing: {
     label: 'Probe: warcraftlogs',
-    description: 'Fetch logs for a single character to verify credentials/endpoint.',
+    description: 'Fetch logs for an existing raider to verify credentials/endpoint. Requires at least one raider in the DB.',
     handler: async () => {
-      // Pick any raider to probe with. If no raiders exist, pick a well-known
-      // test character so the probe still exercises auth + the query path.
       const db = getDatabase();
       const row = db
         .prepare(`SELECT character_name FROM raiders LIMIT 1`)
         .get() as { character_name: string } | undefined;
-      const probeName = row?.character_name ?? 'Testcharacter';
-      const logs = await getTrialLogs(probeName);
-      return `ok (${logs.length} report(s) for ${probeName})`;
+      if (!row) {
+        // Probing with a fabricated name exercises auth but floods logs with
+        // "character not found" noise. Surface the empty state instead.
+        throw new Error('No raiders in DB to probe with — seed one first');
+      }
+      const logs = await getTrialLogs(row.character_name);
+      return `ok (${logs.length} report(s) for ${row.character_name})`;
     },
   },
 };
 
+// Discord caps slash-command choice names at 100 chars. Fail fast at module
+// load if a label ever drifts past that so the command doesn't silently fail
+// to register. Fix the label rather than silently slicing — a truncated name
+// can collide with another label's prefix.
+for (const [key, def] of Object.entries(TRIGGERS)) {
+  if (def.label.length > 100) {
+    throw new Error(
+      `/test trigger: label for "${key}" is ${def.label.length} chars (max 100). Shorten the label.`,
+    );
+  }
+}
+
 const TRIGGER_CHOICES = Object.entries(TRIGGERS).map(([value, def]) => ({
-  // Discord caps choice names at 100 chars. Slicing keeps registration from
-  // failing if a future label drifts long; the uniqueness check below is what
-  // actually matters — duplicate names would break command registration.
-  name: def.label.slice(0, 100),
+  name: def.label,
   value,
 }));
 
@@ -174,8 +189,8 @@ if (TRIGGER_CHOICES.length > 25) {
   );
 }
 
-// And fail fast if two actions ever end up with the same (sliced) choice name,
-// since Discord rejects the command registration silently in that case.
+// Fail fast on duplicate choice names — Discord rejects the registration
+// silently otherwise.
 {
   const seenNames = new Set<string>();
   for (const { name } of TRIGGER_CHOICES) {
@@ -242,9 +257,19 @@ export default {
         '',
         `**/test fire_trial_alert trial_id:<n>** — fire pending review alerts for trial #n immediately.`,
       );
+      let description = lines.join('\n');
+      const EMBED_DESC_LIMIT = 4096;
+      if (description.length > EMBED_DESC_LIMIT) {
+        // Truncate on a line boundary where possible and flag the truncation
+        // explicitly so triggers don't silently disappear from the list.
+        const notice = '\n\n_…list truncated; see /test trigger autocomplete for the rest._';
+        const budget = EMBED_DESC_LIMIT - notice.length;
+        const lastNewline = description.lastIndexOf('\n', budget);
+        description = description.slice(0, lastNewline > 0 ? lastNewline : budget) + notice;
+      }
       const embed = new EmbedBuilder()
         .setTitle(`Available triggers (${Object.keys(TRIGGERS).length})`)
-        .setDescription(lines.join('\n').slice(0, 4096));
+        .setDescription(description);
       await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
       return;
     }

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -261,12 +261,19 @@ export default {
       let description = lines.join('\n');
       const EMBED_DESC_LIMIT = 4096;
       if (description.length > EMBED_DESC_LIMIT) {
-        // Truncate on a line boundary where possible and flag the truncation
-        // explicitly so triggers don't silently disappear from the list.
-        const notice = '\n\n_…list truncated; see /test trigger autocomplete for the rest._';
+        // Walk lines and stop before overflow; no mid-line slice possible.
+        // The `action` option uses a static choice list (capped at 25), so a
+        // trigger missing from this description is also missing from the
+        // dropdown — point the user at the source for the full set.
+        const notice = '\n\n_…list truncated; see TRIGGERS in `src/commands/test.ts` for the full set._';
         const budget = EMBED_DESC_LIMIT - notice.length;
-        const lastNewline = description.lastIndexOf('\n', budget);
-        description = description.slice(0, lastNewline > 0 ? lastNewline : budget) + notice;
+        let truncated = '';
+        for (const line of lines) {
+          const candidate = truncated ? `${truncated}\n${line}` : line;
+          if (candidate.length > budget) break;
+          truncated = candidate;
+        }
+        description = truncated + notice;
       }
       const embed = new EmbedBuilder()
         .setTitle(`Available triggers (${Object.keys(TRIGGERS).length})`)

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,0 +1,291 @@
+import {
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  type Client,
+  MessageFlags,
+  PermissionFlagsBits,
+} from 'discord.js';
+import { requireOfficer } from '../utils.js';
+import { audit } from '../services/auditLog.js';
+import { logger } from '../services/logger.js';
+import { getDatabase } from '../database/db.js';
+
+// Scheduled / background handlers we want manual triggers for (#35).
+import { syncRaiders } from '../functions/raids/syncRaiders.js';
+import { refreshLinkingMessages } from '../functions/raids/refreshLinkingMessages.js';
+import { alertSignups } from '../functions/raids/alertSignups.js';
+import { alertHighestMythicPlusDone } from '../functions/raids/alertHighestMythicPlusDone.js';
+import { updateAchievements } from '../functions/guild-info/updateAchievements.js';
+import { updateAboutUs } from '../functions/guild-info/updateAboutUs.js';
+import { updateSchedule } from '../functions/guild-info/updateSchedule.js';
+import { updateRecruitment } from '../functions/guild-info/updateRecruitment.js';
+import { updateTrialLogs } from '../functions/trial-review/updateTrialLogs.js';
+import { rescheduleAllAlerts, fireTrialAlertsNow } from '../functions/trial-review/scheduleTrialAlerts.js';
+import { resumeSessions } from '../functions/applications/resumeSessions.js';
+import { dailyBackup } from '../functions/backups/dailyBackup.js';
+import { deployCommands } from '../deploy-commands.js';
+import { checkRaidExpansions } from '../functions/loot/checkRaidExpansions.js';
+
+// External service probes (no side effects — used to verify credentials/endpoints).
+import { getUpcomingRaids } from '../services/wowaudit.js';
+import { getGuildRoster } from '../services/raiderio.js';
+import { getTrialLogs } from '../services/warcraftlogs.js';
+
+interface TriggerDef {
+  label: string;
+  description: string;
+  // Returns a one-line status suffix (optional detail). Errors thrown here are
+  // caught by the command wrapper and reported to the invoker.
+  handler: (client: Client) => Promise<string | void>;
+}
+
+// The `value` is the choice key Discord sends back to us.
+// Keep under 25 (Discord's hard limit on choice count per option).
+const TRIGGERS: Record<string, TriggerDef> = {
+  // ─── Scheduled intervals ───────────────────────────────────
+  syncRaiders: {
+    label: 'Interval: syncRaiders (10 min)',
+    description: 'Full roster sync from wowaudit into the raiders table.',
+    handler: async (client) => { await syncRaiders(client); },
+  },
+  refreshLinkingMessages: {
+    label: 'Interval: refreshLinkingMessages (10 min)',
+    description: 'Re-post stale linking messages in #raider-setup.',
+    handler: async (client) => { await refreshLinkingMessages(client); },
+  },
+  updateAchievements: {
+    label: 'Interval: updateAchievements (30 min)',
+    description: 'Recompute and re-post the achievements embed.',
+    handler: async (client) => { await updateAchievements(client); },
+  },
+  updateTrialLogs: {
+    label: 'Interval: updateTrialLogs (1 hour)',
+    description: 'Regenerate logs for each active trial thread.',
+    handler: async (client) => { await updateTrialLogs(client); },
+  },
+
+  // ─── Scheduled crons ───────────────────────────────────────
+  alertSignups: {
+    label: 'Cron: alertSignups (Mon/Tue/Fri/Sat 19:00)',
+    description: 'Ping raiders who haven\'t signed up yet for the next raid.',
+    handler: async (client) => { await alertSignups(client); },
+  },
+  weeklyReports: {
+    label: 'Cron: weeklyReports (Wed 12:00)',
+    description: 'Post the weekly M+ / Great Vault report.',
+    handler: async (client) => { await alertHighestMythicPlusDone(client); },
+  },
+  dailyBackup: {
+    label: 'Cron: dailyBackup (daily 04:00)',
+    description: 'Snapshot the SQLite DB to the backups folder.',
+    handler: async () => { await dailyBackup(); },
+  },
+
+  // ─── Dynamic / startup work ────────────────────────────────
+  rescheduleAllAlerts: {
+    label: 'Startup: rescheduleAllAlerts',
+    description: 'Rebuild in-memory timers for every pending trial alert.',
+    handler: async (client) => {
+      rescheduleAllAlerts(client);
+    },
+  },
+  resumeSessions: {
+    label: 'Startup: resumeSessions',
+    description: 'Re-enter DM questionnaire state for in-progress applications.',
+    handler: async (client) => { await resumeSessions(client); },
+  },
+  deployCommands: {
+    label: 'Startup: deployCommands',
+    description: 'Re-register all slash commands with Discord.',
+    handler: async () => { await deployCommands(); },
+  },
+
+  // ─── Guild info (individual updaters, complement /guildinfo) ──
+  updateAboutUs: {
+    label: 'Guild info: updateAboutUs',
+    description: 'Post / refresh the About Us embed only.',
+    handler: async (client) => { await updateAboutUs(client); },
+  },
+  updateSchedule: {
+    label: 'Guild info: updateSchedule',
+    description: 'Post / refresh the Schedule embed only.',
+    handler: async (client) => { await updateSchedule(client); },
+  },
+  updateRecruitment: {
+    label: 'Guild info: updateRecruitment',
+    description: 'Post / refresh the Recruitment embed only.',
+    handler: async (client) => { await updateRecruitment(client); },
+  },
+
+  // ─── Loot maintenance ──────────────────────────────────────
+  checkRaidExpansions: {
+    label: 'Loot: checkRaidExpansions',
+    description: 'Ensure a loot post exists for every boss of the current tier.',
+    handler: async (client) => { await checkRaidExpansions(client); },
+  },
+
+  // ─── External service probes ───────────────────────────────
+  wowauditPing: {
+    label: 'Probe: wowaudit',
+    description: 'Fetch upcoming raids from wowaudit to verify credentials/endpoint.',
+    handler: async () => {
+      const raids = await getUpcomingRaids();
+      return `ok (${raids.length} upcoming raid(s))`;
+    },
+  },
+  raiderioPing: {
+    label: 'Probe: raiderio',
+    description: 'Fetch the guild roster from raider.io to verify endpoint.',
+    handler: async () => {
+      const roster = await getGuildRoster();
+      return `ok (${roster.length} member(s))`;
+    },
+  },
+  warcraftlogsPing: {
+    label: 'Probe: warcraftlogs',
+    description: 'Fetch logs for a single character to verify credentials/endpoint.',
+    handler: async () => {
+      // Pick any raider to probe with. If no raiders exist, pick a well-known
+      // test character so the probe still exercises auth + the query path.
+      const db = getDatabase();
+      const row = db
+        .prepare(`SELECT character_name FROM raiders LIMIT 1`)
+        .get() as { character_name: string } | undefined;
+      const probeName = row?.character_name ?? 'Testcharacter';
+      const logs = await getTrialLogs(probeName);
+      return `ok (${logs.length} report(s) for ${probeName})`;
+    },
+  },
+};
+
+const TRIGGER_CHOICES = Object.entries(TRIGGERS).map(([value, def]) => ({
+  name: def.label.slice(0, 100),
+  value,
+}));
+
+// Hard-fail at module load if we ever drift past Discord's 25-choice limit.
+if (TRIGGER_CHOICES.length > 25) {
+  throw new Error(
+    `/test trigger has ${TRIGGER_CHOICES.length} choices but Discord allows max 25; switch to autocomplete.`,
+  );
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = (ms / 1000).toFixed(2);
+  return `${s}s`;
+}
+
+export default {
+  devOnly: true,
+  data: new SlashCommandBuilder()
+    .setName('test')
+    .setDescription('Dev-only: manually trigger scheduled actions and background work')
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+    .addSubcommand((sub) =>
+      sub
+        .setName('trigger')
+        .setDescription('Fire a scheduled or background action immediately')
+        .addStringOption((opt) =>
+          opt
+            .setName('action')
+            .setDescription('The action to trigger')
+            .setRequired(true)
+            .addChoices(...TRIGGER_CHOICES),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('fire_trial_alert')
+        .setDescription('Fire every pending review alert for a specific trial immediately')
+        .addIntegerOption((opt) =>
+          opt.setName('trial_id').setDescription('Trial ID').setRequired(true).setMinValue(1),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub.setName('list').setDescription('List every available trigger (for discovery)'),
+    ),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    if (!(await requireOfficer(interaction))) return;
+
+    const sub = interaction.options.getSubcommand();
+
+    if (sub === 'list') {
+      const lines = Object.values(TRIGGERS).map((t) => `- **${t.label}** — ${t.description}`);
+      lines.push('', `**/test fire_trial_alert trial_id:<n>** — fire pending review alerts for trial #n immediately.`);
+      await interaction.reply({
+        content: `**Available triggers (${Object.keys(TRIGGERS).length}):**\n${lines.join('\n')}`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    if (sub === 'trigger') {
+      const action = interaction.options.getString('action', true);
+      const def = TRIGGERS[action];
+      if (!def) {
+        await interaction.editReply({ content: `Unknown action: \`${action}\`.` });
+        return;
+      }
+
+      const started = Date.now();
+      try {
+        const detail = await def.handler(interaction.client);
+        const elapsed = formatDuration(Date.now() - started);
+        const detailSuffix = typeof detail === 'string' && detail.length > 0 ? ` — ${detail}` : '';
+        const message = `✓ **${def.label}** ran in ${elapsed}${detailSuffix}.`;
+        logger.info('TestTrigger', `${action} ok (${elapsed})`);
+        await audit(interaction.user, 'triggered test action', action);
+        await interaction.editReply({ content: message });
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        const elapsed = formatDuration(Date.now() - started);
+        logger.error('TestTrigger', `${action} failed after ${elapsed}: ${error.message}`, error);
+        await interaction.editReply({
+          content: `✗ **${def.label}** failed after ${elapsed}.\n\`\`\`\n${error.message.slice(0, 1500)}\n\`\`\``,
+        });
+      }
+      return;
+    }
+
+    if (sub === 'fire_trial_alert') {
+      const trialId = interaction.options.getInteger('trial_id', true);
+      const db = getDatabase();
+      const trial = db
+        .prepare(`SELECT id, character_name, status FROM trials WHERE id = ?`)
+        .get(trialId) as { id: number; character_name: string; status: string } | undefined;
+      if (!trial) {
+        await interaction.editReply({ content: `No trial with id \`${trialId}\`.` });
+        return;
+      }
+
+      const started = Date.now();
+      try {
+        const result = await fireTrialAlertsNow(interaction.client, trialId);
+        const elapsed = formatDuration(Date.now() - started);
+        await audit(interaction.user, 'fired trial alerts', `#${trialId} (${trial.character_name})`);
+        const parts = [
+          `✓ Fired **${result.fired}** pending alert(s) for trial #${trialId} (${trial.character_name}) in ${elapsed}.`,
+        ];
+        if (result.alreadyFired > 0) {
+          parts.push(`_${result.alreadyFired} alert(s) had already fired previously and were not re-sent._`);
+        }
+        if (trial.status !== 'active') {
+          parts.push(`_Note: trial status is \`${trial.status}\`; fireAlert short-circuits for non-active trials, so most alerts were likely no-ops._`);
+        }
+        await interaction.editReply({ content: parts.join('\n') });
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        const elapsed = formatDuration(Date.now() - started);
+        logger.error('TestTrigger', `fire_trial_alert ${trialId} failed after ${elapsed}: ${error.message}`, error);
+        await interaction.editReply({
+          content: `✗ fire_trial_alert #${trialId} failed after ${elapsed}.\n\`\`\`\n${error.message.slice(0, 1500)}\n\`\`\``,
+        });
+      }
+      return;
+    }
+  },
+};

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -2,6 +2,7 @@ import {
   SlashCommandBuilder,
   type ChatInputCommandInteraction,
   type Client,
+  EmbedBuilder,
   MessageFlags,
   PermissionFlagsBits,
 } from 'discord.js';
@@ -159,6 +160,9 @@ const TRIGGERS: Record<string, TriggerDef> = {
 };
 
 const TRIGGER_CHOICES = Object.entries(TRIGGERS).map(([value, def]) => ({
+  // Discord caps choice names at 100 chars. Slicing keeps registration from
+  // failing if a future label drifts long; the uniqueness check below is what
+  // actually matters — duplicate names would break command registration.
   name: def.label.slice(0, 100),
   value,
 }));
@@ -168,6 +172,25 @@ if (TRIGGER_CHOICES.length > 25) {
   throw new Error(
     `/test trigger has ${TRIGGER_CHOICES.length} choices but Discord allows max 25; switch to autocomplete.`,
   );
+}
+
+// And fail fast if two actions ever end up with the same (sliced) choice name,
+// since Discord rejects the command registration silently in that case.
+{
+  const seenNames = new Set<string>();
+  for (const { name } of TRIGGER_CHOICES) {
+    if (seenNames.has(name)) {
+      throw new Error(`/test trigger choice name "${name}" is duplicated; tighten labels in TRIGGERS.`);
+    }
+    seenNames.add(name);
+  }
+}
+
+// Discord's code-block terminator is three backticks. If an error message
+// contains the same sequence, the reply's formatting breaks. Replace with a
+// visually similar but inert substitute.
+function sanitizeForCodeBlock(text: string): string {
+  return text.replace(/```/g, "'''");
 }
 
 function formatDuration(ms: number): string {
@@ -212,12 +235,17 @@ export default {
     const sub = interaction.options.getSubcommand();
 
     if (sub === 'list') {
+      // Use an embed so we can keep adding triggers without bumping into
+      // Discord's 2000-char message limit. Embed description caps at 4096.
       const lines = Object.values(TRIGGERS).map((t) => `- **${t.label}** — ${t.description}`);
-      lines.push('', `**/test fire_trial_alert trial_id:<n>** — fire pending review alerts for trial #n immediately.`);
-      await interaction.reply({
-        content: `**Available triggers (${Object.keys(TRIGGERS).length}):**\n${lines.join('\n')}`,
-        flags: MessageFlags.Ephemeral,
-      });
+      lines.push(
+        '',
+        `**/test fire_trial_alert trial_id:<n>** — fire pending review alerts for trial #n immediately.`,
+      );
+      const embed = new EmbedBuilder()
+        .setTitle(`Available triggers (${Object.keys(TRIGGERS).length})`)
+        .setDescription(lines.join('\n').slice(0, 4096));
+      await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
       return;
     }
 
@@ -245,7 +273,7 @@ export default {
         const elapsed = formatDuration(Date.now() - started);
         logger.error('TestTrigger', `${action} failed after ${elapsed}: ${error.message}`, error);
         await interaction.editReply({
-          content: `✗ **${def.label}** failed after ${elapsed}.\n\`\`\`\n${error.message.slice(0, 1500)}\n\`\`\``,
+          content: `✗ **${def.label}** failed after ${elapsed}.\n\`\`\`\n${sanitizeForCodeBlock(error.message).slice(0, 1500)}\n\`\`\``,
         });
       }
       return;
@@ -282,7 +310,7 @@ export default {
         const elapsed = formatDuration(Date.now() - started);
         logger.error('TestTrigger', `fire_trial_alert ${trialId} failed after ${elapsed}: ${error.message}`, error);
         await interaction.editReply({
-          content: `✗ fire_trial_alert #${trialId} failed after ${elapsed}.\n\`\`\`\n${error.message.slice(0, 1500)}\n\`\`\``,
+          content: `✗ fire_trial_alert #${trialId} failed after ${elapsed}.\n\`\`\`\n${sanitizeForCodeBlock(error.message).slice(0, 1500)}\n\`\`\``,
         });
       }
       return;

--- a/src/functions/trial-review/scheduleTrialAlerts.ts
+++ b/src/functions/trial-review/scheduleTrialAlerts.ts
@@ -151,17 +151,18 @@ async function firePromoteAlert(
 // ─── Manual Trigger (test/dev) ───────────────────────────────
 
 /**
- * Fire every pending (alerted = 0) alert for a trial immediately, bypassing
- * the scheduled timers. Used by the dev-only `/test fire_trial_alert` command
- * so the 7/14/28-day review flow can be verified without waiting days.
+ * Fire every pending alert for a trial immediately, bypassing the scheduled
+ * timers. Covers both trial_alerts (7/14/28-day reviews) and promote_alerts
+ * (promotion-day reminder) — rescheduleAllAlerts handles both, so a manual
+ * trigger for verifying the full flow should too.
  *
- * Returns the count of alerts that were fired and of those still pending,
- * so the caller can report a meaningful status back to the invoker.
+ * Used by the dev-only `/test fire_trial_alert` command so the review flow
+ * can be exercised without waiting days.
  */
 export async function fireTrialAlertsNow(
   client: Client,
   trialId: number,
-): Promise<{ fired: number; alreadyFired: number }> {
+): Promise<{ reviewAlertsFired: number; promoteAlertsFired: number; alreadyFired: number }> {
   const db = getDatabase();
 
   const pending = db
@@ -182,7 +183,26 @@ export async function fireTrialAlertsNow(
     await fireAlert(client, alert);
   }
 
-  return { fired: pending.length, alreadyFired };
+  // Promote alerts don't have an `alerted` flag — firePromoteAlert deletes
+  // the row on success. So "pending" = "row still exists."
+  const pendingPromotes = db
+    .prepare('SELECT * FROM promote_alerts WHERE trial_id = ?')
+    .all(trialId) as PromoteAlertRow[];
+
+  for (const pa of pendingPromotes) {
+    const existing = promoteTimers.get(pa.id);
+    if (existing) {
+      clearTimeout(existing);
+      promoteTimers.delete(pa.id);
+    }
+    await firePromoteAlert(client, pa);
+  }
+
+  return {
+    reviewAlertsFired: pending.length,
+    promoteAlertsFired: pendingPromotes.length,
+    alreadyFired,
+  };
 }
 
 // ─── Schedule Individual Trial Alerts ────────────────────────

--- a/src/functions/trial-review/scheduleTrialAlerts.ts
+++ b/src/functions/trial-review/scheduleTrialAlerts.ts
@@ -148,6 +148,43 @@ async function firePromoteAlert(
   promoteTimers.delete(promoteAlert.id);
 }
 
+// ─── Manual Trigger (test/dev) ───────────────────────────────
+
+/**
+ * Fire every pending (alerted = 0) alert for a trial immediately, bypassing
+ * the scheduled timers. Used by the dev-only `/test fire_trial_alert` command
+ * so the 7/14/28-day review flow can be verified without waiting days.
+ *
+ * Returns the count of alerts that were fired and of those still pending,
+ * so the caller can report a meaningful status back to the invoker.
+ */
+export async function fireTrialAlertsNow(
+  client: Client,
+  trialId: number,
+): Promise<{ fired: number; alreadyFired: number }> {
+  const db = getDatabase();
+
+  const pending = db
+    .prepare('SELECT * FROM trial_alerts WHERE trial_id = ? AND alerted = 0')
+    .all(trialId) as TrialAlertRow[];
+  const alreadyFired = (
+    db
+      .prepare('SELECT COUNT(*) as c FROM trial_alerts WHERE trial_id = ? AND alerted = 1')
+      .get(trialId) as { c: number }
+  ).c;
+
+  for (const alert of pending) {
+    const existing = alertTimers.get(alert.id);
+    if (existing) {
+      clearTimeout(existing);
+      alertTimers.delete(alert.id);
+    }
+    await fireAlert(client, alert);
+  }
+
+  return { fired: pending.length, alreadyFired };
+}
+
 // ─── Schedule Individual Trial Alerts ────────────────────────
 
 /**


### PR DESCRIPTION
Closes #35 (full scope).

## Summary
Dev-only slash command that lets officers fire every scheduled / background action on demand, instead of waiting on cron schedules or restarting the bot.

```
/test trigger action:<choice>
/test fire_trial_alert trial_id:<n>
/test list
```

## Coverage (17 actions, under Discord's 25-choice cap)

| Group | Actions |
|---|---|
| **Intervals** | `syncRaiders`, `refreshLinkingMessages`, `updateAchievements`, `updateTrialLogs` |
| **Crons** | `alertSignups`, `weeklyReports`, `dailyBackup` |
| **Startup / dynamic** | `rescheduleAllAlerts`, `resumeSessions`, `deployCommands` |
| **Guild info (individual)** | `updateAboutUs`, `updateSchedule`, `updateRecruitment` |
| **Loot maintenance** | `checkRaidExpansions` |
| **External service probes** | `wowauditPing`, `raiderioPing`, `warcraftlogsPing` |
| **Trial alerts** | separate subcommand (needs `trial_id`) |

`/test list` dumps the full registry with descriptions so you don't have to memorize the choice names.

## Trial alerts

`fireAlert` in `scheduleTrialAlerts.ts` was internal. Added a thin exported wrapper `fireTrialAlertsNow(client, trialId)` that clears the in-memory timer and awaits `fireAlert` for each unfired row — so `/test fire_trial_alert` doesn't need to poke at module state, and the sequencing stays inside the existing module.

## Reply shape

Every run reports wall-clock duration and catches errors:
- ✓ **Interval: syncRaiders (10 min)** ran in 342ms.
- ✗ **Probe: wowaudit** failed after 1.12s.
  ```
  WoW Audit API error: 401 Unauthorized
  ```

Success is `audit()`ed so officers can see who triggered what. `devOnly: true` mirrors `/testdata` — skipped during `deployCommands()` in production.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 235/235 pass (no new tests; this is almost entirely orchestration of already-tested handlers)
- [ ] Chrome/dev-guild: `/test list` — renders full registry
- [ ] Chrome/dev-guild: `/test trigger` — pick 2-3 actions, verify duration + audit log
- [ ] Chrome/dev-guild: `/test fire_trial_alert` — seed a trial, fire its alerts, verify thread gets the review messages
- [ ] Chrome/dev-guild: `/test trigger action:wowauditPing` with a bad key — verify failure is reported in the reply rather than silent

## Follow-ups
- The `fireAlert` internals still log errors via `logger.error` but also complete without re-throwing (by design: don't let one bad alert break the scheduler). That means some handler failures won't surface to `/test` as a thrown error. Not fixing in this PR — it'd change scheduler semantics. If it matters we can add a return value to `fireAlert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)