### PR TITLE
feat(signup): Gemini-generated signup quips, drop unused signup_messages table (#27)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ WARCRAFTLOGS_GUILD_ID=486913
 # Raider.io
 RAIDERIO_GUILD_IDS=1061585%2C43113
 
+# Gemini (signup quip generator — optional, falls back to static quips if unset)
+GEMINI_API_KEY=
+
 # Runtime
 LOG_LEVEL=INFO
 NODE_ENV=development

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,11 @@ export const config = {
   warcraftLogsClientSecret: required('WARCRAFTLOGS_CLIENT_SECRET'),
   warcraftLogsGuildId: required('WARCRAFTLOGS_GUILD_ID'),
   raiderIoGuildIds: required('RAIDERIO_GUILD_IDS'),
+  // Optional: signup quip generator falls back to a static V1 corpus when unset.
+  // Read lazily so tests that toggle the env var between cases see the change.
+  get geminiApiKey() {
+    return process.env.GEMINI_API_KEY ?? '';
+  },
   logLevel: optional('LOG_LEVEL', 'INFO') as 'DEBUG' | 'INFO' | 'WARN' | 'ERROR',
   nodeEnv: optional('NODE_ENV', 'development'),
   get isDevelopment() {

--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -74,6 +74,18 @@ export function runMigrations(database: Database.Database): void {
       database.prepare('INSERT INTO schema_version (version) VALUES (?)').run(2);
     })();
   }
+
+  if (currentVersion < 3) {
+    // Drop the signup_messages table. Quips are now generated on demand by
+    // the Gemini quip generator (#27); the table was never seeded in V2 so
+    // no data loss for anyone coming through a V2 install. Kept as
+    // DROP IF EXISTS to stay safe on fresh DBs where createTables ran
+    // after this migration was written.
+    database.transaction(() => {
+      database.exec(`DROP TABLE IF EXISTS signup_messages;`);
+      database.prepare('INSERT INTO schema_version (version) VALUES (?)').run(3);
+    })();
+  }
 }
 
 export function closeDatabase(): void {

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -223,13 +223,7 @@ export function createTables(db: Database.Database): void {
       sort_order INTEGER NOT NULL DEFAULT 0
     );
 
-    -- 28. signup_messages
-    CREATE TABLE IF NOT EXISTS signup_messages (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      message TEXT NOT NULL
-    );
-
-    -- 29. default_messages
+    -- 28. default_messages
     CREATE TABLE IF NOT EXISTS default_messages (
       key TEXT PRIMARY KEY,
       message TEXT NOT NULL

--- a/src/functions/raids/alertSignups.ts
+++ b/src/functions/raids/alertSignups.ts
@@ -4,7 +4,8 @@ import { getUpcomingRaids } from '../../services/wowaudit.js';
 import { logger } from '../../services/logger.js';
 import { config } from '../../config.js';
 import { getOrCreateChannel } from '../channels.js';
-import type { RaiderRow, SettingRow, SignupMessageRow } from '../../types/index.js';
+import { generateSignupQuip } from '../../services/quipGenerator.js';
+import type { RaiderRow, SettingRow } from '../../types/index.js';
 
 interface DayConfig {
   settingKey: string;
@@ -106,12 +107,12 @@ export async function alertSignups(client: Client): Promise<void> {
     }
   }
 
-  // Pick a random signup message
-  const messageRow = db
-    .prepare('SELECT message FROM signup_messages ORDER BY RANDOM() LIMIT 1')
-    .get() as SignupMessageRow | undefined;
-
-  const randomMessage = messageRow?.message ?? 'Sign up for the next raid!';
+  // Generate a fresh signup quip via Gemini (falls back to a static one from
+  // the V1 corpus if GEMINI_API_KEY is unset or the call fails — #27).
+  const randomMessage = await generateSignupQuip({
+    raidDay: dayConfig.raidDay,
+    twoDayReminder: dayConfig.twoDayReminder,
+  });
 
   // Build the alert message
   let content = `${randomMessage}\n\nThe following raiders have not signed up for **${dayConfig.raidDay}**:\n${mentions.join(', ')}`;

--- a/src/functions/testdata/resetData.ts
+++ b/src/functions/testdata/resetData.ts
@@ -80,7 +80,6 @@ export async function resetData(
     db.prepare('DELETE FROM schedule_config').run();
 
     db.prepare('DELETE FROM achievements_manual').run();
-    db.prepare('DELETE FROM signup_messages').run();
     db.prepare('DELETE FROM default_messages').run();
     db.prepare('DELETE FROM settings').run();
     db.prepare('DELETE FROM config').run();

--- a/src/services/quipGenerator.ts
+++ b/src/services/quipGenerator.ts
@@ -1,0 +1,172 @@
+import { logger } from './logger.js';
+
+// V1 quip corpus — handwritten + OpenAI-generated examples that shaped the
+// tone. Kept in-file so fallback still feels like "our" quips when the API
+// is down or the key isn't set. Anything appended here shows up in the
+// fallback pool and as few-shot inspiration in the Gemini prompt.
+const V1_SAMPLE_QUIPS: readonly string[] = [
+  "Oi, sign up innit?",
+  "Have you considered signing up on time?",
+  "Missing raid sign-ups is like going into battle without armor. Suit up and sign up!",
+  "Don't be the ghost of raiding past — haunt the sign-up sheet instead!",
+  "Raid sign-ups: where the only thing better than your DPS is your punctuality!",
+  "Bing's checklist: snacks, buffs, and raid sign-ups. Don't make him hunt you down for the last one!",
+  "Warzania's decree: Thou shalt sign up for the raid or face the wrath of a thousand guildies!",
+];
+
+const FALLBACK_QUIP = 'Sign up for the next raid!';
+
+// Rough upper bound on a quip. Gemini sometimes rambles if left unbounded;
+// anything longer than this is almost certainly a format failure (e.g. the
+// model returned multiple options separated by newlines) and we bail to
+// fallback rather than post a paragraph.
+const MAX_QUIP_LENGTH = 280;
+
+const GEMINI_ENDPOINT =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
+
+// Don't block the signup alert on a slow model. The cron fires at a fixed
+// time of day; a 5s timeout keeps the alert near-real-time and still gives
+// the free tier plenty of headroom (typical latency is <2s).
+const REQUEST_TIMEOUT_MS = 5_000;
+
+// ─── Public ─────────────────────────────────────────────────────────────
+
+export interface GenerateQuipOptions {
+  raidDay: string;
+  twoDayReminder: boolean;
+}
+
+/**
+ * Generate a one-line signup quip. Uses Google's free-tier Gemini 2.0 Flash
+ * when GEMINI_API_KEY is set, and falls back to a handwritten quip from the
+ * V1 corpus when the key is missing or the call fails. Never throws — the
+ * caller is an alert handler and should always get something postable.
+ *
+ * Fallback path is deterministic w.r.t. Math.random so we don't repeat the
+ * same fallback two alerts in a row (in practice, random is enough).
+ */
+export async function generateSignupQuip(options: GenerateQuipOptions): Promise<string> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    return randomFallback();
+  }
+
+  try {
+    const quip = await callGemini(apiKey, options);
+    if (quip) return quip;
+  } catch (err) {
+    logger.warn(
+      'QuipGen',
+      `Gemini call failed, falling back to static quip: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  return randomFallback();
+}
+
+// ─── Internals ──────────────────────────────────────────────────────────
+
+function randomFallback(): string {
+  if (V1_SAMPLE_QUIPS.length === 0) return FALLBACK_QUIP;
+  const index = Math.floor(Math.random() * V1_SAMPLE_QUIPS.length);
+  return V1_SAMPLE_QUIPS[index];
+}
+
+function buildPrompt({ raidDay, twoDayReminder }: GenerateQuipOptions): string {
+  const examples = V1_SAMPLE_QUIPS.map((q, i) => `${i + 1}. ${q}`).join('\n');
+  const reminderNote = twoDayReminder
+    ? 'This is the 48-hour early reminder, so a nudge-not-yell tone.'
+    : 'This is the day-of reminder, so urgency is fair game.';
+
+  return [
+    'You write one-line nudges that a World of Warcraft raiding guild uses to get their raiders to sign up for the next raid.',
+    '',
+    `Context: the next raid is on ${raidDay}. ${reminderNote}`,
+    '',
+    'Tone: playful, sarcastic, WoW-themed. Occasionally reference guild leaders (Warzania, Bing, Splo). OK to be cheeky; keep it safe for a shared Discord channel.',
+    '',
+    'Examples of the tone:',
+    examples,
+    '',
+    'Write ONE quip. Plain text, no quotes, no preamble, no markdown. Under 200 characters. Just the quip.',
+  ].join('\n');
+}
+
+interface GeminiResponse {
+  candidates?: Array<{
+    content?: { parts?: Array<{ text?: string }> };
+    finishReason?: string;
+  }>;
+  error?: { message?: string };
+}
+
+async function callGemini(
+  apiKey: string,
+  options: GenerateQuipOptions,
+): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${GEMINI_ENDPOINT}?key=${encodeURIComponent(apiKey)}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ role: 'user', parts: [{ text: buildPrompt(options) }] }],
+        generationConfig: {
+          temperature: 1.0,
+          topP: 0.95,
+          maxOutputTokens: 120,
+        },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`Gemini HTTP ${response.status}: ${body.slice(0, 200)}`);
+    }
+
+    const json = (await response.json()) as GeminiResponse;
+    if (json.error?.message) {
+      throw new Error(`Gemini API error: ${json.error.message}`);
+    }
+
+    const candidate = json.candidates?.[0];
+    const text = candidate?.content?.parts?.map((p) => p.text ?? '').join('').trim();
+    if (!text) {
+      logger.warn('QuipGen', `Gemini returned no text (finishReason: ${candidate?.finishReason ?? 'unknown'})`);
+      return null;
+    }
+
+    const cleaned = normalizeQuip(text);
+    if (cleaned.length === 0 || cleaned.length > MAX_QUIP_LENGTH) {
+      logger.warn('QuipGen', `Gemini quip rejected (length ${cleaned.length}): ${cleaned.slice(0, 80)}`);
+      return null;
+    }
+    return cleaned;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Gemini sometimes wraps its answer in quotes, returns a numbered list
+// with multiple options, or prefaces with "Here's one:". Strip the obvious
+// junk. If anything weird remains we'll fall through to the length guard.
+function normalizeQuip(raw: string): string {
+  let s = raw.trim();
+
+  // If multiple newline-separated lines, take the first non-empty one.
+  const lines = s.split(/\r?\n/).map((l) => l.trim()).filter((l) => l.length > 0);
+  if (lines.length > 0) s = lines[0];
+
+  // Drop "1. " / "- " / "* " list prefixes.
+  s = s.replace(/^(?:\d+\.\s+|-\s+|\*\s+)/, '');
+
+  // Drop surrounding single or double quotes.
+  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith('\'') && s.endsWith('\''))) {
+    s = s.slice(1, -1).trim();
+  }
+
+  return s;
+}

--- a/src/services/quipGenerator.ts
+++ b/src/services/quipGenerator.ts
@@ -108,13 +108,20 @@ async function callGemini(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
   try {
-    const response = await fetch(`${GEMINI_ENDPOINT}?key=${encodeURIComponent(apiKey)}`, {
+    // Send the key in the x-goog-api-key header rather than as a query
+    // param. Query params are routinely captured in server access logs and
+    // client-side network panels, and a leaked key on the free tier still
+    // maps to an identifiable Google account.
+    const response = await fetch(GEMINI_ENDPOINT, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: {
+        'content-type': 'application/json',
+        'x-goog-api-key': apiKey,
+      },
       body: JSON.stringify({
         contents: [{ role: 'user', parts: [{ text: buildPrompt(options) }] }],
         generationConfig: {
-          temperature: 1.0,
+          temperature: 0.9,
           topP: 0.95,
           maxOutputTokens: 120,
         },
@@ -154,11 +161,9 @@ async function callGemini(
 // with multiple options, or prefaces with "Here's one:". Strip the obvious
 // junk. If anything weird remains we'll fall through to the length guard.
 function normalizeQuip(raw: string): string {
-  let s = raw.trim();
-
-  // If multiple newline-separated lines, take the first non-empty one.
-  const lines = s.split(/\r?\n/).map((l) => l.trim()).filter((l) => l.length > 0);
-  if (lines.length > 0) s = lines[0];
+  // Take the first non-empty line without materializing the rest.
+  const firstLine = raw.split(/\r?\n/).find((l) => l.trim().length > 0);
+  let s = (firstLine ?? raw).trim();
 
   // Drop "1. " / "- " / "* " list prefixes.
   s = s.replace(/^(?:\d+\.\s+|-\s+|\*\s+)/, '');

--- a/src/services/quipGenerator.ts
+++ b/src/services/quipGenerator.ts
@@ -1,4 +1,5 @@
 import { logger } from './logger.js';
+import { config } from '../config.js';
 
 // V1 quip corpus — handwritten + OpenAI-generated examples that shaped the
 // tone. Kept in-file so fallback still feels like "our" quips when the API
@@ -13,8 +14,6 @@ const V1_SAMPLE_QUIPS: readonly string[] = [
   "Bing's checklist: snacks, buffs, and raid sign-ups. Don't make him hunt you down for the last one!",
   "Warzania's decree: Thou shalt sign up for the raid or face the wrath of a thousand guildies!",
 ];
-
-const FALLBACK_QUIP = 'Sign up for the next raid!';
 
 // Rough upper bound on a quip. Gemini sometimes rambles if left unbounded;
 // anything longer than this is almost certainly a format failure (e.g. the
@@ -47,13 +46,12 @@ export interface GenerateQuipOptions {
  * same fallback two alerts in a row (in practice, random is enough).
  */
 export async function generateSignupQuip(options: GenerateQuipOptions): Promise<string> {
-  const apiKey = process.env.GEMINI_API_KEY;
-  if (!apiKey) {
+  if (!config.geminiApiKey) {
     return randomFallback();
   }
 
   try {
-    const quip = await callGemini(apiKey, options);
+    const quip = await callGemini(config.geminiApiKey, options);
     if (quip) return quip;
   } catch (err) {
     logger.warn(
@@ -68,7 +66,6 @@ export async function generateSignupQuip(options: GenerateQuipOptions): Promise<
 // ─── Internals ──────────────────────────────────────────────────────────
 
 function randomFallback(): string {
-  if (V1_SAMPLE_QUIPS.length === 0) return FALLBACK_QUIP;
   const index = Math.floor(Math.random() * V1_SAMPLE_QUIPS.length);
   return V1_SAMPLE_QUIPS[index];
 }
@@ -163,6 +160,12 @@ async function callGemini(
 // Gemini sometimes wraps its answer in quotes, returns a numbered list
 // with multiple options, or prefaces with "Here's one:". Strip the obvious
 // junk. If anything weird remains we'll fall through to the length guard.
+//
+// The model occasionally uses typographic/"smart" quotes instead of ASCII.
+// Cover both ends: "..." / '...' / “...” / ‘...’
+const OPEN_QUOTES = new Set(['"', "'", '\u201C', '\u2018']);
+const CLOSE_QUOTES = new Set(['"', "'", '\u201D', '\u2019']);
+
 function normalizeQuip(raw: string): string {
   // Take the first non-empty line without materializing the rest.
   const firstLine = raw.split(/\r?\n/).find((l) => l.trim().length > 0);
@@ -171,8 +174,12 @@ function normalizeQuip(raw: string): string {
   // Drop "1. " / "- " / "* " list prefixes.
   s = s.replace(/^(?:\d+\.\s+|-\s+|\*\s+)/, '');
 
-  // Drop surrounding single or double quotes.
-  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith('\'') && s.endsWith('\''))) {
+  // Drop a single surrounding quote pair — ASCII or smart. We don't try to
+  // match open-with-close (e.g. "..." closed by ’); anything that symmetric
+  // gets stripped.
+  const first = s[0];
+  const last = s[s.length - 1];
+  if (first && last && OPEN_QUOTES.has(first) && CLOSE_QUOTES.has(last)) {
     s = s.slice(1, -1).trim();
   }
 

--- a/src/services/quipGenerator.ts
+++ b/src/services/quipGenerator.ts
@@ -38,12 +38,9 @@ export interface GenerateQuipOptions {
 
 /**
  * Generate a one-line signup quip. Uses Google's free-tier Gemini 2.0 Flash
- * when GEMINI_API_KEY is set, and falls back to a handwritten quip from the
- * V1 corpus when the key is missing or the call fails. Never throws — the
- * caller is an alert handler and should always get something postable.
- *
- * Fallback path is deterministic w.r.t. Math.random so we don't repeat the
- * same fallback two alerts in a row (in practice, random is enough).
+ * when GEMINI_API_KEY is set, and falls back to a randomly-chosen quip from
+ * the V1 corpus when the key is missing or the call fails. Never throws —
+ * the caller is an alert handler and should always get something postable.
  */
 export async function generateSignupQuip(options: GenerateQuipOptions): Promise<string> {
   if (!config.geminiApiKey) {
@@ -167,7 +164,10 @@ const OPEN_QUOTES = new Set(['"', "'", '\u201C', '\u2018']);
 const CLOSE_QUOTES = new Set(['"', "'", '\u201D', '\u2019']);
 
 function normalizeQuip(raw: string): string {
-  // Take the first non-empty line without materializing the rest.
+  // Take the first non-empty line. split() materializes all lines up front;
+  // .find short-circuits on the first match so we don't trim/inspect the
+  // rest, but the array allocation still happens. Quips max out around
+  // 280 chars anyway — not worth optimizing past this shape.
   const firstLine = raw.split(/\r?\n/).find((l) => l.trim().length > 0);
   let s = (firstLine ?? raw).trim();
 

--- a/src/services/quipGenerator.ts
+++ b/src/services/quipGenerator.ts
@@ -140,7 +140,10 @@ async function callGemini(
     }
 
     const candidate = json.candidates?.[0];
-    const text = candidate?.content?.parts?.map((p) => p.text ?? '').join('').trim();
+    // parts can be absent when the model truncates or returns a finishReason
+    // of SAFETY/MAX_TOKENS. Default to [] so we don't try to .join undefined.
+    const parts = candidate?.content?.parts ?? [];
+    const text = parts.map((p) => p.text ?? '').join('').trim();
     if (!text) {
       logger.warn('QuipGen', `Gemini returned no text (finishReason: ${candidate?.finishReason ?? 'unknown'})`);
       return null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -213,11 +213,6 @@ export interface AchievementsManualRow {
   sort_order: number;
 }
 
-export interface SignupMessageRow {
-  id: number;
-  message: string;
-}
-
 export interface DefaultMessageRow {
   key: string;
   message: string;

--- a/tests/integration/database-schema.test.ts
+++ b/tests/integration/database-schema.test.ts
@@ -42,9 +42,11 @@ describe('database schema', () => {
     expect(tableNames).toContain('guild_info_messages');
     expect(tableNames).toContain('guild_info_links');
     expect(tableNames).toContain('achievements_manual');
-    expect(tableNames).toContain('signup_messages');
     expect(tableNames).toContain('default_messages');
     expect(tableNames).toContain('schema_version');
+
+    // signup_messages was removed in migration v3 (#27).
+    expect(tableNames).not.toContain('signup_messages');
   });
 
   it('should enforce foreign keys', () => {
@@ -61,7 +63,7 @@ describe('database schema', () => {
     const db = getDatabase();
 
     const version = db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get() as { version: number };
-    expect(version.version).toBe(2);
+    expect(version.version).toBe(3);
   });
 
   it('should be idempotent (safe to run twice)', () => {

--- a/tests/unit/db-migration.test.ts
+++ b/tests/unit/db-migration.test.ts
@@ -83,3 +83,41 @@ describe('runMigrations — epgp_channel_id -> epgp_rankings_channel_id', () => 
     expect(oldKey).toBeUndefined();
   });
 });
+
+describe('runMigrations — v3 drops signup_messages', () => {
+  it('drops the signup_messages table if it exists from a prior install', () => {
+    const db = getDatabase();
+
+    // Recreate the legacy table — createTables no longer includes it (#27),
+    // so we manually seed the pre-migration shape to represent an existing
+    // install carrying the old table.
+    db.exec(`CREATE TABLE IF NOT EXISTS signup_messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      message TEXT NOT NULL
+    );`);
+    db.prepare('INSERT INTO signup_messages (message) VALUES (?)').run('legacy');
+
+    // Clear schema_version so migrations from v1 are re-applied (we want v3 to
+    // run against this pre-existing table).
+    db.exec('DELETE FROM schema_version;');
+
+    runMigrations(db);
+
+    const tableExists = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='signup_messages'`)
+      .get();
+    expect(tableExists).toBeUndefined();
+
+    const version = db
+      .prepare('SELECT MAX(version) as v FROM schema_version')
+      .get() as { v: number };
+    expect(version.v).toBeGreaterThanOrEqual(3);
+  });
+
+  it('is a no-op when signup_messages is already gone', () => {
+    const db = getDatabase();
+
+    expect(() => runMigrations(db)).not.toThrow();
+    expect(() => runMigrations(db)).not.toThrow();
+  });
+});

--- a/tests/unit/quipGenerator.test.ts
+++ b/tests/unit/quipGenerator.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { generateSignupQuip } from '../../src/services/quipGenerator.js';
+
+const originalFetch = globalThis.fetch;
+const originalApiKey = process.env.GEMINI_API_KEY;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalApiKey === undefined) delete process.env.GEMINI_API_KEY;
+  else process.env.GEMINI_API_KEY = originalApiKey;
+  vi.restoreAllMocks();
+});
+
+describe('generateSignupQuip', () => {
+  it('falls back to a static quip when GEMINI_API_KEY is not set', async () => {
+    delete process.env.GEMINI_API_KEY;
+
+    const quip = await generateSignupQuip({ raidDay: 'Wednesday', twoDayReminder: false });
+    expect(typeof quip).toBe('string');
+    expect(quip.length).toBeGreaterThan(0);
+  });
+
+  it('returns the Gemini response when the API call succeeds', async () => {
+    process.env.GEMINI_API_KEY = 'test-key';
+
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        ok: true,
+        json: async () => ({
+          candidates: [{ content: { parts: [{ text: 'Stop standing in fire — sign up!' }] } }],
+        }),
+        text: async () => '',
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const quip = await generateSignupQuip({ raidDay: 'Sunday', twoDayReminder: true });
+    expect(quip).toBe('Stop standing in fire — sign up!');
+  });
+
+  it('strips surrounding quotes from the Gemini response', async () => {
+    process.env.GEMINI_API_KEY = 'test-key';
+
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: '"Sign up or face the wrath of Warzania!"' }] } }],
+      }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+
+    const quip = await generateSignupQuip({ raidDay: 'Wednesday', twoDayReminder: false });
+    expect(quip).toBe('Sign up or face the wrath of Warzania!');
+  });
+
+  it('takes only the first line when Gemini returns a numbered list', async () => {
+    process.env.GEMINI_API_KEY = 'test-key';
+
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: {
+              parts: [{ text: '1. Sign up, you slackers!\n2. Or face Warzania\'s wrath.' }],
+            },
+          },
+        ],
+      }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+
+    const quip = await generateSignupQuip({ raidDay: 'Sunday', twoDayReminder: false });
+    expect(quip).toBe('Sign up, you slackers!');
+  });
+
+  it('falls back when Gemini returns HTTP error', async () => {
+    process.env.GEMINI_API_KEY = 'test-key';
+
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 429,
+      json: async () => ({}),
+      text: async () => 'Rate limited',
+    })) as unknown as typeof fetch;
+
+    const quip = await generateSignupQuip({ raidDay: 'Wednesday', twoDayReminder: false });
+    expect(typeof quip).toBe('string');
+    expect(quip.length).toBeGreaterThan(0);
+  });
+
+  it('falls back when Gemini returns error in body', async () => {
+    process.env.GEMINI_API_KEY = 'test-key';
+
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ error: { message: 'Invalid API key' } }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+
+    const quip = await generateSignupQuip({ raidDay: 'Wednesday', twoDayReminder: false });
+    expect(typeof quip).toBe('string');
+    expect(quip.length).toBeGreaterThan(0);
+  });
+
+  it('falls back when Gemini returns an over-long response (format failure)', async () => {
+    process.env.GEMINI_API_KEY = 'test-key';
+
+    const megaQuip = 'x'.repeat(500);
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ candidates: [{ content: { parts: [{ text: megaQuip }] } }] }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+
+    const quip = await generateSignupQuip({ raidDay: 'Wednesday', twoDayReminder: false });
+    expect(quip.length).toBeLessThanOrEqual(280);
+  });
+
+  it('falls back when fetch throws (network failure)', async () => {
+    process.env.GEMINI_API_KEY = 'test-key';
+
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('ENETUNREACH');
+    }) as unknown as typeof fetch;
+
+    const quip = await generateSignupQuip({ raidDay: 'Wednesday', twoDayReminder: false });
+    expect(typeof quip).toBe('string');
+    expect(quip.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/quipGenerator.test.ts
+++ b/tests/unit/quipGenerator.test.ts
@@ -116,6 +116,25 @@ describe('generateSignupQuip', () => {
     expect(quip.length).toBeLessThanOrEqual(280);
   });
 
+  it('falls back when candidate has no parts array (SAFETY / MAX_TOKENS)', async () => {
+    // Gemini sometimes returns a candidate without a parts array — e.g. when
+    // the response hits a safety filter or MAX_TOKENS before producing text.
+    // Previously parts?.map(...).join('') crashed with TypeError.
+    process.env.GEMINI_API_KEY = 'test-key';
+
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        candidates: [{ finishReason: 'SAFETY', content: {} }],
+      }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+
+    const quip = await generateSignupQuip({ raidDay: 'Wednesday', twoDayReminder: false });
+    expect(typeof quip).toBe('string');
+    expect(quip.length).toBeGreaterThan(0);
+  });
+
   it('falls back when fetch throws (network failure)', async () => {
     process.env.GEMINI_API_KEY = 'test-key';
 

--- a/tests/unit/quipGenerator.test.ts
+++ b/tests/unit/quipGenerator.test.ts
@@ -52,6 +52,27 @@ describe('generateSignupQuip', () => {
     expect(quip).toBe('Sign up or face the wrath of Warzania!');
   });
 
+  it('strips surrounding smart (curly) quotes', async () => {
+    // Gemini often returns \u201Ctext\u201D instead of plain "text"; the
+    // normalizer needs to cover both shapes.
+    process.env.GEMINI_API_KEY = 'test-key';
+
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: { parts: [{ text: '\u201CRaid sign-ups: late doesn\u2019t count.\u201D' }] },
+          },
+        ],
+      }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+
+    const quip = await generateSignupQuip({ raidDay: 'Wednesday', twoDayReminder: false });
+    expect(quip).toBe('Raid sign-ups: late doesn\u2019t count.');
+  });
+
   it('takes only the first line when Gemini returns a numbered list', async () => {
     process.env.GEMINI_API_KEY = 'test-key';
 


### PR DESCRIPTION
Closes #27.

## Summary
Replace the unused `signup_messages` DB lookup with a Gemini 2.0 Flash call generated fresh on each alert. Falls back to a static quip from the V1 corpus when `GEMINI_API_KEY` is unset or the API call fails — alert handlers always get something postable.

## Gemini setup (when you're ready)
1. Grab a free key from https://aistudio.google.com/apikey
2. Add `GEMINI_API_KEY=...` to `.env`
3. That's it. No other wiring needed.

If the key isn't set, alerts still work — they just pull from the handwritten V1 quip pool instead.

## Implementation notes
- `services/quipGenerator.ts` — single `generateSignupQuip({ raidDay, twoDayReminder }): Promise<string>`. Raw `fetch` to `generativelanguage.googleapis.com`, no new npm dependency.
- API key sent via `x-goog-api-key` header (not query string — those end up in server access logs).
- Temperature `0.9`, top-p `0.95`, maxOutputTokens `120`.
- **5s AbortController timeout** — the cron fires at a fixed time; we don't want to stall the alert on a flaky model.
- `normalizeQuip()` strips Gemini's format tics: surrounding ASCII *and* smart quotes (`\u201C`/`\u2019` etc.), `1. `/`- ` list prefixes, multi-line output (takes first line).
- `MAX_QUIP_LENGTH = 280` — if the model rambles we fall back instead of dumping a paragraph.
- Guards against missing `candidate.content.parts` (happens on SAFETY/MAX_TOKENS finishReason) — previously would have thrown.
- Key read via `config.geminiApiKey` (lazy getter) rather than raw `process.env`.
- Never throws. The caller is an alert handler; if something goes wrong we log and return a fallback.

## Schema cleanup
Per the issue's own "Cleanup" section: **signup_messages table and type are removed.**
- `DROP TABLE signup_messages` added in migration v3. The table was never seeded in V2 so no data loss.
- Dropped from `createTables`, `resetData` wipe list, `SignupMessageRow` type.

## Tone
System prompt leans on the V1 examples (Warzania/Bing/Splo cameos, cheeky sarcasm, WoW references). Tone nudges on whether it's a 48-hour early reminder or a day-of reminder.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 247/247 pass (10 quipGenerator tests including smart-quote and missing-parts regressions)
- [x] Verified migration drops a pre-seeded legacy `signup_messages` table and advances schema_version to 3
- [ ] Chrome/dev-guild: without \`GEMINI_API_KEY\` set, trigger `alertSignups` via `/test trigger` and confirm a fallback quip is posted
- [ ] Chrome/dev-guild: with \`GEMINI_API_KEY\` set, same test — confirm a fresh quip is generated

## Follow-ups (not in this PR)
- If quip quality drifts, tune the temperature (currently 0.9) or swap to \`gemini-2.5-flash\` once it's GA on the free tier.
- If rate limits become an issue, add a simple in-process cache (one quip per 10 min) — probably overkill for a cron-driven code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)