### PR TITLE
feat(api-health): shared httpClient with retry + per-service breaker

### DIFF
--- a/docs/superpowers/plans/2026-04-19-api-health-and-retry.md
+++ b/docs/superpowers/plans/2026-04-19-api-health-and-retry.md
@@ -1,0 +1,2113 @@
+# API Health & Retry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route all external HTTP calls (Raider.io, WarcraftLogs, wowaudit) through a shared client that applies timeouts, retries, exponential backoff, per-service circuit breakers, and records health into an in-memory rolling tracker surfaced through `/status`.
+
+**Architecture:** Two new service modules (`httpClient`, `apiHealth`) compose: `httpClient` owns the request lifecycle and delegates breaker state + outcome recording to `apiHealth`. The three existing service files are refactored to replace `fetch` with `httpRequest`. `/status` gains an "API Health (last hour)" section. User-invoked commands that hit an open breaker get a friendlier message via `interactionCreate`.
+
+**Tech Stack:** TypeScript (strict, ESM, nodenext module resolution), Node 22 native `fetch` + `AbortSignal.timeout`, Vitest with `vi.useFakeTimers()` for time-based tests, Discord.js v14 embed fields.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-api-health-and-retry-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `src/services/apiHealth.ts` — tracker state + breaker state machine. Exposes `recordOutcome`, `getSummary`, `getAllSummaries`, `isBreakerOpen`, `onBreakerTrialResult`, `noteFailure`, `noteSuccess`, and (for tests only) `__resetForTests`.
+- `src/services/httpClient.ts` — `httpRequest<T>` wrapper. Exports `HttpError`, `CircuitOpenError`, `ServiceName` type.
+- `tests/unit/apiHealth.test.ts`
+- `tests/unit/httpClient.test.ts`
+
+**Modified files:**
+- `src/services/raiderio.ts` — 4 `fetch` sites → `httpRequest`.
+- `src/services/wowaudit.ts` — 3 `fetch` sites → `httpRequest`.
+- `src/services/warcraftlogs.ts` — OAuth POST + GraphQL POST via `httpRequest`; `getTrialLogs` catches `HttpError`/`CircuitOpenError` at its boundary and returns `[]`.
+- `src/commands/status.ts` — appends "API Health (last hour)" section.
+- `src/events/interactionCreate.ts` — ChatInput error handler adds `CircuitOpenError` branch.
+- `tests/unit/raiderio.test.ts` — 5xx single-call assertions updated to expect retries; error-message assertions updated for `HttpError` shape.
+- `tests/unit/wowaudit.test.ts` — same updates.
+
+---
+
+## Task 1: apiHealth — tracker core (no breaker yet)
+
+**Files:**
+- Create: `src/services/apiHealth.ts`
+- Test: `tests/unit/apiHealth.test.ts`
+
+- [ ] **Step 1: Write failing tests for the tracker core**
+
+Create `tests/unit/apiHealth.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  recordOutcome,
+  getSummary,
+  getAllSummaries,
+  __resetForTests,
+} from '../../src/services/apiHealth.js';
+
+beforeEach(() => {
+  __resetForTests();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-19T12:00:00Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('apiHealth tracker core', () => {
+  it('starts with zeroed totals and closed breaker', () => {
+    const s = getSummary('raiderio');
+    expect(s.totals).toEqual({
+      ok: 0, retried: 0, rateLimited: 0, timeouts: 0, failed: 0, circuitRejected: 0,
+    });
+    expect(s.breaker).toBe('closed');
+    expect(s.lastError).toBeUndefined();
+  });
+
+  it('accumulates outcomes in the current minute bucket', () => {
+    recordOutcome('raiderio', 'ok');
+    recordOutcome('raiderio', 'ok');
+    recordOutcome('raiderio', 'retried');
+    recordOutcome('raiderio', 'failed', { msg: 'boom', status: 500 });
+
+    const s = getSummary('raiderio');
+    expect(s.totals.ok).toBe(2);
+    expect(s.totals.retried).toBe(1);
+    expect(s.totals.failed).toBe(1);
+    expect(s.lastError).toEqual({
+      msg: 'boom',
+      status: 500,
+      at: new Date('2026-04-19T12:00:00Z'),
+    });
+  });
+
+  it('evicts buckets older than 60 minutes', () => {
+    recordOutcome('raiderio', 'ok');
+
+    vi.setSystemTime(new Date('2026-04-19T12:59:59Z'));
+    expect(getSummary('raiderio').totals.ok).toBe(1);
+
+    vi.setSystemTime(new Date('2026-04-19T13:00:01Z'));
+    expect(getSummary('raiderio').totals.ok).toBe(0);
+  });
+
+  it('keeps per-service state isolated', () => {
+    recordOutcome('raiderio', 'ok');
+    recordOutcome('wowaudit', 'failed', { msg: 'x' });
+
+    expect(getSummary('raiderio').totals.ok).toBe(1);
+    expect(getSummary('raiderio').totals.failed).toBe(0);
+    expect(getSummary('wowaudit').totals.ok).toBe(0);
+    expect(getSummary('wowaudit').totals.failed).toBe(1);
+  });
+
+  it('getAllSummaries returns an entry per known service', () => {
+    const all = getAllSummaries();
+    expect(Object.keys(all).sort()).toEqual(['raiderio', 'warcraftlogs', 'wowaudit']);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/apiHealth.test.ts`
+Expected: FAIL — module `../../src/services/apiHealth.js` not found.
+
+- [ ] **Step 3: Implement the tracker core**
+
+Create `src/services/apiHealth.ts`:
+
+```ts
+export type ServiceName = 'raiderio' | 'warcraftlogs' | 'wowaudit';
+
+export type Outcome =
+  | 'ok'
+  | 'retried'
+  | 'rate_limited'
+  | 'timeout'
+  | 'failed'
+  | 'circuit_rejected';
+
+export type BreakerState = 'closed' | 'half_open' | 'open';
+
+export interface ErrorDetail {
+  msg: string;
+  status?: number;
+}
+
+interface MinuteBucket {
+  minuteEpoch: number;
+  counts: Record<Outcome, number>;
+}
+
+interface ServiceState {
+  buckets: MinuteBucket[];
+  lastError?: { msg: string; status?: number; at: Date };
+  breaker: {
+    state: BreakerState;
+    openedAt?: Date;
+    consecutiveFailures: number;
+  };
+}
+
+export interface ServiceSummary {
+  totals: {
+    ok: number;
+    retried: number;
+    rateLimited: number;
+    timeouts: number;
+    failed: number;
+    circuitRejected: number;
+  };
+  lastError?: { msg: string; status?: number; at: Date };
+  breaker: BreakerState;
+}
+
+const SERVICES: ServiceName[] = ['raiderio', 'warcraftlogs', 'wowaudit'];
+const WINDOW_MINUTES = 60;
+
+function emptyBucketCounts(): Record<Outcome, number> {
+  return {
+    ok: 0,
+    retried: 0,
+    rate_limited: 0,
+    timeout: 0,
+    failed: 0,
+    circuit_rejected: 0,
+  };
+}
+
+function freshState(): ServiceState {
+  return {
+    buckets: [],
+    breaker: { state: 'closed', consecutiveFailures: 0 },
+  };
+}
+
+const state = new Map<ServiceName, ServiceState>();
+for (const s of SERVICES) state.set(s, freshState());
+
+function currentMinute(): number {
+  return Math.floor(Date.now() / 60_000);
+}
+
+function getOrCreateBucket(svc: ServiceState): MinuteBucket {
+  const minute = currentMinute();
+  let bucket = svc.buckets[svc.buckets.length - 1];
+  if (!bucket || bucket.minuteEpoch !== minute) {
+    bucket = { minuteEpoch: minute, counts: emptyBucketCounts() };
+    svc.buckets.push(bucket);
+  }
+  // Evict buckets older than WINDOW_MINUTES
+  const cutoff = minute - WINDOW_MINUTES + 1;
+  while (svc.buckets.length > 0 && svc.buckets[0].minuteEpoch < cutoff) {
+    svc.buckets.shift();
+  }
+  return bucket;
+}
+
+function evict(svc: ServiceState): void {
+  const cutoff = currentMinute() - WINDOW_MINUTES + 1;
+  while (svc.buckets.length > 0 && svc.buckets[0].minuteEpoch < cutoff) {
+    svc.buckets.shift();
+  }
+}
+
+export function recordOutcome(
+  service: ServiceName,
+  outcome: Outcome,
+  errorDetail?: ErrorDetail,
+): void {
+  const svc = state.get(service);
+  if (!svc) return;
+  const bucket = getOrCreateBucket(svc);
+  bucket.counts[outcome] += 1;
+  if (errorDetail) {
+    svc.lastError = { ...errorDetail, at: new Date() };
+  }
+}
+
+export function getSummary(service: ServiceName): ServiceSummary {
+  const svc = state.get(service);
+  if (!svc) {
+    return {
+      totals: { ok: 0, retried: 0, rateLimited: 0, timeouts: 0, failed: 0, circuitRejected: 0 },
+      breaker: 'closed',
+    };
+  }
+  evict(svc);
+
+  const totals = {
+    ok: 0,
+    retried: 0,
+    rateLimited: 0,
+    timeouts: 0,
+    failed: 0,
+    circuitRejected: 0,
+  };
+  for (const b of svc.buckets) {
+    totals.ok += b.counts.ok;
+    totals.retried += b.counts.retried;
+    totals.rateLimited += b.counts.rate_limited;
+    totals.timeouts += b.counts.timeout;
+    totals.failed += b.counts.failed;
+    totals.circuitRejected += b.counts.circuit_rejected;
+  }
+
+  return {
+    totals,
+    lastError: svc.lastError,
+    breaker: svc.breaker.state,
+  };
+}
+
+export function getAllSummaries(): Record<ServiceName, ServiceSummary> {
+  return {
+    raiderio: getSummary('raiderio'),
+    warcraftlogs: getSummary('warcraftlogs'),
+    wowaudit: getSummary('wowaudit'),
+  };
+}
+
+// Test-only: reset all in-memory state.
+export function __resetForTests(): void {
+  state.clear();
+  for (const s of SERVICES) state.set(s, freshState());
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run tests/unit/apiHealth.test.ts`
+Expected: PASS — 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/apiHealth.ts tests/unit/apiHealth.test.ts
+git commit -m "feat(api-health): in-memory rolling tracker with 60-min sliding window"
+```
+
+---
+
+## Task 2: apiHealth — circuit breaker state machine
+
+**Files:**
+- Modify: `src/services/apiHealth.ts`
+- Test: `tests/unit/apiHealth.test.ts`
+
+- [ ] **Step 1: Add failing breaker tests**
+
+Append to `tests/unit/apiHealth.test.ts`:
+
+```ts
+import {
+  isBreakerOpen,
+  noteFailure,
+  noteSuccess,
+  onBreakerTrialResult,
+} from '../../src/services/apiHealth.js';
+
+describe('apiHealth breaker', () => {
+  it('opens after 5 consecutive failures', () => {
+    for (let i = 0; i < 4; i++) noteFailure('raiderio');
+    expect(isBreakerOpen('raiderio')).toBe(false);
+    expect(getSummary('raiderio').breaker).toBe('closed');
+
+    noteFailure('raiderio');
+    expect(isBreakerOpen('raiderio')).toBe(true);
+    expect(getSummary('raiderio').breaker).toBe('open');
+  });
+
+  it('resets consecutive failures on success', () => {
+    for (let i = 0; i < 4; i++) noteFailure('raiderio');
+    noteSuccess('raiderio');
+    for (let i = 0; i < 4; i++) noteFailure('raiderio');
+    expect(isBreakerOpen('raiderio')).toBe(false);
+
+    noteFailure('raiderio');
+    expect(isBreakerOpen('raiderio')).toBe(true);
+  });
+
+  it('transitions open -> half_open after 60s cooldown', () => {
+    for (let i = 0; i < 5; i++) noteFailure('raiderio');
+    expect(getSummary('raiderio').breaker).toBe('open');
+
+    vi.setSystemTime(new Date('2026-04-19T12:00:59Z'));
+    expect(isBreakerOpen('raiderio')).toBe(true);
+
+    vi.setSystemTime(new Date('2026-04-19T12:01:00Z'));
+    expect(isBreakerOpen('raiderio')).toBe(false);
+    expect(getSummary('raiderio').breaker).toBe('half_open');
+  });
+
+  it('half_open -> closed on trial success, resets counter', () => {
+    for (let i = 0; i < 5; i++) noteFailure('raiderio');
+    vi.setSystemTime(new Date('2026-04-19T12:01:00Z'));
+    expect(getSummary('raiderio').breaker).toBe('half_open');
+
+    onBreakerTrialResult('raiderio', true);
+    expect(getSummary('raiderio').breaker).toBe('closed');
+
+    for (let i = 0; i < 4; i++) noteFailure('raiderio');
+    expect(isBreakerOpen('raiderio')).toBe(false);
+  });
+
+  it('half_open -> open on trial failure, cooldown resets', () => {
+    for (let i = 0; i < 5; i++) noteFailure('raiderio');
+    vi.setSystemTime(new Date('2026-04-19T12:01:00Z'));
+    expect(getSummary('raiderio').breaker).toBe('half_open');
+
+    onBreakerTrialResult('raiderio', false);
+    expect(getSummary('raiderio').breaker).toBe('open');
+
+    vi.setSystemTime(new Date('2026-04-19T12:01:59Z'));
+    expect(isBreakerOpen('raiderio')).toBe(true);
+    vi.setSystemTime(new Date('2026-04-19T12:02:00Z'));
+    expect(isBreakerOpen('raiderio')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/apiHealth.test.ts`
+Expected: FAIL — `isBreakerOpen`, `noteFailure`, `noteSuccess`, `onBreakerTrialResult` not exported.
+
+- [ ] **Step 3: Implement breaker in `apiHealth.ts`**
+
+Add near the top of `src/services/apiHealth.ts` after the `WINDOW_MINUTES` constant:
+
+```ts
+const BREAKER_OPEN_THRESHOLD = 5;
+const BREAKER_COOLDOWN_MS = 60_000;
+```
+
+Append these exported functions to `src/services/apiHealth.ts` (after `__resetForTests`):
+
+```ts
+export function noteFailure(service: ServiceName): void {
+  const svc = state.get(service);
+  if (!svc) return;
+  svc.breaker.consecutiveFailures += 1;
+  if (
+    svc.breaker.state === 'closed' &&
+    svc.breaker.consecutiveFailures >= BREAKER_OPEN_THRESHOLD
+  ) {
+    svc.breaker.state = 'open';
+    svc.breaker.openedAt = new Date();
+  }
+}
+
+export function noteSuccess(service: ServiceName): void {
+  const svc = state.get(service);
+  if (!svc) return;
+  svc.breaker.consecutiveFailures = 0;
+}
+
+export function isBreakerOpen(service: ServiceName): boolean {
+  const svc = state.get(service);
+  if (!svc) return false;
+
+  if (svc.breaker.state === 'open' && svc.breaker.openedAt) {
+    const elapsed = Date.now() - svc.breaker.openedAt.getTime();
+    if (elapsed >= BREAKER_COOLDOWN_MS) {
+      svc.breaker.state = 'half_open';
+      return false;
+    }
+    return true;
+  }
+
+  // half_open and closed both permit a request attempt.
+  return false;
+}
+
+export function onBreakerTrialResult(service: ServiceName, success: boolean): void {
+  const svc = state.get(service);
+  if (!svc) return;
+  if (svc.breaker.state !== 'half_open') return;
+
+  if (success) {
+    svc.breaker.state = 'closed';
+    svc.breaker.openedAt = undefined;
+    svc.breaker.consecutiveFailures = 0;
+  } else {
+    svc.breaker.state = 'open';
+    svc.breaker.openedAt = new Date();
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run tests/unit/apiHealth.test.ts`
+Expected: PASS — 10 tests pass (5 core + 5 breaker).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/apiHealth.ts tests/unit/apiHealth.test.ts
+git commit -m "feat(api-health): per-service circuit breaker state machine"
+```
+
+---
+
+## Task 3: httpClient — skeleton + happy path + typed errors
+
+**Files:**
+- Create: `src/services/httpClient.ts`
+- Test: `tests/unit/httpClient.test.ts`
+
+- [ ] **Step 1: Write failing tests for the happy path and non-retryable errors**
+
+Create `tests/unit/httpClient.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { __resetForTests } from '../../src/services/apiHealth.js';
+import {
+  httpRequest,
+  HttpError,
+} from '../../src/services/httpClient.js';
+import { getSummary } from '../../src/services/apiHealth.js';
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  __resetForTests();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-19T12:00:00Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+function mockResponse(init: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  json?: unknown;
+  headers?: Record<string, string>;
+}): Response {
+  const headers = new Headers(init.headers);
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    statusText: init.statusText ?? 'OK',
+    headers,
+    json: async () => init.json ?? {},
+  } as unknown as Response;
+}
+
+describe('httpRequest — happy path', () => {
+  it('returns parsed JSON on 200', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({ ok: true, json: { hello: 'world' } }),
+    );
+
+    const result = await httpRequest<{ hello: string }>('raiderio', 'https://x.test/');
+    expect(result).toEqual({ hello: 'world' });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('records an ok outcome on success', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({ ok: true, json: {} }));
+    await httpRequest('raiderio', 'https://x.test/');
+    expect(getSummary('raiderio').totals.ok).toBe(1);
+  });
+});
+
+describe('httpRequest — non-retryable failures', () => {
+  it.each([400, 401, 403, 404, 410, 422])(
+    'throws HttpError immediately on %s without retry',
+    async (status) => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse({ ok: false, status, statusText: 'Bad' }),
+      );
+      globalThis.fetch = fetchMock;
+
+      await expect(httpRequest('raiderio', 'https://x.test/')).rejects.toBeInstanceOf(
+        HttpError,
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('HttpError carries service, status, attempts', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 404, statusText: 'Not Found' }),
+    );
+
+    try {
+      await httpRequest('raiderio', 'https://x.test/');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      const e = err as HttpError;
+      expect(e.service).toBe('raiderio');
+      expect(e.status).toBe(404);
+      expect(e.attempts).toBe(1);
+    }
+  });
+
+  it('records failed outcome on non-retryable error', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 404, statusText: 'Not Found' }),
+    );
+
+    await httpRequest('raiderio', 'https://x.test/').catch(() => {});
+    const s = getSummary('raiderio');
+    expect(s.totals.failed).toBe(1);
+    expect(s.lastError?.status).toBe(404);
+  });
+
+  it('throws on JSON parse error without retry', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers(),
+      json: async () => {
+        throw new SyntaxError('Unexpected token');
+      },
+    } as unknown as Response);
+
+    await expect(httpRequest('raiderio', 'https://x.test/')).rejects.toBeInstanceOf(
+      HttpError,
+    );
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/httpClient.test.ts`
+Expected: FAIL — module `../../src/services/httpClient.js` not found.
+
+- [ ] **Step 3: Implement httpClient skeleton**
+
+Create `src/services/httpClient.ts`:
+
+```ts
+import type { ServiceName } from './apiHealth.js';
+import { recordOutcome, noteFailure, noteSuccess } from './apiHealth.js';
+
+export type { ServiceName };
+
+export interface HttpRequestOptions {
+  timeoutMs?: number;
+  maxRetries?: number;
+  parseJson?: boolean;
+}
+
+export class HttpError extends Error {
+  readonly service: ServiceName;
+  readonly status?: number;
+  readonly attempts: number;
+  readonly lastError?: Error;
+
+  constructor(args: {
+    service: ServiceName;
+    status?: number;
+    attempts: number;
+    message: string;
+    lastError?: Error;
+  }) {
+    super(args.message);
+    this.name = 'HttpError';
+    this.service = args.service;
+    this.status = args.status;
+    this.attempts = args.attempts;
+    this.lastError = args.lastError;
+  }
+}
+
+export class CircuitOpenError extends Error {
+  readonly service: ServiceName;
+  constructor(service: ServiceName) {
+    super(`Circuit open for ${service}`);
+    this.name = 'CircuitOpenError';
+    this.service = service;
+  }
+}
+
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+// NOTE: httpRequest assumes all calls are idempotent. All current callers
+// (Raider.io/wowaudit GETs, WarcraftLogs OAuth client_credentials POST and
+// GraphQL read queries) are safe to retry. Adding a non-idempotent caller
+// in future requires a caller-level opt-out (e.g. `opts.maxRetries = 0`).
+export async function httpRequest<T>(
+  service: ServiceName,
+  url: string,
+  init?: RequestInit,
+  opts?: HttpRequestOptions,
+): Promise<T> {
+  const parseJson = opts?.parseJson ?? true;
+  const attempts = 1;
+
+  let response: Response;
+  try {
+    response = await fetch(url, init);
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    recordOutcome(service, 'failed', { msg: e.message });
+    noteFailure(service);
+    throw new HttpError({
+      service, attempts, message: `${service} request failed: ${e.message}`, lastError: e,
+    });
+  }
+
+  if (!response.ok) {
+    recordOutcome(service, 'failed', {
+      msg: `${response.status} ${response.statusText}`,
+      status: response.status,
+    });
+    noteFailure(service);
+    throw new HttpError({
+      service, attempts, status: response.status,
+      message: `${service} API error: ${response.status} ${response.statusText}`,
+    });
+  }
+
+  if (!parseJson) {
+    recordOutcome(service, 'ok');
+    noteSuccess(service);
+    return undefined as T;
+  }
+
+  try {
+    const data = (await response.json()) as T;
+    recordOutcome(service, 'ok');
+    noteSuccess(service);
+    return data;
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    recordOutcome(service, 'failed', { msg: `JSON parse error: ${e.message}` });
+    noteFailure(service);
+    throw new HttpError({
+      service, attempts,
+      message: `${service} JSON parse error: ${e.message}`, lastError: e,
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run tests/unit/httpClient.test.ts`
+Expected: PASS — all happy-path and non-retryable tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/httpClient.ts tests/unit/httpClient.test.ts
+git commit -m "feat(http-client): skeleton with happy path + typed errors"
+```
+
+---
+
+## Task 4: httpClient — timeout via AbortSignal.timeout
+
+**Files:**
+- Modify: `src/services/httpClient.ts`
+- Modify: `tests/unit/httpClient.test.ts`
+
+- [ ] **Step 1: Add failing timeout test**
+
+Append to `tests/unit/httpClient.test.ts`:
+
+```ts
+describe('httpRequest — timeout', () => {
+  it('aborts the request after timeoutMs and throws HttpError', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (signal) {
+            signal.addEventListener('abort', () => {
+              const err = new Error('aborted');
+              (err as Error & { name: string }).name = 'AbortError';
+              reject(err);
+            });
+          }
+        }),
+    );
+
+    const promise = httpRequest('raiderio', 'https://x.test/', undefined, {
+      timeoutMs: 100,
+      maxRetries: 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(101);
+    await expect(promise).rejects.toBeInstanceOf(HttpError);
+  });
+
+  it('passes caller-provided signal alongside timeout', async () => {
+    const abortController = new AbortController();
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse({ ok: true, json: {} }));
+    globalThis.fetch = fetchMock;
+
+    await httpRequest('raiderio', 'https://x.test/', { signal: abortController.signal });
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit | undefined;
+    expect(init?.signal).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/httpClient.test.ts`
+Expected: FAIL — timeout test hangs or fails; `timeoutMs` option is not honoured.
+
+- [ ] **Step 3: Add timeout handling to `httpRequest`**
+
+Replace the single-attempt body of `httpRequest` in `src/services/httpClient.ts` (everything after the opening brace) with:
+
+```ts
+  const timeoutMs = opts?.timeoutMs ?? 10_000;
+  const parseJson = opts?.parseJson ?? true;
+  const attempts = 1;
+
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = init?.signal
+    ? mergeSignals([init.signal, timeoutSignal])
+    : timeoutSignal;
+
+  let response: Response;
+  try {
+    response = await fetch(url, { ...init, signal });
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    const isTimeout = e.name === 'AbortError' || e.name === 'TimeoutError';
+    const outcome = isTimeout ? 'timeout' : 'failed';
+    recordOutcome(service, outcome, { msg: e.message });
+    noteFailure(service);
+    throw new HttpError({
+      service, attempts,
+      message: isTimeout
+        ? `${service} request timed out after ${timeoutMs}ms`
+        : `${service} request failed: ${e.message}`,
+      lastError: e,
+    });
+  }
+
+  if (!response.ok) {
+    recordOutcome(service, 'failed', {
+      msg: `${response.status} ${response.statusText}`,
+      status: response.status,
+    });
+    noteFailure(service);
+    throw new HttpError({
+      service, attempts, status: response.status,
+      message: `${service} API error: ${response.status} ${response.statusText}`,
+    });
+  }
+
+  if (!parseJson) {
+    recordOutcome(service, 'ok');
+    noteSuccess(service);
+    return undefined as T;
+  }
+
+  try {
+    const data = (await response.json()) as T;
+    recordOutcome(service, 'ok');
+    noteSuccess(service);
+    return data;
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    recordOutcome(service, 'failed', { msg: `JSON parse error: ${e.message}` });
+    noteFailure(service);
+    throw new HttpError({
+      service, attempts,
+      message: `${service} JSON parse error: ${e.message}`, lastError: e,
+    });
+  }
+}
+
+// Combines an external abort signal with a timeout signal. Aborts when
+// either fires.
+function mergeSignals(signals: AbortSignal[]): AbortSignal {
+  const controller = new AbortController();
+  for (const s of signals) {
+    if (s.aborted) {
+      controller.abort(s.reason);
+      return controller.signal;
+    }
+    s.addEventListener('abort', () => controller.abort(s.reason), { once: true });
+  }
+  return controller.signal;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run tests/unit/httpClient.test.ts`
+Expected: PASS — all existing tests plus the two new timeout tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/httpClient.ts tests/unit/httpClient.test.ts
+git commit -m "feat(http-client): per-request timeout via AbortSignal.timeout"
+```
+
+---
+
+## Task 5: httpClient — retry loop with backoff + jitter
+
+**Files:**
+- Modify: `src/services/httpClient.ts`
+- Modify: `tests/unit/httpClient.test.ts`
+
+- [ ] **Step 1: Add failing retry tests**
+
+Append to `tests/unit/httpClient.test.ts`:
+
+```ts
+describe('httpRequest — retry loop', () => {
+  it.each([429, 500, 502, 503, 504])(
+    'retries on %s up to maxRetries+1 attempts',
+    async (status) => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse({ ok: false, status, statusText: 'x' }),
+      );
+      globalThis.fetch = fetchMock;
+
+      const promise = httpRequest('raiderio', 'https://x.test/').catch((e) => e);
+      await vi.advanceTimersByTimeAsync(5_000);
+      const err = await promise;
+
+      expect(err).toBeInstanceOf(HttpError);
+      expect(fetchMock).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+    },
+  );
+
+  it('succeeds on retry and records `retried`', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(mockResponse({ ok: false, status: 503, statusText: 'x' }))
+      .mockResolvedValueOnce(mockResponse({ ok: true, json: { ok: 1 } }));
+
+    const promise = httpRequest<{ ok: number }>('raiderio', 'https://x.test/');
+    await vi.advanceTimersByTimeAsync(5_000);
+    const result = await promise;
+
+    expect(result).toEqual({ ok: 1 });
+    const s = getSummary('raiderio');
+    expect(s.totals.ok).toBe(1);
+    expect(s.totals.retried).toBe(1);
+  });
+
+  it('records `rate_limited` when any attempt saw a 429 and the call ultimately fails', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 429, statusText: 'Too Many Requests' }),
+    );
+
+    const promise = httpRequest('raiderio', 'https://x.test/').catch((e) => e);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await promise;
+
+    const s = getSummary('raiderio');
+    expect(s.totals.rateLimited).toBe(1);
+    expect(s.totals.failed).toBe(0);
+  });
+
+  it('records `timeout` when any attempt timed out and the call ultimately fails', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            (err as Error & { name: string }).name = 'AbortError';
+            reject(err);
+          });
+        }),
+    );
+
+    const promise = httpRequest('raiderio', 'https://x.test/', undefined, {
+      timeoutMs: 50,
+    }).catch((e) => e);
+    await vi.advanceTimersByTimeAsync(10_000);
+    await promise;
+
+    const s = getSummary('raiderio');
+    expect(s.totals.timeouts).toBe(1);
+  });
+
+  it('does not retry on 404', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 404, statusText: 'Not Found' }),
+    );
+    globalThis.fetch = fetchMock;
+
+    await httpRequest('raiderio', 'https://x.test/').catch(() => {});
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on network throw (TypeError)', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('fetch failed'));
+    globalThis.fetch = fetchMock;
+
+    const promise = httpRequest('raiderio', 'https://x.test/').catch(() => {});
+    await vi.advanceTimersByTimeAsync(5_000);
+    await promise;
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/httpClient.test.ts`
+Expected: FAIL — retry tests see exactly 1 fetch call, not 3.
+
+- [ ] **Step 3: Implement the retry loop**
+
+Replace the entire exported `httpRequest` body in `src/services/httpClient.ts` with this loop-based version (keep the existing `HttpError`, `CircuitOpenError`, `RETRYABLE_STATUSES`, `mergeSignals`, and comment block intact above it):
+
+```ts
+export async function httpRequest<T>(
+  service: ServiceName,
+  url: string,
+  init?: RequestInit,
+  opts?: HttpRequestOptions,
+): Promise<T> {
+  const timeoutMs = opts?.timeoutMs ?? 10_000;
+  const maxRetries = opts?.maxRetries ?? 2;
+  const parseJson = opts?.parseJson ?? true;
+
+  let attempt = 0;
+  let sawRateLimit = false;
+  let sawTimeout = false;
+  let lastError: Error | undefined;
+  let lastStatus: number | undefined;
+
+  while (attempt <= maxRetries) {
+    attempt += 1;
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
+    const signal = init?.signal
+      ? mergeSignals([init.signal, timeoutSignal])
+      : timeoutSignal;
+
+    let response: Response;
+    try {
+      response = await fetch(url, { ...init, signal });
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      const isTimeout = e.name === 'AbortError' || e.name === 'TimeoutError';
+      lastError = e;
+      if (isTimeout) sawTimeout = true;
+
+      if (attempt > maxRetries) break;
+      await sleep(computeBackoffMs(attempt));
+      continue;
+    }
+
+    if (response.ok) {
+      if (!parseJson) {
+        finishSuccess(service, attempt);
+        return undefined as T;
+      }
+      try {
+        const data = (await response.json()) as T;
+        finishSuccess(service, attempt);
+        return data;
+      } catch (err) {
+        const e = err instanceof Error ? err : new Error(String(err));
+        // JSON parse errors are not transient.
+        recordOutcome(service, 'failed', { msg: `JSON parse error: ${e.message}` });
+        noteFailure(service);
+        throw new HttpError({
+          service, attempts: attempt,
+          message: `${service} JSON parse error: ${e.message}`, lastError: e,
+        });
+      }
+    }
+
+    lastStatus = response.status;
+    if (response.status === 429) sawRateLimit = true;
+
+    if (!RETRYABLE_STATUSES.has(response.status)) {
+      // Non-retryable HTTP error.
+      recordOutcome(service, 'failed', {
+        msg: `${response.status} ${response.statusText}`,
+        status: response.status,
+      });
+      noteFailure(service);
+      throw new HttpError({
+        service, attempts: attempt, status: response.status,
+        message: `${service} API error: ${response.status} ${response.statusText}`,
+      });
+    }
+
+    if (attempt > maxRetries) break;
+    await sleep(computeBackoffMs(attempt));
+  }
+
+  // Exhausted retries.
+  const outcome = sawRateLimit ? 'rate_limited' : sawTimeout ? 'timeout' : 'failed';
+  const msg = lastError
+    ? lastError.message
+    : lastStatus !== undefined
+    ? `${lastStatus}`
+    : 'unknown error';
+  recordOutcome(service, outcome, { msg, status: lastStatus });
+  noteFailure(service);
+  throw new HttpError({
+    service, attempts: attempt, status: lastStatus,
+    message: `${service} request failed after ${attempt} attempt(s): ${msg}`,
+    lastError,
+  });
+}
+
+function finishSuccess(service: ServiceName, attempt: number): void {
+  recordOutcome(service, 'ok');
+  if (attempt > 1) recordOutcome(service, 'retried');
+  noteSuccess(service);
+}
+
+function computeBackoffMs(attemptJustCompleted: number): number {
+  // attemptJustCompleted is 1 after the first attempt, 2 after the second.
+  // Backoff waits BEFORE the next attempt: base * 2^(n-1) + jitter(0..base/2).
+  const base = 500;
+  const exponent = attemptJustCompleted - 1;
+  const computed = base * Math.pow(2, exponent);
+  const jitter = Math.random() * (base * Math.pow(2, exponent - 1));
+  return Math.floor(computed + (exponent >= 0 ? jitter : 0));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run tests/unit/httpClient.test.ts`
+Expected: PASS — all prior tests + all retry tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/httpClient.ts tests/unit/httpClient.test.ts
+git commit -m "feat(http-client): retry loop with exponential backoff + jitter"
+```
+
+---
+
+## Task 6: httpClient — Retry-After header
+
+**Files:**
+- Modify: `src/services/httpClient.ts`
+- Modify: `tests/unit/httpClient.test.ts`
+
+- [ ] **Step 1: Add failing Retry-After tests**
+
+Append to `tests/unit/httpClient.test.ts`:
+
+```ts
+describe('httpRequest — Retry-After', () => {
+  it('honours Retry-After in seconds', async () => {
+    const sleepStart = Date.now();
+    let observedGap = 0;
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: false, status: 429, statusText: 'x',
+          headers: { 'Retry-After': '5' },
+        }),
+      )
+      .mockImplementationOnce(async () => {
+        observedGap = Date.now() - sleepStart;
+        return mockResponse({ ok: true, json: {} });
+      });
+
+    const promise = httpRequest('raiderio', 'https://x.test/');
+    await vi.advanceTimersByTimeAsync(6_000);
+    await promise;
+
+    expect(observedGap).toBeGreaterThanOrEqual(5_000);
+  });
+
+  it('honours Retry-After as HTTP-date', async () => {
+    const sleepStart = Date.now();
+    const futureDate = new Date(sleepStart + 2_000).toUTCString();
+    let observedGap = 0;
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: false, status: 503, statusText: 'x',
+          headers: { 'Retry-After': futureDate },
+        }),
+      )
+      .mockImplementationOnce(async () => {
+        observedGap = Date.now() - sleepStart;
+        return mockResponse({ ok: true, json: {} });
+      });
+
+    const promise = httpRequest('raiderio', 'https://x.test/');
+    await vi.advanceTimersByTimeAsync(3_000);
+    await promise;
+
+    expect(observedGap).toBeGreaterThanOrEqual(2_000);
+  });
+
+  it('treats Retry-After > 30s as final failure without waiting', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({
+        ok: false, status: 429, statusText: 'x',
+        headers: { 'Retry-After': '120' },
+      }),
+    );
+    globalThis.fetch = fetchMock;
+
+    const err = await httpRequest('raiderio', 'https://x.test/').catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const s = getSummary('raiderio');
+    expect(s.totals.rateLimited).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/httpClient.test.ts`
+Expected: FAIL — current backoff ignores `Retry-After`.
+
+- [ ] **Step 3: Integrate Retry-After into the retry loop**
+
+In `src/services/httpClient.ts`, add this constant near `RETRYABLE_STATUSES`:
+
+```ts
+const RETRY_AFTER_CAP_MS = 30_000;
+```
+
+Add this helper above `computeBackoffMs`:
+
+```ts
+function parseRetryAfter(header: string | null): number | null {
+  if (!header) return null;
+  const trimmed = header.trim();
+  const seconds = Number(trimmed);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.floor(seconds * 1_000);
+  }
+  const asDate = Date.parse(trimmed);
+  if (!Number.isNaN(asDate)) {
+    return Math.max(0, asDate - Date.now());
+  }
+  return null;
+}
+```
+
+In the main loop, replace the non-ok branch (the `lastStatus = response.status;` block through the `await sleep(computeBackoffMs(attempt));` at the end of the iteration) with:
+
+```ts
+    lastStatus = response.status;
+    if (response.status === 429) sawRateLimit = true;
+
+    if (!RETRYABLE_STATUSES.has(response.status)) {
+      recordOutcome(service, 'failed', {
+        msg: `${response.status} ${response.statusText}`,
+        status: response.status,
+      });
+      noteFailure(service);
+      throw new HttpError({
+        service, attempts: attempt, status: response.status,
+        message: `${service} API error: ${response.status} ${response.statusText}`,
+      });
+    }
+
+    const retryAfterMs = parseRetryAfter(response.headers.get('retry-after'));
+    if (retryAfterMs !== null && retryAfterMs > RETRY_AFTER_CAP_MS) {
+      // Upstream told us to wait longer than our cap; treat as final failure.
+      const outcome = sawRateLimit ? 'rate_limited' : 'failed';
+      recordOutcome(service, outcome, {
+        msg: `Retry-After ${Math.round(retryAfterMs / 1_000)}s exceeds ${RETRY_AFTER_CAP_MS / 1_000}s cap`,
+        status: response.status,
+      });
+      noteFailure(service);
+      throw new HttpError({
+        service, attempts: attempt, status: response.status,
+        message: `${service} Retry-After exceeds ${RETRY_AFTER_CAP_MS / 1_000}s cap`,
+      });
+    }
+
+    if (attempt > maxRetries) break;
+    const waitMs = retryAfterMs !== null ? retryAfterMs : computeBackoffMs(attempt);
+    await sleep(waitMs);
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run tests/unit/httpClient.test.ts`
+Expected: PASS — all prior tests + three Retry-After tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/httpClient.ts tests/unit/httpClient.test.ts
+git commit -m "feat(http-client): honour Retry-After header with 30s cap"
+```
+
+---
+
+## Task 7: httpClient — circuit breaker integration
+
+**Files:**
+- Modify: `src/services/httpClient.ts`
+- Modify: `tests/unit/httpClient.test.ts`
+
+- [ ] **Step 1: Add failing breaker-integration tests**
+
+Append to `tests/unit/httpClient.test.ts`:
+
+```ts
+import {
+  isBreakerOpen,
+} from '../../src/services/apiHealth.js';
+import { CircuitOpenError } from '../../src/services/httpClient.js';
+
+describe('httpRequest — circuit breaker integration', () => {
+  it('opens the breaker after 5 consecutive failed calls', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 404, statusText: 'x' }),
+    );
+
+    for (let i = 0; i < 5; i++) {
+      await httpRequest('raiderio', 'https://x.test/').catch(() => {});
+    }
+    expect(isBreakerOpen('raiderio')).toBe(true);
+  });
+
+  it('fast-fails with CircuitOpenError while open, without calling fetch', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 404, statusText: 'x' }),
+    );
+    for (let i = 0; i < 5; i++) {
+      await httpRequest('raiderio', 'https://x.test/').catch(() => {});
+    }
+
+    const callCountBefore = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length;
+    await expect(
+      httpRequest('raiderio', 'https://x.test/'),
+    ).rejects.toBeInstanceOf(CircuitOpenError);
+
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callCountBefore);
+    expect(getSummary('raiderio').totals.circuitRejected).toBe(1);
+  });
+
+  it('half_open -> closed on a successful trial call', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 500, statusText: 'x' }),
+    );
+    const kick = async () => {
+      const p = httpRequest('raiderio', 'https://x.test/').catch(() => {});
+      await vi.advanceTimersByTimeAsync(5_000);
+      return p;
+    };
+    for (let i = 0; i < 5; i++) await kick();
+    expect(getSummary('raiderio').breaker).toBe('open');
+
+    // Fast-forward past 60s cooldown.
+    vi.setSystemTime(new Date(Date.now() + 61_000));
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({ ok: true, json: {} }));
+
+    await httpRequest('raiderio', 'https://x.test/');
+    expect(getSummary('raiderio').breaker).toBe('closed');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/httpClient.test.ts`
+Expected: FAIL — breaker state is not gating fetches; trial success is not closing the breaker.
+
+- [ ] **Step 3: Add the breaker check and half-open trial handling**
+
+In `src/services/httpClient.ts`:
+
+Add to the imports near the top:
+
+```ts
+import {
+  recordOutcome, noteFailure, noteSuccess,
+  isBreakerOpen, onBreakerTrialResult,
+} from './apiHealth.js';
+import { getSummary } from './apiHealth.js';
+```
+
+At the *start* of `httpRequest` (before `const timeoutMs = ...`), add:
+
+```ts
+  if (isBreakerOpen(service)) {
+    recordOutcome(service, 'circuit_rejected', {
+      msg: `Circuit open for ${service}`,
+    });
+    throw new CircuitOpenError(service);
+  }
+
+  // If the breaker is in half_open, this call is the trial.
+  const breakerWasHalfOpen = getSummary(service).breaker === 'half_open';
+```
+
+Modify `finishSuccess` to accept and propagate the half-open flag:
+
+```ts
+function finishSuccess(service: ServiceName, attempt: number, wasTrial: boolean): void {
+  recordOutcome(service, 'ok');
+  if (attempt > 1) recordOutcome(service, 'retried');
+  noteSuccess(service);
+  if (wasTrial) onBreakerTrialResult(service, true);
+}
+```
+
+Update the two call sites of `finishSuccess` inside the loop to pass `breakerWasHalfOpen`:
+
+```ts
+      if (!parseJson) {
+        finishSuccess(service, attempt, breakerWasHalfOpen);
+        return undefined as T;
+      }
+      try {
+        const data = (await response.json()) as T;
+        finishSuccess(service, attempt, breakerWasHalfOpen);
+        return data;
+```
+
+After the `throw new HttpError(...)` calls at the non-retryable and Retry-After-exceeded branches, and after the final "Exhausted retries" throw, add a single helper call on the failure path. The cleanest way: introduce a `onFinalFailure` helper that wraps the final `throw new HttpError`, and call `onBreakerTrialResult(service, false)` from it when `breakerWasHalfOpen`. Refactor as follows — replace each final-failure `throw new HttpError({...})` with an explicit `onBreakerTrialResult` call first:
+
+Define this helper near `finishSuccess`:
+
+```ts
+function onFinalFailure(service: ServiceName, wasTrial: boolean): void {
+  if (wasTrial) onBreakerTrialResult(service, false);
+}
+```
+
+Before each final-failure `throw new HttpError(...)` in `httpRequest` (there are three: non-retryable HTTP error, Retry-After exceeded, and the exhausted-retries throw), insert `onFinalFailure(service, breakerWasHalfOpen);`. Also insert the same call before the JSON-parse-error `throw` (a parse error on a half-open trial counts as a trial failure).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run tests/unit/httpClient.test.ts`
+Expected: PASS — all prior tests + three breaker-integration tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/httpClient.ts tests/unit/httpClient.test.ts
+git commit -m "feat(http-client): integrate circuit breaker with half-open trial"
+```
+
+---
+
+## Task 8: Refactor `raiderio.ts` to use `httpRequest`
+
+**Files:**
+- Modify: `src/services/raiderio.ts`
+- Modify: `tests/unit/raiderio.test.ts`
+
+- [ ] **Step 1: Update failing tests to expect new error shape + retries on 5xx**
+
+Open `tests/unit/raiderio.test.ts` and replace the two `should throw on non-OK response` tests with these. The first now expects retries on 5xx; the second (404 on `getRaidRankings`) is non-retryable.
+
+Replace `getGuildRoster`'s `should throw on non-OK response`:
+
+```ts
+  it('retries on 5xx and throws HttpError after exhausting retries', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false, status: 500, statusText: 'Internal Server Error',
+      headers: new Headers(),
+    });
+    globalThis.fetch = fetchMock;
+
+    const promise = getGuildRoster().catch((e) => e);
+    await vi.advanceTimersByTimeAsync(5_000);
+    const err = await promise;
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain('raiderio');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+  });
+```
+
+Replace `getRaidRankings`'s `should throw on non-OK response`:
+
+```ts
+  it('throws HttpError without retry on 404', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false, status: 404, statusText: 'Not Found',
+      headers: new Headers(),
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(getRaidRankings('invalid')).rejects.toThrow('raiderio');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+```
+
+Every existing happy-path mock in this file needs a `headers: new Headers()` field added so `response.headers.get(...)` works inside `httpRequest`. Update each `vi.fn().mockResolvedValue({ ok: true, ... })` to include `headers: new Headers()`. Example:
+
+```ts
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      json: async () => ({ members: mockMembers }),
+    });
+```
+
+Also add `import { __resetForTests } from '../../src/services/apiHealth.js';` at the top and call it in `beforeEach`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/raiderio.test.ts`
+Expected: FAIL — `raiderio.ts` still uses raw `fetch`; error messages and retry counts don't match.
+
+- [ ] **Step 3: Refactor `raiderio.ts`**
+
+Replace `src/services/raiderio.ts` with:
+
+```ts
+import { config } from '../config.js';
+import { httpRequest } from './httpClient.js';
+
+const BASE_URL = 'https://raider.io/api/v1';
+const ROSTER_RANKS = [0, 1, 3, 4, 5, 7];
+
+export interface RaiderIoMember {
+  rank: number;
+  character: {
+    name: string;
+    realm: string;
+    region: string;
+    class: string;
+  };
+}
+
+export interface RaidRanking {
+  rank: number;
+  guild: {
+    name: string;
+    realm: string;
+    region: string;
+  };
+  encountersDefeated: number;
+  encountersTotal: number;
+}
+
+export interface RaidStaticData {
+  raids: Array<{
+    id: number;
+    slug: string;
+    name: string;
+    expansion_id: number;
+    starts: { us: string | null; eu: string | null };
+    ends: { us: string | null; eu: string | null };
+    encounters: Array<{
+      id: number;
+      slug: string;
+      name: string;
+    }>;
+  }>;
+}
+
+export interface MythicPlusRun {
+  dungeon: string;
+  short_name: string;
+  mythic_level: number;
+  num_keystone_upgrades: number;
+  score: number;
+}
+
+export async function getGuildRoster(): Promise<RaiderIoMember[]> {
+  const url = `${BASE_URL}/guilds/profile?region=eu&realm=silvermoon&name=seriouslycasual&fields=members`;
+  const data = await httpRequest<{ members: RaiderIoMember[] }>('raiderio', url);
+  return data.members.filter((m) => ROSTER_RANKS.includes(m.rank));
+}
+
+export async function getRaidRankings(raidSlug: string): Promise<RaidRanking[]> {
+  const url = `${BASE_URL}/raiding/raid-rankings?raid=${raidSlug}&difficulty=mythic&region=world&guilds=${config.raiderIoGuildIds}&limit=50`;
+  const data = await httpRequest<{ raidRankings: RaidRanking[] }>('raiderio', url);
+  return data.raidRankings;
+}
+
+export async function getRaidStaticData(expansionId: number): Promise<RaidStaticData> {
+  const url = `${BASE_URL}/raiding/static-data?expansion_id=${expansionId}`;
+  return httpRequest<RaidStaticData>('raiderio', url);
+}
+
+export async function getWeeklyMythicPlusRuns(
+  region: string,
+  realm: string,
+  name: string,
+): Promise<MythicPlusRun[]> {
+  const url = `${BASE_URL}/characters/profile?region=${region}&realm=${realm}&name=${encodeURIComponent(name)}&fields=mythic_plus_previous_weekly_highest_level_runs`;
+  const data = await httpRequest<{
+    mythic_plus_previous_weekly_highest_level_runs: MythicPlusRun[];
+  }>('raiderio', url);
+  return data.mythic_plus_previous_weekly_highest_level_runs;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run tests/unit/raiderio.test.ts`
+Expected: PASS — updated tests pass; URL-shape assertions continue to pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/raiderio.ts tests/unit/raiderio.test.ts
+git commit -m "refactor(raiderio): route through shared httpClient"
+```
+
+---
+
+## Task 9: Refactor `wowaudit.ts` to use `httpRequest`
+
+**Files:**
+- Modify: `src/services/wowaudit.ts`
+- Modify: `tests/unit/wowaudit.test.ts`
+
+- [ ] **Step 1: Update wowaudit tests the same way**
+
+In `tests/unit/wowaudit.test.ts`:
+- Add `import { __resetForTests } from '../../src/services/apiHealth.js';` and call it in `beforeEach` (add a `beforeEach` if none exists).
+- Add `headers: new Headers()` to every `mockResolvedValue({ ok: true, ... })`.
+- Replace the three `should throw on non-OK response` tests to expect `HttpError` and (for 5xx cases) retries.
+
+Replace `getUpcomingRaids`'s `should throw on non-OK response`:
+
+```ts
+  it('throws HttpError without retry on 401', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false, status: 401, statusText: 'Unauthorized', headers: new Headers(),
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(getUpcomingRaids()).rejects.toThrow('wowaudit');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+```
+
+Replace the 500-on-getCurrentPeriod case in `getHistoricalData`:
+
+```ts
+  it('retries on 500 from getCurrentPeriod and throws HttpError', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false, status: 500, statusText: 'Internal Server Error',
+      headers: new Headers(),
+    });
+    globalThis.fetch = fetchMock;
+
+    const promise = getHistoricalData().catch((e) => e);
+    await vi.advanceTimersByTimeAsync(5_000);
+    const err = await promise;
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain('wowaudit');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+  });
+```
+
+Replace the 404-on-historical-data case:
+
+```ts
+  it('throws HttpError without retry when historical data returns 404', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true, headers: new Headers(),
+        json: async () => ({ current_period: 42 }),
+      })
+      .mockResolvedValueOnce({
+        ok: false, status: 404, statusText: 'Not Found', headers: new Headers(),
+      });
+    globalThis.fetch = fetchMock;
+
+    await expect(getHistoricalData()).rejects.toThrow('wowaudit');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/wowaudit.test.ts`
+Expected: FAIL — `wowaudit.ts` still uses raw `fetch`.
+
+- [ ] **Step 3: Refactor `wowaudit.ts`**
+
+Replace `src/services/wowaudit.ts` with:
+
+```ts
+import { config } from '../config.js';
+import { httpRequest } from './httpClient.js';
+
+const BASE_URL = 'https://wowaudit.com/v1';
+
+function headers(): Record<string, string> {
+  return {
+    accept: 'application/json',
+    Authorization: config.wowAuditApiSecret,
+  };
+}
+
+export interface WowAuditRaid {
+  id: number;
+  date: string;
+  title: string;
+  note: string;
+  signups: Array<{
+    character: {
+      name: string;
+      realm: string;
+      class_name: string;
+    };
+    status: string;
+  }>;
+}
+
+export interface WowAuditHistoricalEntry {
+  character: {
+    name: string;
+    realm: string;
+  };
+  data: Record<string, unknown>;
+}
+
+async function getCurrentPeriod(): Promise<number> {
+  const data = await httpRequest<{ current_period: number }>(
+    'wowaudit',
+    `${BASE_URL}/period`,
+    { headers: headers() },
+  );
+  return data.current_period;
+}
+
+export async function getUpcomingRaids(): Promise<WowAuditRaid[]> {
+  return httpRequest<WowAuditRaid[]>(
+    'wowaudit',
+    `${BASE_URL}/raids?include_past=false`,
+    { headers: headers() },
+  );
+}
+
+export async function getHistoricalData(): Promise<WowAuditHistoricalEntry[]> {
+  const currentPeriod = await getCurrentPeriod();
+  const previousPeriod = currentPeriod - 1;
+
+  return httpRequest<WowAuditHistoricalEntry[]>(
+    'wowaudit',
+    `${BASE_URL}/historical_data?period=${previousPeriod}`,
+    { headers: headers() },
+  );
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run tests/unit/wowaudit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/wowaudit.ts tests/unit/wowaudit.test.ts
+git commit -m "refactor(wowaudit): route through shared httpClient"
+```
+
+---
+
+## Task 10: Refactor `warcraftlogs.ts` (preserve `getTrialLogs` fail-soft)
+
+**Files:**
+- Modify: `src/services/warcraftlogs.ts`
+
+- [ ] **Step 1: Refactor `warcraftlogs.ts`**
+
+Replace `src/services/warcraftlogs.ts` with:
+
+```ts
+import { config } from '../config.js';
+import { logger } from './logger.js';
+import { httpRequest, HttpError, CircuitOpenError } from './httpClient.js';
+
+// ─── Token Cache ─────────────────────────────────────────────
+
+let cachedToken: string | null = null;
+let tokenExpiresAt = 0;
+
+interface TokenResponse {
+  access_token: string;
+  expires_in: number;
+}
+
+async function getAccessToken(): Promise<string> {
+  const now = Date.now();
+
+  if (cachedToken && now < tokenExpiresAt) {
+    return cachedToken;
+  }
+
+  const body = new URLSearchParams({ grant_type: 'client_credentials' });
+
+  const data = await httpRequest<TokenResponse>(
+    'warcraftlogs',
+    'https://www.warcraftlogs.com/oauth/token',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization:
+          'Basic ' +
+          Buffer.from(
+            `${config.warcraftLogsClientId}:${config.warcraftLogsClientSecret}`,
+          ).toString('base64'),
+      },
+      body: body.toString(),
+    },
+  );
+
+  cachedToken = data.access_token;
+  // Expire 60 seconds early to avoid edge cases
+  tokenExpiresAt = now + (data.expires_in - 60) * 1000;
+
+  logger.debug('WarcraftLogs', 'Refreshed OAuth2 access token');
+
+  return cachedToken;
+}
+
+// ─── GraphQL Query ───────────────────────────────────────────
+
+interface AttendancePlayer {
+  name: string;
+  presence: number;
+  type: string;
+}
+
+interface AttendanceReport {
+  code: string;
+  players: AttendancePlayer[];
+}
+
+interface GuildAttendanceResponse {
+  data: {
+    guildData: {
+      guild: {
+        id: number;
+        name: string;
+        attendance: {
+          data: AttendanceReport[];
+        };
+      };
+    };
+  };
+}
+
+const ATTENDANCE_QUERY = `
+  query getGuildAttendance($guildId: Int) {
+    guildData {
+      guild(id: $guildId) {
+        id
+        name
+        attendance {
+          data {
+            code
+            players { name, presence, type }
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Fetch WarcraftLogs report codes where `characterName` was present.
+ * Returns codes in reverse chronological order (newest first).
+ * Returns empty array on any HTTP error or open circuit (fail-soft).
+ */
+export async function getTrialLogs(characterName: string): Promise<string[]> {
+  try {
+    const token = await getAccessToken();
+
+    const result = await httpRequest<GuildAttendanceResponse>(
+      'warcraftlogs',
+      'https://www.warcraftlogs.com/api/v2/client',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: ATTENDANCE_QUERY,
+          variables: {
+            guildId: parseInt(config.warcraftLogsGuildId, 10),
+          },
+        }),
+      },
+    );
+
+    const reports = result.data.guildData.guild.attendance.data;
+
+    const matchingCodes = reports
+      .filter((report) =>
+        report.players.some(
+          (player) =>
+            player.name === characterName && player.presence === 1,
+        ),
+      )
+      .map((report) => report.code);
+
+    return matchingCodes.reverse();
+  } catch (error) {
+    if (error instanceof HttpError || error instanceof CircuitOpenError) {
+      logger.warn(
+        'WarcraftLogs',
+        `Failed to fetch trial logs for "${characterName}": ${error.message}`,
+      );
+      return [];
+    }
+    throw error;
+  }
+}
+```
+
+- [ ] **Step 2: Run existing tests to verify nothing regresses**
+
+Run: `npx vitest run`
+Expected: PASS — the full suite still passes. No WarcraftLogs unit tests exist currently; integration and other unit tests should be unaffected.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/services/warcraftlogs.ts
+git commit -m "refactor(warcraftlogs): route through shared httpClient; preserve fail-soft"
+```
+
+---
+
+## Task 11: `/status` — render API health section
+
+**Files:**
+- Modify: `src/commands/status.ts`
+
+- [ ] **Step 1: Extend `status.ts`**
+
+Edit `src/commands/status.ts`. Add the import near the existing ones:
+
+```ts
+import { getAllSummaries, type BreakerState, type ServiceSummary } from '../services/apiHealth.js';
+```
+
+Add this helper near the bottom of the file, above the `export default`:
+
+```ts
+function breakerEmoji(state: BreakerState): string {
+  if (state === 'open') return '🔴';
+  if (state === 'half_open') return '🟡';
+  return '🟢';
+}
+
+function formatApiHealthLine(label: string, summary: ServiceSummary): string {
+  const { totals, breaker, lastError } = summary;
+  const totalCalls =
+    totals.ok + totals.rateLimited + totals.timeouts + totals.failed + totals.circuitRejected;
+
+  if (totalCalls === 0) {
+    return `**${label}**  ${breakerEmoji(breaker)} ${breaker}  ·  — no traffic`;
+  }
+
+  const successPart = totals.retried > 0
+    ? `${totals.ok} ok (${totals.retried} retried)`
+    : `${totals.ok} ok`;
+
+  const failureParts: string[] = [];
+  const totalFailures = totals.rateLimited + totals.timeouts + totals.failed + totals.circuitRejected;
+  if (totalFailures > 0) {
+    const breakdown: string[] = [];
+    if (totals.rateLimited > 0) breakdown.push(`${totals.rateLimited} rate-limited`);
+    if (totals.timeouts > 0) breakdown.push(`${totals.timeouts} timeouts`);
+    if (totals.circuitRejected > 0) breakdown.push(`${totals.circuitRejected} circuit-rejected`);
+    const breakdownStr = breakdown.length > 0 ? ` (${breakdown.join(', ')})` : '';
+    failureParts.push(`${totalFailures} failed${breakdownStr}`);
+  } else {
+    failureParts.push('0 failed');
+  }
+
+  let line = `**${label}**  ${breakerEmoji(breaker)} ${breaker}  ·  ${successPart}  ·  ${failureParts.join(', ')}`;
+  if (lastError) {
+    const hh = String(lastError.at.getUTCHours()).padStart(2, '0');
+    const mm = String(lastError.at.getUTCMinutes()).padStart(2, '0');
+    const statusPart = lastError.status ? `${lastError.status} ` : '';
+    line += `\nlast error: ${statusPart}${hh}:${mm} UTC — ${lastError.msg}`;
+  }
+  return line;
+}
+```
+
+Then, inside `execute`, append the API health fields after the existing fields. Replace the existing `.addFields(...)` block with:
+
+```ts
+    const apiSummaries = getAllSummaries();
+
+    const embed = createEmbed('Bot Status')
+      .addFields(
+        { name: 'Uptime', value: `${hours}h ${minutes}m ${seconds}s`, inline: true },
+        { name: 'Log Level', value: logger.getLevel(), inline: true },
+        { name: 'DB Size', value: dbSizeStr, inline: true },
+        { name: 'Raiders', value: `${raiders.linked}/${raiders.total} linked`, inline: true },
+        { name: 'Active Applications', value: `${activeApps.count}`, inline: true },
+        { name: 'Active Trials', value: `${activeTrials.count}`, inline: true },
+        { name: 'Last Roster Sync', value: formatAge(syncStatus?.lastRun), inline: true },
+        { name: 'Last Achievements Update', value: formatAge(achievementsStatus?.lastRun), inline: true },
+        { name: 'Last Trial Logs Update', value: formatAge(trialLogsStatus?.lastRun), inline: true },
+        { name: 'EPGP Last Upload', value: epgpLastUpload, inline: true },
+        { name: '\u200B', value: '**API Health (last hour)**', inline: false },
+        { name: '\u200B', value: formatApiHealthLine('Raider.io', apiSummaries.raiderio), inline: false },
+        { name: '\u200B', value: formatApiHealthLine('WarcraftLogs', apiSummaries.warcraftlogs), inline: false },
+        { name: '\u200B', value: formatApiHealthLine('wowaudit', apiSummaries.wowaudit), inline: false },
+      );
+```
+
+- [ ] **Step 2: Build the project to catch type errors**
+
+Run: `npx tsc --noEmit`
+Expected: clean — no type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/commands/status.ts
+git commit -m "feat(status): render API health section (last hour) per service"
+```
+
+---
+
+## Task 12: `interactionCreate` — friendlier message for `CircuitOpenError`
+
+**Files:**
+- Modify: `src/events/interactionCreate.ts`
+
+- [ ] **Step 1: Add the CircuitOpenError branch to the ChatInput error handler**
+
+Edit `src/events/interactionCreate.ts`. Add the import at the top with the others:
+
+```ts
+import { CircuitOpenError } from '../services/httpClient.js';
+```
+
+Replace the existing ChatInput `catch` block (around lines 56–66, the one that starts with `} catch (error) {` after `await command.execute(interaction);`) with:
+
+```ts
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        logger.error('interaction', `Command ${interaction.commandName} failed: ${err.message}`, err);
+
+        const message =
+          err instanceof CircuitOpenError
+            ? `⚠️ ${err.service} is currently unreachable (circuit open). Try again in ~60s.`
+            : 'There was an error executing this command.';
+        const reply = { content: message, flags: MessageFlags.Ephemeral } as const;
+        if (interaction.replied || interaction.deferred) {
+          await interaction.followUp(reply).catch(() => {});
+        } else {
+          await interaction.reply(reply).catch(() => {});
+        }
+      }
+```
+
+- [ ] **Step 2: Build to catch type errors**
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Run the full suite one more time**
+
+Run: `npx vitest run`
+Expected: PASS — full suite green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/events/interactionCreate.ts
+git commit -m "feat(interaction): friendlier ChatInput message on CircuitOpenError"
+```
+
+---
+
+## Task 13: Integration smoke
+
+**Files:** none
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run: `npx vitest run`
+Expected: PASS — all unit + integration tests green.
+
+- [ ] **Step 2: Type-check the entire project**
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Manual verification checklist (documented for the reviewer)**
+
+Start the bot locally:
+
+```bash
+npm run dev
+```
+
+From the test guild, in order:
+1. Run `/status` — confirm a new "API Health (last hour)" heading plus three per-service rows are present with `🟢 closed  ·  — no traffic`.
+2. Run `/raiders sync_raiders` once — confirm `/status` now shows `1 ok` on the `Raider.io` line.
+3. Temporarily point `raiderio.ts` `BASE_URL` to `https://raider.io/api/v1/invalid-endpoint` (a 404 path), restart the bot, run `sync_raiders`. Expect the call to fail fast (1 attempt, 404 non-retryable), `/status` should show `1 failed` with the 404 in `last error`.
+4. Temporarily point `BASE_URL` to a URL that returns 500 (e.g., use `https://httpbin.org/status/500`). Run `sync_raiders` 5 times. Confirm the breaker shows `🔴 open` on `/status` and that a subsequent invocation replies with `⚠️ raiderio is currently unreachable (circuit open). Try again in ~60s.`.
+5. Wait 60s, run `sync_raiders` again with the URL restored to a good endpoint. Confirm the breaker transitions back to `🟢 closed` on `/status`.
+
+If all five pass, the implementation is correct.
+
+---
+
+## Self-Review (by plan author)
+
+**Spec coverage check** — every section in the spec has an implementing task:
+
+- Architecture (httpClient, apiHealth, service refactors, status extension, interactionCreate) → Tasks 1–12
+- Retry policy (what retries, what doesn't, backoff, Retry-After, outcome classification) → Tasks 3, 5, 6
+- Circuit breaker (state machine, open threshold, cooldown, half-open trial, behaviour while open) → Tasks 2, 7
+- Error handling & fail-soft boundary (getTrialLogs swallow, scheduler propagation, interactionCreate CircuitOpenError branch) → Tasks 10, 12
+- /status surface (API health section, rendering rules) → Task 11
+- Testing (httpClient unit, apiHealth unit, existing service test audit) → Tasks 1, 2, 3, 4, 5, 6, 7, 8, 9
+- File changes summary — all files listed are touched.
+
+**Placeholder scan** — no TBDs, no "add appropriate error handling", no "similar to Task N". Every code step has real code.
+
+**Type consistency** — `Outcome` snake_case values in `apiHealth` bucket counts (`rate_limited`, `timeout`, `circuit_rejected`) intentionally differ from camelCase `totals` keys (`rateLimited`, `timeouts`, `circuitRejected`). This is called out by the summary projection in `getSummary`. `ServiceName` is used identically across all files. `HttpError` / `CircuitOpenError` signatures consistent throughout.
+
+**Scope check** — single cohesive feature. All tasks build one working thing. No over-decomposition.
+
+No issues to fix.

--- a/docs/superpowers/specs/2026-04-19-api-health-and-retry-design.md
+++ b/docs/superpowers/specs/2026-04-19-api-health-and-retry-design.md
@@ -1,0 +1,290 @@
+# API Health & Retry - Design Spec
+
+Shared HTTP client with retry, backoff, timeout, and circuit breaker for the three external services (Raider.io, WarcraftLogs, wowaudit), plus an in-memory health tracker surfaced through `/status`.
+
+**Context:** Today each service hand-rolls raw `fetch` with no retry, no timeout, no rate-limit awareness. Error handling is inconsistent — Raider.io and wowaudit throw on non-2xx, WarcraftLogs swallows and returns `[]`. Nothing tells an operator which service is struggling right now. The question "is something rate-limiting us?" can't be answered without both (a) reliable retry for transient failures so the signal isn't noise, and (b) visibility into what's happening.
+
+**Motivation:** Scheduled tasks like `updateAchievements` make many per-raider calls in sequence. A transient 429 kills the task. Compounded retries across many calls could also push task duration past the next scheduler trigger — we need a circuit breaker to bound total time under sustained upstream failure.
+
+---
+
+## Architecture
+
+Three new concerns, one place each:
+
+```
+src/services/
+  httpClient.ts      NEW: shared wrapper (timeout + retry + circuit breaker + tracking)
+  apiHealth.ts       NEW: in-memory rolling health tracker
+  raiderio.ts        refactored to call httpClient
+  warcraftlogs.ts    refactored
+  wowaudit.ts        refactored
+src/commands/
+  status.ts          adds "API Health (last hour)" section
+```
+
+### `httpClient.ts`
+
+One exported function:
+
+```ts
+type ServiceName = 'raiderio' | 'warcraftlogs' | 'wowaudit';
+
+httpRequest<T>(
+  service: ServiceName,
+  url: string,
+  init?: RequestInit,
+  opts?: {
+    timeoutMs?: number;    // default 10_000
+    maxRetries?: number;   // default 2 (3 attempts total)
+    parseJson?: boolean;   // default true
+  }
+): Promise<T>
+```
+
+Owns the full request lifecycle: `AbortSignal.timeout`, retry loop, backoff, `Retry-After` honouring, circuit-breaker gating, and recording every attempt into `apiHealth`. Throws a typed `HttpError` on final failure with `{service, status?, attempts, lastError}`. Throws `CircuitOpenError` when breaker is open and request is rejected without a fetch attempt.
+
+Per-service enum (3 known values, not arbitrary strings) keeps the health tracker surface closed and simplifies `/status` rendering.
+
+### `apiHealth.ts`
+
+In-memory per-service state, cleared on restart:
+
+```ts
+type Outcome =
+  | 'ok'
+  | 'retried'            // success, but took >1 attempt
+  | 'rate_limited'       // final failure, any attempt saw 429
+  | 'timeout'            // final failure, any attempt timed out
+  | 'failed'             // final failure, other
+  | 'circuit_rejected';  // fast-failed because breaker was open
+
+type MinuteBucket = {
+  minuteEpoch: number;   // Math.floor(Date.now() / 60000)
+  counts: Record<Outcome, number>;
+};
+
+type BreakerState = 'closed' | 'half_open' | 'open';
+
+type ServiceState = {
+  buckets: MinuteBucket[];  // ring, max 60 entries (1-hour sliding window)
+  lastError?: { msg: string; at: Date; status?: number };
+  breaker: {
+    state: BreakerState;
+    openedAt?: Date;
+    consecutiveFailures: number;
+  };
+};
+```
+
+Public API:
+
+```ts
+recordOutcome(service: ServiceName, outcome: Outcome, errorDetail?: { msg: string; status?: number }): void;
+getSummary(service: ServiceName): ServiceSummary;
+getAllSummaries(): Record<ServiceName, ServiceSummary>;
+
+// Breaker hooks (called from httpClient)
+isBreakerOpen(service: ServiceName): boolean;
+onBreakerTrialResult(service: ServiceName, success: boolean): void;
+noteFailure(service: ServiceName): void;  // increments consecutiveFailures, may open breaker
+noteSuccess(service: ServiceName): void;  // resets consecutiveFailures
+```
+
+`ServiceSummary` shape:
+
+```ts
+{
+  totals: { ok: number; retried: number; rateLimited: number; timeouts: number; failed: number; circuitRejected: number };
+  lastError?: { msg: string; at: Date; status?: number };
+  breaker: BreakerState;
+}
+```
+
+**Rationale for in-memory only:** the question being answered is "what's happening right now" (last hour). Restart visibility loss is acceptable — the bot is up ~100% of the time in normal operation. Avoiding a SQLite table sidesteps migration, retention policy, and a new service for reads. If historical trends become interesting later, that's a future concern.
+
+### Service refactor shape
+
+Each `fetch(url)` call becomes `httpRequest('raiderio', url)` (or the appropriate service). `response.ok` check and JSON parse happen inside `httpRequest`. Callers receive typed data or throw.
+
+Example — `raiderio.ts#getGuildRoster` before/after:
+
+```ts
+// BEFORE
+const response = await fetch(url);
+if (!response.ok) throw new Error(`Raider.io API error: ${response.status} ${response.statusText}`);
+const data = (await response.json()) as { members: RaiderIoMember[] };
+return data.members.filter(...);
+
+// AFTER
+const data = await httpRequest<{ members: RaiderIoMember[] }>('raiderio', url);
+return data.members.filter(...);
+```
+
+---
+
+## Retry policy
+
+**Attempts:** up to 3 total (initial + 2 retries). Configurable per call via `opts.maxRetries`.
+
+**What retries:**
+- HTTP 429 (rate limited)
+- HTTP 500, 502, 503, 504
+- Network throw (DNS, ECONNRESET, ECONNREFUSED, etc.)
+- Timeout (`AbortError` from `AbortSignal.timeout`)
+
+**What does NOT retry (fail fast):**
+- 400, 401, 403, 404, 410, 422, any other 4xx — client errors, retrying won't help
+- JSON parse errors — response body is broken, not transient
+
+**Backoff schedule:**
+
+| Retry | Computed wait | With jitter |
+|-------|---------------|-------------|
+| 1     | 500ms         | +random(0–250ms) |
+| 2     | 1000ms        | +random(0–500ms) |
+
+If the response includes a `Retry-After` header (seconds or HTTP-date format), use that value **instead** of computed backoff, capped at **30s**. If the value exceeds the cap, treat the call as a final failure immediately rather than blocking the task.
+
+**Worst-case wall time per call:** 10s (initial timeout) + ~0.75s + 10s (retry 1) + ~1.5s + 10s (retry 2) ≈ **32.25s**. Acceptable within scheduler tasks since the scheduler already guards against task overlap via its `running` map.
+
+**Idempotency:** All current calls across the three services are GET-only except WarcraftLogs' OAuth token POST (`grant_type=client_credentials`), which is a stateless credential exchange and safe to retry. `httpRequest` does not gate on method. A code comment documents that adding a non-idempotent call later requires an opt-out.
+
+**Outcome classification (fed to `apiHealth`):**
+
+Every final call outcome increments exactly one of the *result* counters (`ok` / `rate_limited` / `timeout` / `failed` / `circuit_rejected`). The `retried` counter is an **additional flag** incremented alongside `ok` when the success required more than one attempt.
+
+| Path | Counters incremented |
+|------|----------------------|
+| Success on attempt 1 | `ok` |
+| Success on attempt 2 or 3 | `ok` + `retried` |
+| Final failure, any attempt saw 429 | `rate_limited` |
+| Final failure, any attempt timed out | `timeout` |
+| Final failure, other | `failed` |
+| Rejected because breaker open | `circuit_rejected` |
+
+This makes `totals.ok` equal to "total successful calls" for simple reporting, while `totals.retried` gives pressure visibility (`"312 ok (2 retried)"` = 312 successes of which 2 needed retries).
+
+---
+
+## Circuit breaker
+
+**Purpose:** prevent a service's sustained failure from causing a scheduled task to consume its entire interval in per-call retries. Concrete risk: if `updateAchievements` (30-min cadence) runs ~300 Raider.io calls and upstream starts 429ing, without a breaker the task could take hours of retry wall time.
+
+**Tracking:** per-service `consecutiveFailures` counter. Incremented on any final failure (`rate_limited`, `timeout`, `failed`). Reset to zero on any final success.
+
+**State transitions:**
+
+```
+closed  ──[5 consecutive failures]──▶  open
+open    ──[60s cooldown elapsed]───▶  half_open
+half_open ──[trial call succeeds]─▶  closed   (consecutiveFailures reset)
+half_open ──[trial call fails]────▶  open     (cooldown resets)
+```
+
+**Behaviour while open:** `httpRequest` does not attempt a fetch. It records `circuit_rejected` and throws `CircuitOpenError`.
+
+**Half-open:** the very next `httpRequest` call is allowed through as a trial. Subsequent calls during that trial are rejected (treated as open) until the trial resolves. This prevents a burst of parallel calls all bypassing the breaker simultaneously.
+
+**Why this resolves the scheduler-overlap concern:**
+- Under sustained upstream failure, ~5 bad calls open the breaker. Remaining calls in the task fail fast in milliseconds, not 32s each.
+- The task finishes within its interval. The scheduler's existing `running` guard was always in place to prevent same-task stacking; the breaker is what prevents the task itself from running past its interval.
+- The next scheduled trigger starts with the breaker eligible to re-open via half-open, so recovery is automatic without operator intervention.
+
+---
+
+## Error handling & fail-soft boundary
+
+**Default behaviour:** `httpRequest` throws. Callers either let it propagate or catch.
+
+**Who catches:**
+
+1. **`getTrialLogs` (WarcraftLogs)** keeps its existing swallow semantics. Catches `HttpError`/`CircuitOpenError` at its own boundary, calls `logger.warn`, returns `[]`. Preserves today's "empty logs = not found yet" contract for the trial-review flow.
+2. **All other service functions** let errors propagate. Matches current behaviour — callers decide.
+3. **Scheduler handlers** are already wrapped in a try/catch in `scheduler.ts` that logs and clears `running`. No change. `HttpError` surfaces as a normal `Error` there. `recordTaskRun(name, false, err.message)` continues to populate the existing "Last Roster Sync 2h ago" panel.
+4. **User-invoked commands** propagate to the existing `interactionCreate` error handler. Add one branch there: if `err instanceof CircuitOpenError`, reply ephemerally with `"⚠️ {service} is currently unreachable (circuit open). Try again in ~60s."` — friendlier than a raw stack-trace-style message.
+
+---
+
+## `/status` surface
+
+Extend the existing `/status` embed. No new command — keep one pane of glass.
+
+After existing fields, append an "API Health (last hour)" section. One embed field per service (`inline: false`), compact multiline value:
+
+```
+Raider.io       🟢 closed  ·  312 ok (2 retried)  ·  0 failed
+WarcraftLogs    🟢 closed  ·  12 ok              ·  0 failed
+wowaudit        🔴 open    ·  8 ok · 3 failed (2 rate-limited)
+                last error: 429 at 16:42 — "Retry-After exceeded 30s cap"
+```
+
+**Rendering rules:**
+- Emoji prefix: 🟢 `closed`, 🟡 `half_open`, 🔴 `open`
+- "retried" subcount only shown when > 0
+- Failure breakdown `(N rate-limited)` / `(N timeouts)` / `(N circuit-rejected)` shown only when respective count > 0
+- `last error` line only rendered when there has been a failure in the window
+- If no calls happened in the window for a service, render `— no traffic`
+
+The existing `/status` uses 10 fields; adding 3 new service fields keeps us well under Discord's 25-field limit.
+
+---
+
+## File changes summary
+
+**New files:**
+- `src/services/httpClient.ts` — the wrapper, `HttpError`, `CircuitOpenError`
+- `src/services/apiHealth.ts` — tracker + breaker state machine
+- `tests/unit/httpClient.test.ts`
+- `tests/unit/apiHealth.test.ts`
+
+**Modified files:**
+- `src/services/raiderio.ts` — 4 `fetch` calls replaced with `httpRequest<T>('raiderio', url)`
+- `src/services/warcraftlogs.ts` — OAuth POST + GraphQL POST routed through `httpRequest`; `getTrialLogs` catches `HttpError`/`CircuitOpenError` at boundary
+- `src/services/wowaudit.ts` — 3 `fetch` calls replaced
+- `src/commands/status.ts` — append "API Health (last hour)" section, read from `apiHealth.getAllSummaries()`
+- `src/events/interactionCreate.ts` — add `CircuitOpenError` branch to error handler for friendlier user-facing message
+- `tests/unit/raiderio.test.ts`, `tests/unit/wowaudit.test.ts` — update any 5xx single-call assertions to expect retries
+
+---
+
+## Testing
+
+### `tests/unit/httpClient.test.ts` (new)
+
+Uses `vi.useFakeTimers()` and stubs `global.fetch`:
+- Retries on 429 / 500 / 502 / 503 / 504 / network throw / timeout (table-driven)
+- Does NOT retry on 400 / 401 / 403 / 404 / 422 / JSON parse error
+- Exponential backoff with jitter — assert total waits fall within min/max bands across attempts
+- `Retry-After` header (seconds AND HTTP-date) honoured
+- `Retry-After` > 30s treated as final failure without blocking
+- Timeout via `AbortSignal.timeout` cancels the slow response and counts as retryable
+- `HttpError` shape: `{service, status?, attempts, lastError}`
+- Circuit breaker: opens after 5 consecutive failures, fails fast while open, half-opens after 60s, closes on trial success, reopens on trial failure
+- `apiHealth.recordOutcome` called with correct outcome per path (`ok` / `retried` / `rate_limited` / `timeout` / `failed` / `circuit_rejected`)
+
+### `tests/unit/apiHealth.test.ts` (new)
+- Minute buckets accumulate and evict at the 60-min boundary
+- `getSummary` aggregates across the window, excludes evicted buckets
+- `lastError` updates on failures, persists until overwritten by a newer error
+- Breaker state round-trip (closed → open → half_open → closed / open)
+- `noteFailure` / `noteSuccess` correctly manage `consecutiveFailures`
+
+### Existing service tests
+Minimal churn: they already stub `fetch`. Same stubs continue to work because `httpClient` wraps `fetch`. Any tests that asserted single-call behaviour on 5xx (expecting exactly one failed call) need updating to expect retries. Audit during implementation.
+
+### Integration tests
+No new integration tests. API health is a cross-cutting concern best exercised by unit tests.
+
+### Manual verification
+After merge, run `/status` in the test guild. Force a 429 by pointing one service at a bad endpoint, confirm the API Health section renders correctly and the breaker opens after 5 failures.
+
+---
+
+## Out of scope
+
+- Persistent (SQLite) storage of API health history. In-memory suffices for the "right now" question. Revisit if trend analysis becomes interesting.
+- Per-raider or per-query retry budgets beyond the circuit breaker. The breaker bounds total time per task sufficiently.
+- Non-idempotent request handling. No current callers need it. A comment in `httpClient.ts` documents the constraint.
+- Retry on `CircuitOpenError`. Caller-level concern; not the wrapper's job.
+- Discord-channel alerting when the breaker opens. Could be added later as a `bot-audit` message, but is deferred to avoid scope creep.

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -4,6 +4,7 @@ import { createEmbed } from '../utils.js';
 import { getDatabase } from '../database/db.js';
 import { logger } from '../services/logger.js';
 import { getTaskStatus } from '../services/statusTracker.js';
+import { getAllSummaries, type BreakerState, type ServiceSummary } from '../services/apiHealth.js';
 
 const startTime = Date.now();
 
@@ -23,6 +24,48 @@ function formatDbSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function breakerEmoji(state: BreakerState): string {
+  if (state === 'open') return '🔴';
+  if (state === 'half_open') return '🟡';
+  return '🟢';
+}
+
+function formatApiHealthLine(label: string, summary: ServiceSummary): string {
+  const { totals, breaker, lastError } = summary;
+  const totalCalls =
+    totals.ok + totals.rateLimited + totals.timeouts + totals.failed + totals.circuitRejected;
+
+  if (totalCalls === 0) {
+    return `**${label}**  ${breakerEmoji(breaker)} ${breaker}  ·  — no traffic`;
+  }
+
+  const successPart = totals.retried > 0
+    ? `${totals.ok} ok (${totals.retried} retried)`
+    : `${totals.ok} ok`;
+
+  const failureParts: string[] = [];
+  const totalFailures = totals.rateLimited + totals.timeouts + totals.failed + totals.circuitRejected;
+  if (totalFailures > 0) {
+    const breakdown: string[] = [];
+    if (totals.rateLimited > 0) breakdown.push(`${totals.rateLimited} rate-limited`);
+    if (totals.timeouts > 0) breakdown.push(`${totals.timeouts} timeouts`);
+    if (totals.circuitRejected > 0) breakdown.push(`${totals.circuitRejected} circuit-rejected`);
+    const breakdownStr = breakdown.length > 0 ? ` (${breakdown.join(', ')})` : '';
+    failureParts.push(`${totalFailures} failed${breakdownStr}`);
+  } else {
+    failureParts.push('0 failed');
+  }
+
+  let line = `**${label}**  ${breakerEmoji(breaker)} ${breaker}  ·  ${successPart}  ·  ${failureParts.join(', ')}`;
+  if (lastError) {
+    const hh = String(lastError.at.getUTCHours()).padStart(2, '0');
+    const mm = String(lastError.at.getUTCMinutes()).padStart(2, '0');
+    const statusPart = lastError.status ? `${lastError.status} ` : '';
+    line += `\nlast error: ${statusPart}${hh}:${mm} UTC — ${lastError.msg}`;
+  }
+  return line;
 }
 
 export default {
@@ -56,6 +99,8 @@ export default {
 
     const epgpLastUpload = epgpUpload?.ts ? formatAge(new Date(epgpUpload.ts)) : 'Never';
 
+    const apiSummaries = getAllSummaries();
+
     const embed = createEmbed('Bot Status')
       .addFields(
         { name: 'Uptime', value: `${hours}h ${minutes}m ${seconds}s`, inline: true },
@@ -68,6 +113,10 @@ export default {
         { name: 'Last Achievements Update', value: formatAge(achievementsStatus?.lastRun), inline: true },
         { name: 'Last Trial Logs Update', value: formatAge(trialLogsStatus?.lastRun), inline: true },
         { name: 'EPGP Last Upload', value: epgpLastUpload, inline: true },
+        { name: '\u200B', value: '**API Health (last hour)**', inline: false },
+        { name: '\u200B', value: formatApiHealthLine('Raider.io', apiSummaries.raiderio), inline: false },
+        { name: '\u200B', value: formatApiHealthLine('WarcraftLogs', apiSummaries.warcraftlogs), inline: false },
+        { name: '\u200B', value: formatApiHealthLine('wowaudit', apiSummaries.wowaudit), inline: false },
       );
 
     await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -59,7 +59,7 @@ function formatApiHealthLine(label: string, summary: ServiceSummary): string {
   }
 
   let line = `**${label}**  ${breakerEmoji(breaker)} ${breaker}  ·  ${successPart}  ·  ${failureParts.join(', ')}`;
-  if (lastError) {
+  if (lastError && totalFailures > 0) {
     const hh = String(lastError.at.getUTCHours()).padStart(2, '0');
     const mm = String(lastError.at.getUTCMinutes()).padStart(2, '0');
     const statusPart = lastError.status ? `${lastError.status} ` : '';

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -36,6 +36,7 @@ import { updateLootPost } from '../functions/loot/updateLootPost.js';
 import { generateLootPost } from '../functions/loot/generateLootPost.js';
 import type { LootPostRow, LootResponseRow } from '../types/index.js';
 import { getCachedPage, buildPageEmbed, buildPageButtons } from '../functions/pagination.js';
+import { CircuitOpenError } from '../services/httpClient.js';
 
 export default {
   name: 'interactionCreate',
@@ -57,7 +58,11 @@ export default {
         const err = error instanceof Error ? error : new Error(String(error));
         logger.error('interaction', `Command ${interaction.commandName} failed: ${err.message}`, err);
 
-        const reply = { content: 'There was an error executing this command.', flags: MessageFlags.Ephemeral } as const;
+        const message =
+          err instanceof CircuitOpenError
+            ? `⚠️ ${err.service} is currently unreachable (circuit open). Try again in ~60s.`
+            : 'There was an error executing this command.';
+        const reply = { content: message, flags: MessageFlags.Ephemeral } as const;
         if (interaction.replied || interaction.deferred) {
           await interaction.followUp(reply).catch(() => {});
         } else {

--- a/src/services/apiHealth.ts
+++ b/src/services/apiHealth.ts
@@ -1,0 +1,156 @@
+export type ServiceName = 'raiderio' | 'warcraftlogs' | 'wowaudit';
+
+export type Outcome =
+  | 'ok'
+  | 'retried'
+  | 'rate_limited'
+  | 'timeout'
+  | 'failed'
+  | 'circuit_rejected';
+
+export type BreakerState = 'closed' | 'half_open' | 'open';
+
+export interface ErrorDetail {
+  msg: string;
+  status?: number;
+}
+
+interface MinuteBucket {
+  minuteEpoch: number;
+  counts: Record<Outcome, number>;
+}
+
+interface ServiceState {
+  buckets: MinuteBucket[];
+  lastError?: { msg: string; status?: number; at: Date };
+  breaker: {
+    state: BreakerState;
+    openedAt?: Date;
+    consecutiveFailures: number;
+  };
+}
+
+export interface ServiceSummary {
+  totals: {
+    ok: number;
+    retried: number;
+    rateLimited: number;
+    timeouts: number;
+    failed: number;
+    circuitRejected: number;
+  };
+  lastError?: { msg: string; status?: number; at: Date };
+  breaker: BreakerState;
+}
+
+const SERVICES: ServiceName[] = ['raiderio', 'warcraftlogs', 'wowaudit'];
+const WINDOW_MINUTES = 60;
+
+function emptyBucketCounts(): Record<Outcome, number> {
+  return {
+    ok: 0,
+    retried: 0,
+    rate_limited: 0,
+    timeout: 0,
+    failed: 0,
+    circuit_rejected: 0,
+  };
+}
+
+function freshState(): ServiceState {
+  return {
+    buckets: [],
+    breaker: { state: 'closed', consecutiveFailures: 0 },
+  };
+}
+
+const state = new Map<ServiceName, ServiceState>();
+for (const s of SERVICES) state.set(s, freshState());
+
+function currentMinute(): number {
+  return Math.floor(Date.now() / 60_000);
+}
+
+function getOrCreateBucket(svc: ServiceState): MinuteBucket {
+  const minute = currentMinute();
+  let bucket = svc.buckets[svc.buckets.length - 1];
+  if (!bucket || bucket.minuteEpoch !== minute) {
+    bucket = { minuteEpoch: minute, counts: emptyBucketCounts() };
+    svc.buckets.push(bucket);
+  }
+  // Evict buckets older than WINDOW_MINUTES
+  const cutoff = minute - WINDOW_MINUTES + 1;
+  while (svc.buckets.length > 0 && svc.buckets[0].minuteEpoch < cutoff) {
+    svc.buckets.shift();
+  }
+  return bucket;
+}
+
+function evict(svc: ServiceState): void {
+  const cutoff = currentMinute() - WINDOW_MINUTES + 1;
+  while (svc.buckets.length > 0 && svc.buckets[0].minuteEpoch < cutoff) {
+    svc.buckets.shift();
+  }
+}
+
+export function recordOutcome(
+  service: ServiceName,
+  outcome: Outcome,
+  errorDetail?: ErrorDetail,
+): void {
+  const svc = state.get(service);
+  if (!svc) return;
+  const bucket = getOrCreateBucket(svc);
+  bucket.counts[outcome] += 1;
+  if (errorDetail) {
+    svc.lastError = { ...errorDetail, at: new Date() };
+  }
+}
+
+export function getSummary(service: ServiceName): ServiceSummary {
+  const svc = state.get(service);
+  if (!svc) {
+    return {
+      totals: { ok: 0, retried: 0, rateLimited: 0, timeouts: 0, failed: 0, circuitRejected: 0 },
+      breaker: 'closed',
+    };
+  }
+  evict(svc);
+
+  const totals = {
+    ok: 0,
+    retried: 0,
+    rateLimited: 0,
+    timeouts: 0,
+    failed: 0,
+    circuitRejected: 0,
+  };
+  for (const b of svc.buckets) {
+    totals.ok += b.counts.ok;
+    totals.retried += b.counts.retried;
+    totals.rateLimited += b.counts.rate_limited;
+    totals.timeouts += b.counts.timeout;
+    totals.failed += b.counts.failed;
+    totals.circuitRejected += b.counts.circuit_rejected;
+  }
+
+  return {
+    totals,
+    lastError: svc.lastError,
+    breaker: svc.breaker.state,
+  };
+}
+
+export function getAllSummaries(): Record<ServiceName, ServiceSummary> {
+  return {
+    raiderio: getSummary('raiderio'),
+    warcraftlogs: getSummary('warcraftlogs'),
+    wowaudit: getSummary('wowaudit'),
+  };
+}
+
+// Test-only: reset all in-memory state.
+export function __resetForTests(): void {
+  state.clear();
+  for (const s of SERVICES) state.set(s, freshState());
+}

--- a/src/services/apiHealth.ts
+++ b/src/services/apiHealth.ts
@@ -74,6 +74,13 @@ function currentMinute(): number {
   return Math.floor(Date.now() / 60_000);
 }
 
+function evict(svc: ServiceState): void {
+  const cutoff = currentMinute() - WINDOW_MINUTES + 1;
+  while (svc.buckets.length > 0 && svc.buckets[0].minuteEpoch < cutoff) {
+    svc.buckets.shift();
+  }
+}
+
 function getOrCreateBucket(svc: ServiceState): MinuteBucket {
   const minute = currentMinute();
   let bucket = svc.buckets[svc.buckets.length - 1];
@@ -81,19 +88,8 @@ function getOrCreateBucket(svc: ServiceState): MinuteBucket {
     bucket = { minuteEpoch: minute, counts: emptyBucketCounts() };
     svc.buckets.push(bucket);
   }
-  // Evict buckets older than WINDOW_MINUTES
-  const cutoff = minute - WINDOW_MINUTES + 1;
-  while (svc.buckets.length > 0 && svc.buckets[0].minuteEpoch < cutoff) {
-    svc.buckets.shift();
-  }
+  evict(svc);
   return bucket;
-}
-
-function evict(svc: ServiceState): void {
-  const cutoff = currentMinute() - WINDOW_MINUTES + 1;
-  while (svc.buckets.length > 0 && svc.buckets[0].minuteEpoch < cutoff) {
-    svc.buckets.shift();
-  }
 }
 
 export function recordOutcome(
@@ -155,11 +151,9 @@ export function getSummary(service: ServiceName): ServiceSummary {
 }
 
 export function getAllSummaries(): Record<ServiceName, ServiceSummary> {
-  return {
-    raiderio: getSummary('raiderio'),
-    warcraftlogs: getSummary('warcraftlogs'),
-    wowaudit: getSummary('wowaudit'),
-  };
+  return Object.fromEntries(
+    SERVICES.map((s) => [s, getSummary(s)]),
+  ) as Record<ServiceName, ServiceSummary>;
 }
 
 // Test-only: reset all in-memory state.

--- a/src/services/apiHealth.ts
+++ b/src/services/apiHealth.ts
@@ -45,6 +45,8 @@ export interface ServiceSummary {
 
 const SERVICES: ServiceName[] = ['raiderio', 'warcraftlogs', 'wowaudit'];
 const WINDOW_MINUTES = 60;
+const BREAKER_OPEN_THRESHOLD = 5;
+const BREAKER_COOLDOWN_MS = 60_000;
 
 function emptyBucketCounts(): Record<Outcome, number> {
   return {
@@ -107,6 +109,15 @@ export function recordOutcome(
   }
 }
 
+function maybeTransitionToHalfOpen(svc: ServiceState): void {
+  if (svc.breaker.state === 'open' && svc.breaker.openedAt) {
+    const elapsed = Date.now() - svc.breaker.openedAt.getTime();
+    if (elapsed >= BREAKER_COOLDOWN_MS) {
+      svc.breaker.state = 'half_open';
+    }
+  }
+}
+
 export function getSummary(service: ServiceName): ServiceSummary {
   const svc = state.get(service);
   if (!svc) {
@@ -116,6 +127,7 @@ export function getSummary(service: ServiceName): ServiceSummary {
     };
   }
   evict(svc);
+  maybeTransitionToHalfOpen(svc);
 
   const totals = {
     ok: 0,
@@ -153,4 +165,48 @@ export function getAllSummaries(): Record<ServiceName, ServiceSummary> {
 export function __resetForTests(): void {
   state.clear();
   for (const s of SERVICES) state.set(s, freshState());
+}
+
+export function noteFailure(service: ServiceName): void {
+  const svc = state.get(service);
+  if (!svc) return;
+  svc.breaker.consecutiveFailures += 1;
+  if (
+    svc.breaker.state === 'closed' &&
+    svc.breaker.consecutiveFailures >= BREAKER_OPEN_THRESHOLD
+  ) {
+    svc.breaker.state = 'open';
+    svc.breaker.openedAt = new Date();
+  }
+}
+
+export function noteSuccess(service: ServiceName): void {
+  const svc = state.get(service);
+  if (!svc) return;
+  svc.breaker.consecutiveFailures = 0;
+}
+
+export function isBreakerOpen(service: ServiceName): boolean {
+  const svc = state.get(service);
+  if (!svc) return false;
+
+  maybeTransitionToHalfOpen(svc);
+
+  // Only 'open' blocks; 'half_open' and 'closed' permit a request attempt.
+  return svc.breaker.state === 'open';
+}
+
+export function onBreakerTrialResult(service: ServiceName, success: boolean): void {
+  const svc = state.get(service);
+  if (!svc) return;
+  if (svc.breaker.state !== 'half_open') return;
+
+  if (success) {
+    svc.breaker.state = 'closed';
+    svc.breaker.openedAt = undefined;
+    svc.breaker.consecutiveFailures = 0;
+  } else {
+    svc.breaker.state = 'open';
+    svc.breaker.openedAt = new Date();
+  }
 }

--- a/src/services/apiHealth.ts
+++ b/src/services/apiHealth.ts
@@ -187,25 +187,28 @@ export function noteSuccess(service: ServiceName): void {
   svc.breaker.consecutiveFailures = 0;
 }
 
-// Returns true when the call should be rejected. For half_open, atomically
-// claims the single trial slot: the first caller proceeds (returns false,
-// flagged as the trial via trialInFlight=true) and subsequent concurrent
-// callers are rejected until onBreakerTrialResult clears the flag.
+// Pure predicate: true when the breaker should block a new call. Applies
+// the lazy open→half_open transition (a state-machine advance, not a
+// trial claim). 'half_open' with a trial already in flight also blocks.
 export function isBreakerOpen(service: ServiceName): boolean {
   const svc = state.get(service);
   if (!svc) return false;
-
   maybeTransitionToHalfOpen(svc);
-
   if (svc.breaker.state === 'open') return true;
-
-  if (svc.breaker.state === 'half_open') {
-    if (svc.breaker.trialInFlight) return true;
-    svc.breaker.trialInFlight = true;
-    return false;
-  }
-
+  if (svc.breaker.state === 'half_open' && svc.breaker.trialInFlight) return true;
   return false;
+}
+
+// Atomically claim the single half_open trial slot. Returns true if
+// claimed (caller is the trial), false otherwise (state is closed, or
+// state is half_open but another trial is already in flight).
+export function tryClaimTrialSlot(service: ServiceName): boolean {
+  const svc = state.get(service);
+  if (!svc) return false;
+  if (svc.breaker.state !== 'half_open') return false;
+  if (svc.breaker.trialInFlight) return false;
+  svc.breaker.trialInFlight = true;
+  return true;
 }
 
 // Lightweight breaker-state query for the httpClient's wasTrial decision.

--- a/src/services/apiHealth.ts
+++ b/src/services/apiHealth.ts
@@ -27,6 +27,7 @@ interface ServiceState {
     state: BreakerState;
     openedAt?: Date;
     consecutiveFailures: number;
+    trialInFlight: boolean;
   };
 }
 
@@ -62,7 +63,7 @@ function emptyBucketCounts(): Record<Outcome, number> {
 function freshState(): ServiceState {
   return {
     buckets: [],
-    breaker: { state: 'closed', consecutiveFailures: 0 },
+    breaker: { state: 'closed', consecutiveFailures: 0, trialInFlight: false },
   };
 }
 
@@ -186,20 +187,42 @@ export function noteSuccess(service: ServiceName): void {
   svc.breaker.consecutiveFailures = 0;
 }
 
+// Returns true when the call should be rejected. For half_open, atomically
+// claims the single trial slot: the first caller proceeds (returns false,
+// flagged as the trial via trialInFlight=true) and subsequent concurrent
+// callers are rejected until onBreakerTrialResult clears the flag.
 export function isBreakerOpen(service: ServiceName): boolean {
   const svc = state.get(service);
   if (!svc) return false;
 
   maybeTransitionToHalfOpen(svc);
 
-  // Only 'open' blocks; 'half_open' and 'closed' permit a request attempt.
-  return svc.breaker.state === 'open';
+  if (svc.breaker.state === 'open') return true;
+
+  if (svc.breaker.state === 'half_open') {
+    if (svc.breaker.trialInFlight) return true;
+    svc.breaker.trialInFlight = true;
+    return false;
+  }
+
+  return false;
+}
+
+// Lightweight breaker-state query for the httpClient's wasTrial decision.
+// Avoids the full bucket aggregation that getSummary does.
+export function getBreakerState(service: ServiceName): BreakerState {
+  const svc = state.get(service);
+  if (!svc) return 'closed';
+  maybeTransitionToHalfOpen(svc);
+  return svc.breaker.state;
 }
 
 export function onBreakerTrialResult(service: ServiceName, success: boolean): void {
   const svc = state.get(service);
   if (!svc) return;
   if (svc.breaker.state !== 'half_open') return;
+
+  svc.breaker.trialInFlight = false;
 
   if (success) {
     svc.breaker.state = 'closed';

--- a/src/services/apiHealth.ts
+++ b/src/services/apiHealth.ts
@@ -201,14 +201,29 @@ export function isBreakerOpen(service: ServiceName): boolean {
 
 // Atomically claim the single half_open trial slot. Returns true if
 // claimed (caller is the trial), false otherwise (state is closed, or
-// state is half_open but another trial is already in flight).
+// state is half_open but another trial is already in flight). Applies
+// the lazy open→half_open transition itself so it's safe to call
+// without first observing state via isBreakerOpen.
 export function tryClaimTrialSlot(service: ServiceName): boolean {
   const svc = state.get(service);
   if (!svc) return false;
+  maybeTransitionToHalfOpen(svc);
   if (svc.breaker.state !== 'half_open') return false;
   if (svc.breaker.trialInFlight) return false;
   svc.breaker.trialInFlight = true;
   return true;
+}
+
+// Release a half_open trial slot without resolving it as success or
+// failure. Used when a trial is cancelled by the caller — don't punish
+// the service by reopening the breaker, but don't leave the slot stuck
+// either.
+export function releaseBreakerTrialSlot(service: ServiceName): void {
+  const svc = state.get(service);
+  if (!svc) return;
+  if (svc.breaker.state === 'half_open') {
+    svc.breaker.trialInFlight = false;
+  }
 }
 
 // Lightweight breaker-state query for the httpClient's wasTrial decision.

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -2,6 +2,7 @@ import type { ServiceName } from './apiHealth.js';
 import {
   recordOutcome, noteFailure, noteSuccess,
   isBreakerOpen, onBreakerTrialResult, tryClaimTrialSlot,
+  releaseBreakerTrialSlot,
 } from './apiHealth.js';
 
 export type { ServiceName };
@@ -95,15 +96,13 @@ export async function httpRequest<T>(
     let response: Response;
     try {
       response = await fetch(url, { ...init, signal });
-      clearTimeout(timeoutId);
     } catch (err) {
       clearTimeout(timeoutId);
-      // Caller explicitly aborted. Propagate their abort verbatim and don't
-      // retry. Release the trial slot (if any) so the breaker doesn't get
-      // stuck. Don't record this as a service failure — it's a caller
-      // cancellation, not an upstream problem.
+      // Caller explicitly aborted. Propagate verbatim, don't retry, and
+      // release (not fail) the trial slot — caller cancellation isn't a
+      // service failure and shouldn't reset the cooldown.
       if (init?.signal?.aborted) {
-        if (breakerWasHalfOpen) onBreakerTrialResult(service, false);
+        if (breakerWasHalfOpen) releaseBreakerTrialSlot(service);
         throw err;
       }
       const e = err instanceof Error ? err : new Error(String(err));
@@ -118,16 +117,36 @@ export async function httpRequest<T>(
 
     if (response.ok) {
       if (!parseJson) {
+        clearTimeout(timeoutId);
         finishSuccess(service, attempt, breakerWasHalfOpen);
         return undefined as T;
       }
+      // NOTE: timeoutId is still armed — the timeout must cover body
+      // parsing, not just the fetch headers phase. A server that streams
+      // headers and hangs on the body would otherwise block indefinitely.
       try {
         const data = (await response.json()) as T;
+        clearTimeout(timeoutId);
         finishSuccess(service, attempt, breakerWasHalfOpen);
         return data;
       } catch (err) {
+        clearTimeout(timeoutId);
+        // Caller aborted during body parse → propagate, release trial slot.
+        if (init?.signal?.aborted) {
+          if (breakerWasHalfOpen) releaseBreakerTrialSlot(service);
+          throw err;
+        }
+        // Our timeout fired during body parse → treat as transient timeout.
+        if (abortController.signal.aborted) {
+          const e = err instanceof Error ? err : new Error(String(err));
+          lastError = e;
+          sawTimeout = true;
+          if (attempt > maxRetries) break;
+          await sleep(computeBackoffMs(attempt));
+          continue;
+        }
+        // Genuine JSON parse error — not transient.
         const e = err instanceof Error ? err : new Error(String(err));
-        // JSON parse errors are not transient.
         recordOutcome(service, 'failed', { msg: `JSON parse error: ${e.message}` });
         noteFailure(service);
         onFinalFailure(service, breakerWasHalfOpen);
@@ -138,6 +157,7 @@ export async function httpRequest<T>(
       }
     }
 
+    clearTimeout(timeoutId);
     lastStatus = response.status;
     if (response.status === 429) sawRateLimit = true;
 

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -56,6 +56,12 @@ export async function httpRequest<T>(
   init?: RequestInit,
   opts?: HttpRequestOptions,
 ): Promise<T> {
+  // Respect caller's abort signal before doing any work. Don't touch the
+  // breaker or record outcomes — the caller decided not to run this at all.
+  if (init?.signal?.aborted) {
+    throw init.signal.reason ?? new DOMException('Aborted', 'AbortError');
+  }
+
   if (isBreakerOpen(service)) {
     recordOutcome(service, 'circuit_rejected', {
       msg: `Circuit open for ${service}`,
@@ -174,7 +180,10 @@ export async function httpRequest<T>(
       });
     }
 
-    const retryAfterMs = parseRetryAfter(response.headers.get('retry-after'));
+    const retryAfterMs = parseRetryAfter(
+      response.headers.get('retry-after'),
+      response.headers.get('date'),
+    );
     if (retryAfterMs !== null && retryAfterMs > RETRY_AFTER_CAP_MS) {
       // Upstream told us to wait longer than our cap; treat as final failure.
       const outcome = sawRateLimit ? 'rate_limited' : 'failed';
@@ -223,7 +232,7 @@ function onFinalFailure(service: ServiceName, wasTrial: boolean): void {
   if (wasTrial) onBreakerTrialResult(service, false);
 }
 
-function parseRetryAfter(header: string | null): number | null {
+function parseRetryAfter(header: string | null, serverDateHeader: string | null): number | null {
   if (!header) return null;
   const trimmed = header.trim();
   const seconds = Number(trimmed);
@@ -232,7 +241,12 @@ function parseRetryAfter(header: string | null): number | null {
   }
   const asDate = Date.parse(trimmed);
   if (!Number.isNaN(asDate)) {
-    return Math.max(0, asDate - Date.now());
+    // Compute the offset against the server's own Date header when present
+    // so we're robust to clock skew between this process and the upstream.
+    // Fall back to local time if the server didn't provide a Date header.
+    const serverNowMs = serverDateHeader ? Date.parse(serverDateHeader) : NaN;
+    const referenceMs = Number.isNaN(serverNowMs) ? Date.now() : serverNowMs;
+    return Math.max(0, asDate - referenceMs);
   }
   return null;
 }

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -1,7 +1,7 @@
 import type { ServiceName } from './apiHealth.js';
 import {
   recordOutcome, noteFailure, noteSuccess,
-  isBreakerOpen, onBreakerTrialResult, getBreakerState,
+  isBreakerOpen, onBreakerTrialResult, tryClaimTrialSlot,
 } from './apiHealth.js';
 
 export type { ServiceName };
@@ -62,10 +62,11 @@ export async function httpRequest<T>(
     throw new CircuitOpenError(service);
   }
 
-  // isBreakerOpen already transitioned state and (for half_open) claimed the
-  // trial slot. If the breaker is half_open here, this call is the trial and
-  // must resolve it via onBreakerTrialResult on every exit path.
-  const breakerWasHalfOpen = getBreakerState(service) === 'half_open';
+  // If state is half_open, atomically claim the single trial slot.
+  // tryClaimTrialSlot returns true iff this call is the trial; subsequent
+  // concurrent callers see isBreakerOpen === true (trialInFlight=true) and
+  // fast-fail at the check above.
+  const breakerWasHalfOpen = tryClaimTrialSlot(service);
 
   const timeoutMs = opts?.timeoutMs ?? 10_000;
   const maxRetries = opts?.maxRetries ?? 2;
@@ -97,6 +98,14 @@ export async function httpRequest<T>(
       clearTimeout(timeoutId);
     } catch (err) {
       clearTimeout(timeoutId);
+      // Caller explicitly aborted. Propagate their abort verbatim and don't
+      // retry. Release the trial slot (if any) so the breaker doesn't get
+      // stuck. Don't record this as a service failure — it's a caller
+      // cancellation, not an upstream problem.
+      if (init?.signal?.aborted) {
+        if (breakerWasHalfOpen) onBreakerTrialResult(service, false);
+        throw err;
+      }
       const e = err instanceof Error ? err : new Error(String(err));
       const isTimeout = e.name === 'AbortError' || e.name === 'TimeoutError';
       lastError = e;
@@ -209,13 +218,13 @@ function parseRetryAfter(header: string | null): number | null {
 }
 
 function computeBackoffMs(attemptJustCompleted: number): number {
-  // attemptJustCompleted is 1 after the first attempt, 2 after the second.
-  // Backoff waits BEFORE the next attempt: base * 2^(n-1) + jitter(0..base/2).
+  // attemptJustCompleted is 1 after the first attempt, 2 after the second,
+  // so exponent is always >= 0. Wait: base * 2^(n-1) + proportional jitter.
   const base = 500;
   const exponent = attemptJustCompleted - 1;
   const computed = base * Math.pow(2, exponent);
   const jitter = Math.random() * (base * Math.pow(2, exponent - 1));
-  return Math.floor(computed + (exponent >= 0 ? jitter : 0));
+  return Math.floor(computed + jitter);
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -52,64 +52,120 @@ export async function httpRequest<T>(
   opts?: HttpRequestOptions,
 ): Promise<T> {
   const timeoutMs = opts?.timeoutMs ?? 10_000;
+  const maxRetries = opts?.maxRetries ?? 2;
   const parseJson = opts?.parseJson ?? true;
-  const attempts = 1;
 
-  const timeoutSignal = AbortSignal.timeout(timeoutMs);
-  const signal = init?.signal
-    ? mergeSignals([init.signal, timeoutSignal])
-    : timeoutSignal;
+  let attempt = 0;
+  let sawRateLimit = false;
+  let sawTimeout = false;
+  let lastError: Error | undefined;
+  let lastStatus: number | undefined;
 
-  let response: Response;
-  try {
-    response = await fetch(url, { ...init, signal });
-  } catch (err) {
-    const e = err instanceof Error ? err : new Error(String(err));
-    const isTimeout = e.name === 'AbortError' || e.name === 'TimeoutError';
-    const outcome = isTimeout ? 'timeout' : 'failed';
-    recordOutcome(service, outcome, { msg: e.message });
-    noteFailure(service);
-    throw new HttpError({
-      service, attempts,
-      message: isTimeout
-        ? `${service} request timed out after ${timeoutMs}ms`
-        : `${service} request failed: ${e.message}`,
-      lastError: e,
-    });
+  while (attempt <= maxRetries) {
+    attempt += 1;
+    // NOTE: AbortController + setTimeout (rather than AbortSignal.timeout)
+    // avoids a fake-timer interaction bug in Node where a fired
+    // AbortSignal.timeout prevents subsequent setTimeout-based fake timers
+    // from advancing correctly in the same promise chain.
+    const abortController = new AbortController();
+    const timeoutId = setTimeout(() => {
+      abortController.abort();
+    }, timeoutMs);
+    const signal = init?.signal
+      ? mergeSignals([init.signal, abortController.signal])
+      : abortController.signal;
+
+    let response: Response;
+    try {
+      response = await fetch(url, { ...init, signal });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const e = err instanceof Error ? err : new Error(String(err));
+      const isTimeout = e.name === 'AbortError' || e.name === 'TimeoutError';
+      lastError = e;
+      if (isTimeout) sawTimeout = true;
+
+      if (attempt > maxRetries) break;
+      await sleep(computeBackoffMs(attempt));
+      continue;
+    }
+
+    if (response.ok) {
+      if (!parseJson) {
+        finishSuccess(service, attempt);
+        return undefined as T;
+      }
+      try {
+        const data = (await response.json()) as T;
+        finishSuccess(service, attempt);
+        return data;
+      } catch (err) {
+        const e = err instanceof Error ? err : new Error(String(err));
+        // JSON parse errors are not transient.
+        recordOutcome(service, 'failed', { msg: `JSON parse error: ${e.message}` });
+        noteFailure(service);
+        throw new HttpError({
+          service, attempts: attempt,
+          message: `${service} JSON parse error: ${e.message}`, lastError: e,
+        });
+      }
+    }
+
+    lastStatus = response.status;
+    if (response.status === 429) sawRateLimit = true;
+
+    if (!RETRYABLE_STATUSES.has(response.status)) {
+      // Non-retryable HTTP error.
+      recordOutcome(service, 'failed', {
+        msg: `${response.status} ${response.statusText}`,
+        status: response.status,
+      });
+      noteFailure(service);
+      throw new HttpError({
+        service, attempts: attempt, status: response.status,
+        message: `${service} API error: ${response.status} ${response.statusText}`,
+      });
+    }
+
+    if (attempt > maxRetries) break;
+    await sleep(computeBackoffMs(attempt));
   }
 
-  if (!response.ok) {
-    recordOutcome(service, 'failed', {
-      msg: `${response.status} ${response.statusText}`,
-      status: response.status,
-    });
-    noteFailure(service);
-    throw new HttpError({
-      service, attempts, status: response.status,
-      message: `${service} API error: ${response.status} ${response.statusText}`,
-    });
-  }
+  // Exhausted retries.
+  const outcome = sawRateLimit ? 'rate_limited' : sawTimeout ? 'timeout' : 'failed';
+  const msg = lastError
+    ? lastError.message
+    : lastStatus !== undefined
+    ? `${lastStatus}`
+    : 'unknown error';
+  recordOutcome(service, outcome, { msg, status: lastStatus });
+  noteFailure(service);
+  throw new HttpError({
+    service, attempts: attempt, status: lastStatus,
+    message: `${service} request failed after ${attempt} attempt(s): ${msg}`,
+    lastError,
+  });
+}
 
-  if (!parseJson) {
-    recordOutcome(service, 'ok');
-    noteSuccess(service);
-    return undefined as T;
-  }
+function finishSuccess(service: ServiceName, attempt: number): void {
+  recordOutcome(service, 'ok');
+  if (attempt > 1) recordOutcome(service, 'retried');
+  noteSuccess(service);
+}
 
-  try {
-    const data = (await response.json()) as T;
-    recordOutcome(service, 'ok');
-    noteSuccess(service);
-    return data;
-  } catch (err) {
-    const e = err instanceof Error ? err : new Error(String(err));
-    recordOutcome(service, 'failed', { msg: `JSON parse error: ${e.message}` });
-    noteFailure(service);
-    throw new HttpError({
-      service, attempts,
-      message: `${service} JSON parse error: ${e.message}`, lastError: e,
-    });
-  }
+function computeBackoffMs(attemptJustCompleted: number): number {
+  // attemptJustCompleted is 1 after the first attempt, 2 after the second.
+  // Backoff waits BEFORE the next attempt: base * 2^(n-1) + jitter(0..base/2).
+  const base = 500;
+  const exponent = attemptJustCompleted - 1;
+  const computed = base * Math.pow(2, exponent);
+  const jitter = Math.random() * (base * Math.pow(2, exponent - 1));
+  return Math.floor(computed + (exponent >= 0 ? jitter : 0));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 // Combines an external abort signal with a timeout signal. Aborts when

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -1,5 +1,8 @@
 import type { ServiceName } from './apiHealth.js';
-import { recordOutcome, noteFailure, noteSuccess } from './apiHealth.js';
+import {
+  recordOutcome, noteFailure, noteSuccess,
+  isBreakerOpen, onBreakerTrialResult, getSummary,
+} from './apiHealth.js';
 
 export type { ServiceName };
 
@@ -52,6 +55,16 @@ export async function httpRequest<T>(
   init?: RequestInit,
   opts?: HttpRequestOptions,
 ): Promise<T> {
+  if (isBreakerOpen(service)) {
+    recordOutcome(service, 'circuit_rejected', {
+      msg: `Circuit open for ${service}`,
+    });
+    throw new CircuitOpenError(service);
+  }
+
+  // If the breaker is in half_open, this call is the trial.
+  const breakerWasHalfOpen = getSummary(service).breaker === 'half_open';
+
   const timeoutMs = opts?.timeoutMs ?? 10_000;
   const maxRetries = opts?.maxRetries ?? 2;
   const parseJson = opts?.parseJson ?? true;
@@ -94,18 +107,19 @@ export async function httpRequest<T>(
 
     if (response.ok) {
       if (!parseJson) {
-        finishSuccess(service, attempt);
+        finishSuccess(service, attempt, breakerWasHalfOpen);
         return undefined as T;
       }
       try {
         const data = (await response.json()) as T;
-        finishSuccess(service, attempt);
+        finishSuccess(service, attempt, breakerWasHalfOpen);
         return data;
       } catch (err) {
         const e = err instanceof Error ? err : new Error(String(err));
         // JSON parse errors are not transient.
         recordOutcome(service, 'failed', { msg: `JSON parse error: ${e.message}` });
         noteFailure(service);
+        onFinalFailure(service, breakerWasHalfOpen);
         throw new HttpError({
           service, attempts: attempt,
           message: `${service} JSON parse error: ${e.message}`, lastError: e,
@@ -122,6 +136,7 @@ export async function httpRequest<T>(
         status: response.status,
       });
       noteFailure(service);
+      onFinalFailure(service, breakerWasHalfOpen);
       throw new HttpError({
         service, attempts: attempt, status: response.status,
         message: `${service} API error: ${response.status} ${response.statusText}`,
@@ -137,6 +152,7 @@ export async function httpRequest<T>(
         status: response.status,
       });
       noteFailure(service);
+      onFinalFailure(service, breakerWasHalfOpen);
       throw new HttpError({
         service, attempts: attempt, status: response.status,
         message: `${service} Retry-After exceeds ${RETRY_AFTER_CAP_MS / 1_000}s cap`,
@@ -157,6 +173,7 @@ export async function httpRequest<T>(
     : 'unknown error';
   recordOutcome(service, outcome, { msg, status: lastStatus });
   noteFailure(service);
+  onFinalFailure(service, breakerWasHalfOpen);
   throw new HttpError({
     service, attempts: attempt, status: lastStatus,
     message: `${service} request failed after ${attempt} attempt(s): ${msg}`,
@@ -164,10 +181,15 @@ export async function httpRequest<T>(
   });
 }
 
-function finishSuccess(service: ServiceName, attempt: number): void {
+function finishSuccess(service: ServiceName, attempt: number, wasTrial: boolean): void {
   recordOutcome(service, 'ok');
   if (attempt > 1) recordOutcome(service, 'retried');
   noteSuccess(service);
+  if (wasTrial) onBreakerTrialResult(service, true);
+}
+
+function onFinalFailure(service: ServiceName, wasTrial: boolean): void {
+  if (wasTrial) onBreakerTrialResult(service, false);
 }
 
 function parseRetryAfter(header: string | null): number | null {

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -102,10 +102,9 @@ export async function httpRequest<T>(
         // fetch threw AbortError but we don't know which signal caused it —
         // caller-supplied `init.signal` or our internal timeout. Check
         // init.signal.aborted to distinguish: if the caller aborted, don't
-        // retry and don't punish the service; release the trial slot and
-        // propagate verbatim.
+        // retry and don't punish the service. The outer finally will
+        // release the trial slot.
         if (init?.signal?.aborted) {
-          if (breakerWasHalfOpen) releaseBreakerTrialSlot(service);
           throw err;
         }
         const e = asError(err);
@@ -137,9 +136,9 @@ export async function httpRequest<T>(
           // Distinguish caller-abort from our timeout. response.json() throws
           // AbortError for either; the flags on the underlying controllers are
           // what tell us which signal fired. Must check the caller signal
-          // first — if both are aborted, caller-intent wins.
+          // first — if both are aborted, caller-intent wins. The outer
+          // finally will release the trial slot.
           if (init?.signal?.aborted) {
-            if (breakerWasHalfOpen) releaseBreakerTrialSlot(service);
             throw err;
           }
           if (abortController.signal.aborted) {
@@ -290,15 +289,15 @@ function sleep(ms: number, signal?: AbortSignal | null): Promise<void> {
     return Promise.reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
   }
   return new Promise((resolve, reject) => {
-    const id = setTimeout(resolve, ms);
-    signal?.addEventListener(
-      'abort',
-      () => {
-        clearTimeout(id);
-        reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
-      },
-      { once: true },
-    );
+    const onAbort = () => {
+      clearTimeout(id);
+      reject(signal!.reason ?? new DOMException('Aborted', 'AbortError'));
+    };
+    const id = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
   });
 }
 

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -51,18 +51,30 @@ export async function httpRequest<T>(
   init?: RequestInit,
   opts?: HttpRequestOptions,
 ): Promise<T> {
+  const timeoutMs = opts?.timeoutMs ?? 10_000;
   const parseJson = opts?.parseJson ?? true;
   const attempts = 1;
 
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = init?.signal
+    ? mergeSignals([init.signal, timeoutSignal])
+    : timeoutSignal;
+
   let response: Response;
   try {
-    response = await fetch(url, init);
+    response = await fetch(url, { ...init, signal });
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
-    recordOutcome(service, 'failed', { msg: e.message });
+    const isTimeout = e.name === 'AbortError' || e.name === 'TimeoutError';
+    const outcome = isTimeout ? 'timeout' : 'failed';
+    recordOutcome(service, outcome, { msg: e.message });
     noteFailure(service);
     throw new HttpError({
-      service, attempts, message: `${service} request failed: ${e.message}`, lastError: e,
+      service, attempts,
+      message: isTimeout
+        ? `${service} request timed out after ${timeoutMs}ms`
+        : `${service} request failed: ${e.message}`,
+      lastError: e,
     });
   }
 
@@ -98,4 +110,18 @@ export async function httpRequest<T>(
       message: `${service} JSON parse error: ${e.message}`, lastError: e,
     });
   }
+}
+
+// Combines an external abort signal with a timeout signal. Aborts when
+// either fires.
+function mergeSignals(signals: AbortSignal[]): AbortSignal {
+  const controller = new AbortController();
+  for (const s of signals) {
+    if (s.aborted) {
+      controller.abort(s.reason);
+      return controller.signal;
+    }
+    s.addEventListener('abort', () => controller.abort(s.reason), { once: true });
+  }
+  return controller.signal;
 }

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -69,6 +69,7 @@ export async function httpRequest<T>(
   // fast-fail at the check above.
   const breakerWasHalfOpen = tryClaimTrialSlot(service);
 
+  try {
   const timeoutMs = opts?.timeoutMs ?? 10_000;
   const maxRetries = opts?.maxRetries ?? 2;
   const parseJson = opts?.parseJson ?? true;
@@ -113,7 +114,7 @@ export async function httpRequest<T>(
       if (isTimeout) sawTimeout = true;
 
       if (attempt > maxRetries) break;
-      await sleep(computeBackoffMs(attempt));
+      await sleep(computeBackoffMs(attempt), init?.signal);
       continue;
     }
 
@@ -146,7 +147,7 @@ export async function httpRequest<T>(
           lastError = e;
           sawTimeout = true;
           if (attempt > maxRetries) break;
-          await sleep(computeBackoffMs(attempt));
+          await sleep(computeBackoffMs(attempt), init?.signal);
           continue;
         }
         // Genuine JSON parse error — not transient. Still honor outcome
@@ -201,7 +202,7 @@ export async function httpRequest<T>(
 
     if (attempt > maxRetries) break;
     const waitMs = retryAfterMs !== null ? retryAfterMs : computeBackoffMs(attempt);
-    await sleep(waitMs);
+    await sleep(waitMs, init?.signal);
   }
 
   // Exhausted retries.
@@ -221,6 +222,17 @@ export async function httpRequest<T>(
     message: `${service} request failed after ${attempt} attempt(s): ${msg}`,
     lastError,
   });
+  } finally {
+    // Defense in depth. All normal exit paths already release/resolve the
+    // trial slot (finishSuccess → onBreakerTrialResult(true); onFinalFailure
+    // → onBreakerTrialResult(false); caller-abort branches →
+    // releaseBreakerTrialSlot). releaseBreakerTrialSlot is a no-op unless
+    // state is still half_open with trialInFlight=true — so on normal
+    // exits this is harmless, and on unexpected throws (signal-aware
+    // sleep aborting, internal helper failing, etc.) it prevents the
+    // breaker from getting stuck.
+    if (breakerWasHalfOpen) releaseBreakerTrialSlot(service);
+  }
 }
 
 function finishSuccess(service: ServiceName, attempt: number, wasTrial: boolean): void {
@@ -269,6 +281,27 @@ function parseRetryAfter(header: string | null, serverDateHeader: string | null)
   return null;
 }
 
+// Signal-aware sleep. Rejects with the signal's reason if aborted.
+// We roll our own (rather than timers/promises.setTimeout) because the
+// test suite drives backoff via vitest fake timers, which intercept the
+// global setTimeout but not the timers/promises variant reliably.
+function sleep(ms: number, signal?: AbortSignal | null): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+  }
+  return new Promise((resolve, reject) => {
+    const id = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(id);
+        reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+      },
+      { once: true },
+    );
+  });
+}
+
 function computeBackoffMs(attemptJustCompleted: number): number {
   // attemptJustCompleted is 1 after the first attempt, 2 after the second,
   // so exponent is always >= 0. Wait: base * 2^(n-1) + proportional jitter.
@@ -279,6 +312,3 @@ function computeBackoffMs(attemptJustCompleted: number): number {
   return Math.floor(computed + jitter);
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -107,7 +107,7 @@ export async function httpRequest<T>(
         if (breakerWasHalfOpen) releaseBreakerTrialSlot(service);
         throw err;
       }
-      const e = err instanceof Error ? err : new Error(String(err));
+      const e = asError(err);
       const isTimeout = e.name === 'AbortError' || e.name === 'TimeoutError';
       lastError = e;
       if (isTimeout) sawTimeout = true;
@@ -142,16 +142,19 @@ export async function httpRequest<T>(
           throw err;
         }
         if (abortController.signal.aborted) {
-          const e = err instanceof Error ? err : new Error(String(err));
+          const e = asError(err);
           lastError = e;
           sawTimeout = true;
           if (attempt > maxRetries) break;
           await sleep(computeBackoffMs(attempt));
           continue;
         }
-        // Genuine JSON parse error — not transient.
-        const e = err instanceof Error ? err : new Error(String(err));
-        recordOutcome(service, 'failed', { msg: `JSON parse error: ${e.message}` });
+        // Genuine JSON parse error — not transient. Still honor outcome
+        // classification in case earlier attempts saw 429 / timeout.
+        const e = asError(err);
+        recordOutcome(service, classifyFinalFailure(sawRateLimit, sawTimeout), {
+          msg: `JSON parse error: ${e.message}`,
+        });
         noteFailure(service);
         onFinalFailure(service, breakerWasHalfOpen);
         throw new HttpError({
@@ -166,7 +169,7 @@ export async function httpRequest<T>(
     if (response.status === 429) sawRateLimit = true;
 
     if (!RETRYABLE_STATUSES.has(response.status)) {
-      recordOutcome(service, 'failed', {
+      recordOutcome(service, classifyFinalFailure(sawRateLimit, sawTimeout), {
         msg: `${response.status} ${response.statusText}`,
         status: response.status,
       });
@@ -184,8 +187,7 @@ export async function httpRequest<T>(
     );
     if (retryAfterMs !== null && retryAfterMs > RETRY_AFTER_CAP_MS) {
       // Upstream told us to wait longer than our cap; treat as final failure.
-      const outcome = sawRateLimit ? 'rate_limited' : 'failed';
-      recordOutcome(service, outcome, {
+      recordOutcome(service, classifyFinalFailure(sawRateLimit, sawTimeout), {
         msg: `Retry-After ${Math.round(retryAfterMs / 1_000)}s exceeds ${RETRY_AFTER_CAP_MS / 1_000}s cap`,
         status: response.status,
       });
@@ -203,13 +205,15 @@ export async function httpRequest<T>(
   }
 
   // Exhausted retries.
-  const outcome = sawRateLimit ? 'rate_limited' : sawTimeout ? 'timeout' : 'failed';
   const msg = lastError
     ? lastError.message
     : lastStatus !== undefined
     ? `${lastStatus}`
     : 'unknown error';
-  recordOutcome(service, outcome, { msg, status: lastStatus });
+  recordOutcome(service, classifyFinalFailure(sawRateLimit, sawTimeout), {
+    msg,
+    status: lastStatus,
+  });
   noteFailure(service);
   onFinalFailure(service, breakerWasHalfOpen);
   throw new HttpError({
@@ -228,6 +232,22 @@ function finishSuccess(service: ServiceName, attempt: number, wasTrial: boolean)
 
 function onFinalFailure(service: ServiceName, wasTrial: boolean): void {
   if (wasTrial) onBreakerTrialResult(service, false);
+}
+
+function asError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+// Outcome precedence for a final failure: if any attempt was rate-limited,
+// classify as rate_limited; otherwise if any timed out, timeout; else failed.
+// Matches the spec's outcome classification table.
+function classifyFinalFailure(
+  sawRateLimit: boolean,
+  sawTimeout: boolean,
+): 'rate_limited' | 'timeout' | 'failed' {
+  if (sawRateLimit) return 'rate_limited';
+  if (sawTimeout) return 'timeout';
+  return 'failed';
 }
 
 function parseRetryAfter(header: string | null, serverDateHeader: string | null): number | null {

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -56,12 +56,6 @@ export async function httpRequest<T>(
   init?: RequestInit,
   opts?: HttpRequestOptions,
 ): Promise<T> {
-  // Respect caller's abort signal before doing any work. Don't touch the
-  // breaker or record outcomes — the caller decided not to run this at all.
-  if (init?.signal?.aborted) {
-    throw init.signal.reason ?? new DOMException('Aborted', 'AbortError');
-  }
-
   if (isBreakerOpen(service)) {
     recordOutcome(service, 'circuit_rejected', {
       msg: `Circuit open for ${service}`,
@@ -104,9 +98,11 @@ export async function httpRequest<T>(
       response = await fetch(url, { ...init, signal });
     } catch (err) {
       clearTimeout(timeoutId);
-      // Caller explicitly aborted. Propagate verbatim, don't retry, and
-      // release (not fail) the trial slot — caller cancellation isn't a
-      // service failure and shouldn't reset the cooldown.
+      // fetch threw AbortError but we don't know which signal caused it —
+      // caller-supplied `init.signal` or our internal timeout. Check
+      // init.signal.aborted to distinguish: if the caller aborted, don't
+      // retry and don't punish the service; release the trial slot and
+      // propagate verbatim.
       if (init?.signal?.aborted) {
         if (breakerWasHalfOpen) releaseBreakerTrialSlot(service);
         throw err;
@@ -137,12 +133,14 @@ export async function httpRequest<T>(
         return data;
       } catch (err) {
         clearTimeout(timeoutId);
-        // Caller aborted during body parse → propagate, release trial slot.
+        // Distinguish caller-abort from our timeout. response.json() throws
+        // AbortError for either; the flags on the underlying controllers are
+        // what tell us which signal fired. Must check the caller signal
+        // first — if both are aborted, caller-intent wins.
         if (init?.signal?.aborted) {
           if (breakerWasHalfOpen) releaseBreakerTrialSlot(service);
           throw err;
         }
-        // Our timeout fired during body parse → treat as transient timeout.
         if (abortController.signal.aborted) {
           const e = err instanceof Error ? err : new Error(String(err));
           lastError = e;

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -70,158 +70,158 @@ export async function httpRequest<T>(
   const breakerWasHalfOpen = tryClaimTrialSlot(service);
 
   try {
-  const timeoutMs = opts?.timeoutMs ?? 10_000;
-  const maxRetries = opts?.maxRetries ?? 2;
-  const parseJson = opts?.parseJson ?? true;
+    const timeoutMs = opts?.timeoutMs ?? 10_000;
+    const maxRetries = opts?.maxRetries ?? 2;
+    const parseJson = opts?.parseJson ?? true;
 
-  let attempt = 0;
-  let sawRateLimit = false;
-  let sawTimeout = false;
-  let lastError: Error | undefined;
-  let lastStatus: number | undefined;
+    let attempt = 0;
+    let sawRateLimit = false;
+    let sawTimeout = false;
+    let lastError: Error | undefined;
+    let lastStatus: number | undefined;
 
-  while (attempt <= maxRetries) {
-    attempt += 1;
-    // NOTE: AbortController + setTimeout (rather than AbortSignal.timeout)
-    // avoids a fake-timer interaction bug in Node where a fired
-    // AbortSignal.timeout prevents subsequent setTimeout-based fake timers
-    // from advancing correctly in the same promise chain.
-    const abortController = new AbortController();
-    const timeoutId = setTimeout(() => {
-      abortController.abort();
-    }, timeoutMs);
-    const signal = init?.signal
-      ? AbortSignal.any([init.signal, abortController.signal])
-      : abortController.signal;
+    while (attempt <= maxRetries) {
+      attempt += 1;
+      // NOTE: AbortController + setTimeout (rather than AbortSignal.timeout)
+      // avoids a fake-timer interaction bug in Node where a fired
+      // AbortSignal.timeout prevents subsequent setTimeout-based fake timers
+      // from advancing correctly in the same promise chain.
+      const abortController = new AbortController();
+      const timeoutId = setTimeout(() => {
+        abortController.abort();
+      }, timeoutMs);
+      const signal = init?.signal
+        ? AbortSignal.any([init.signal, abortController.signal])
+        : abortController.signal;
 
-    let response: Response;
-    try {
-      response = await fetch(url, { ...init, signal });
-    } catch (err) {
-      clearTimeout(timeoutId);
-      // fetch threw AbortError but we don't know which signal caused it —
-      // caller-supplied `init.signal` or our internal timeout. Check
-      // init.signal.aborted to distinguish: if the caller aborted, don't
-      // retry and don't punish the service; release the trial slot and
-      // propagate verbatim.
-      if (init?.signal?.aborted) {
-        if (breakerWasHalfOpen) releaseBreakerTrialSlot(service);
-        throw err;
-      }
-      const e = asError(err);
-      const isTimeout = e.name === 'AbortError' || e.name === 'TimeoutError';
-      lastError = e;
-      if (isTimeout) sawTimeout = true;
-
-      if (attempt > maxRetries) break;
-      await sleep(computeBackoffMs(attempt), init?.signal);
-      continue;
-    }
-
-    if (response.ok) {
-      if (!parseJson) {
-        clearTimeout(timeoutId);
-        finishSuccess(service, attempt, breakerWasHalfOpen);
-        return undefined as T;
-      }
-      // NOTE: timeoutId is still armed — the timeout must cover body
-      // parsing, not just the fetch headers phase. A server that streams
-      // headers and hangs on the body would otherwise block indefinitely.
+      let response: Response;
       try {
-        const data = (await response.json()) as T;
-        clearTimeout(timeoutId);
-        finishSuccess(service, attempt, breakerWasHalfOpen);
-        return data;
+        response = await fetch(url, { ...init, signal });
       } catch (err) {
         clearTimeout(timeoutId);
-        // Distinguish caller-abort from our timeout. response.json() throws
-        // AbortError for either; the flags on the underlying controllers are
-        // what tell us which signal fired. Must check the caller signal
-        // first — if both are aborted, caller-intent wins.
+        // fetch threw AbortError but we don't know which signal caused it —
+        // caller-supplied `init.signal` or our internal timeout. Check
+        // init.signal.aborted to distinguish: if the caller aborted, don't
+        // retry and don't punish the service; release the trial slot and
+        // propagate verbatim.
         if (init?.signal?.aborted) {
           if (breakerWasHalfOpen) releaseBreakerTrialSlot(service);
           throw err;
         }
-        if (abortController.signal.aborted) {
-          const e = asError(err);
-          lastError = e;
-          sawTimeout = true;
-          if (attempt > maxRetries) break;
-          await sleep(computeBackoffMs(attempt), init?.signal);
-          continue;
-        }
-        // Genuine JSON parse error — not transient. Still honor outcome
-        // classification in case earlier attempts saw 429 / timeout.
         const e = asError(err);
+        const isTimeout = e.name === 'AbortError' || e.name === 'TimeoutError';
+        lastError = e;
+        if (isTimeout) sawTimeout = true;
+
+        if (attempt > maxRetries) break;
+        await sleep(computeBackoffMs(attempt), init?.signal);
+        continue;
+      }
+
+      if (response.ok) {
+        if (!parseJson) {
+          clearTimeout(timeoutId);
+          finishSuccess(service, attempt, breakerWasHalfOpen);
+          return undefined as T;
+        }
+        // NOTE: timeoutId is still armed — the timeout must cover body
+        // parsing, not just the fetch headers phase. A server that streams
+        // headers and hangs on the body would otherwise block indefinitely.
+        try {
+          const data = (await response.json()) as T;
+          clearTimeout(timeoutId);
+          finishSuccess(service, attempt, breakerWasHalfOpen);
+          return data;
+        } catch (err) {
+          clearTimeout(timeoutId);
+          // Distinguish caller-abort from our timeout. response.json() throws
+          // AbortError for either; the flags on the underlying controllers are
+          // what tell us which signal fired. Must check the caller signal
+          // first — if both are aborted, caller-intent wins.
+          if (init?.signal?.aborted) {
+            if (breakerWasHalfOpen) releaseBreakerTrialSlot(service);
+            throw err;
+          }
+          if (abortController.signal.aborted) {
+            const e = asError(err);
+            lastError = e;
+            sawTimeout = true;
+            if (attempt > maxRetries) break;
+            await sleep(computeBackoffMs(attempt), init?.signal);
+            continue;
+          }
+          // Genuine JSON parse error — not transient. Still honor outcome
+          // classification in case earlier attempts saw 429 / timeout.
+          const e = asError(err);
+          recordOutcome(service, classifyFinalFailure(sawRateLimit, sawTimeout), {
+            msg: `JSON parse error: ${e.message}`,
+          });
+          noteFailure(service);
+          onFinalFailure(service, breakerWasHalfOpen);
+          throw new HttpError({
+            service, attempts: attempt, status: response.status,
+            message: `${service} JSON parse error: ${e.message}`, lastError: e,
+          });
+        }
+      }
+
+      clearTimeout(timeoutId);
+      lastStatus = response.status;
+      if (response.status === 429) sawRateLimit = true;
+
+      if (!RETRYABLE_STATUSES.has(response.status)) {
         recordOutcome(service, classifyFinalFailure(sawRateLimit, sawTimeout), {
-          msg: `JSON parse error: ${e.message}`,
+          msg: `${response.status} ${response.statusText}`,
+          status: response.status,
         });
         noteFailure(service);
         onFinalFailure(service, breakerWasHalfOpen);
         throw new HttpError({
-          service, attempts: attempt,
-          message: `${service} JSON parse error: ${e.message}`, lastError: e,
+          service, attempts: attempt, status: response.status,
+          message: `${service} API error: ${response.status} ${response.statusText}`,
         });
       }
+
+      const retryAfterMs = parseRetryAfter(
+        response.headers.get('retry-after'),
+        response.headers.get('date'),
+      );
+      if (retryAfterMs !== null && retryAfterMs > RETRY_AFTER_CAP_MS) {
+        // Upstream told us to wait longer than our cap; treat as final failure.
+        recordOutcome(service, classifyFinalFailure(sawRateLimit, sawTimeout), {
+          msg: `Retry-After ${Math.round(retryAfterMs / 1_000)}s exceeds ${RETRY_AFTER_CAP_MS / 1_000}s cap`,
+          status: response.status,
+        });
+        noteFailure(service);
+        onFinalFailure(service, breakerWasHalfOpen);
+        throw new HttpError({
+          service, attempts: attempt, status: response.status,
+          message: `${service} Retry-After exceeds ${RETRY_AFTER_CAP_MS / 1_000}s cap`,
+        });
+      }
+
+      if (attempt > maxRetries) break;
+      const waitMs = retryAfterMs !== null ? retryAfterMs : computeBackoffMs(attempt);
+      await sleep(waitMs, init?.signal);
     }
 
-    clearTimeout(timeoutId);
-    lastStatus = response.status;
-    if (response.status === 429) sawRateLimit = true;
-
-    if (!RETRYABLE_STATUSES.has(response.status)) {
-      recordOutcome(service, classifyFinalFailure(sawRateLimit, sawTimeout), {
-        msg: `${response.status} ${response.statusText}`,
-        status: response.status,
-      });
-      noteFailure(service);
-      onFinalFailure(service, breakerWasHalfOpen);
-      throw new HttpError({
-        service, attempts: attempt, status: response.status,
-        message: `${service} API error: ${response.status} ${response.statusText}`,
-      });
-    }
-
-    const retryAfterMs = parseRetryAfter(
-      response.headers.get('retry-after'),
-      response.headers.get('date'),
-    );
-    if (retryAfterMs !== null && retryAfterMs > RETRY_AFTER_CAP_MS) {
-      // Upstream told us to wait longer than our cap; treat as final failure.
-      recordOutcome(service, classifyFinalFailure(sawRateLimit, sawTimeout), {
-        msg: `Retry-After ${Math.round(retryAfterMs / 1_000)}s exceeds ${RETRY_AFTER_CAP_MS / 1_000}s cap`,
-        status: response.status,
-      });
-      noteFailure(service);
-      onFinalFailure(service, breakerWasHalfOpen);
-      throw new HttpError({
-        service, attempts: attempt, status: response.status,
-        message: `${service} Retry-After exceeds ${RETRY_AFTER_CAP_MS / 1_000}s cap`,
-      });
-    }
-
-    if (attempt > maxRetries) break;
-    const waitMs = retryAfterMs !== null ? retryAfterMs : computeBackoffMs(attempt);
-    await sleep(waitMs, init?.signal);
-  }
-
-  // Exhausted retries.
-  const msg = lastError
-    ? lastError.message
-    : lastStatus !== undefined
-    ? `${lastStatus}`
-    : 'unknown error';
-  recordOutcome(service, classifyFinalFailure(sawRateLimit, sawTimeout), {
-    msg,
-    status: lastStatus,
-  });
-  noteFailure(service);
-  onFinalFailure(service, breakerWasHalfOpen);
-  throw new HttpError({
-    service, attempts: attempt, status: lastStatus,
-    message: `${service} request failed after ${attempt} attempt(s): ${msg}`,
-    lastError,
-  });
+    // Exhausted retries.
+    const msg = lastError
+      ? lastError.message
+      : lastStatus !== undefined
+      ? `${lastStatus}`
+      : 'unknown error';
+    recordOutcome(service, classifyFinalFailure(sawRateLimit, sawTimeout), {
+      msg,
+      status: lastStatus,
+    });
+    noteFailure(service);
+    onFinalFailure(service, breakerWasHalfOpen);
+    throw new HttpError({
+      service, attempts: attempt, status: lastStatus,
+      message: `${service} request failed after ${attempt} attempt(s): ${msg}`,
+      lastError,
+    });
   } finally {
     // Defense in depth. All normal exit paths already release/resolve the
     // trial slot (finishSuccess → onBreakerTrialResult(true); onFinalFailure

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -1,0 +1,101 @@
+import type { ServiceName } from './apiHealth.js';
+import { recordOutcome, noteFailure, noteSuccess } from './apiHealth.js';
+
+export type { ServiceName };
+
+export interface HttpRequestOptions {
+  timeoutMs?: number;
+  maxRetries?: number;
+  parseJson?: boolean;
+}
+
+export class HttpError extends Error {
+  readonly service: ServiceName;
+  readonly status?: number;
+  readonly attempts: number;
+  readonly lastError?: Error;
+
+  constructor(args: {
+    service: ServiceName;
+    status?: number;
+    attempts: number;
+    message: string;
+    lastError?: Error;
+  }) {
+    super(args.message);
+    this.name = 'HttpError';
+    this.service = args.service;
+    this.status = args.status;
+    this.attempts = args.attempts;
+    this.lastError = args.lastError;
+  }
+}
+
+export class CircuitOpenError extends Error {
+  readonly service: ServiceName;
+  constructor(service: ServiceName) {
+    super(`Circuit open for ${service}`);
+    this.name = 'CircuitOpenError';
+    this.service = service;
+  }
+}
+
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+// NOTE: httpRequest assumes all calls are idempotent. All current callers
+// (Raider.io/wowaudit GETs, WarcraftLogs OAuth client_credentials POST and
+// GraphQL read queries) are safe to retry. Adding a non-idempotent caller
+// in future requires a caller-level opt-out (e.g. `opts.maxRetries = 0`).
+export async function httpRequest<T>(
+  service: ServiceName,
+  url: string,
+  init?: RequestInit,
+  opts?: HttpRequestOptions,
+): Promise<T> {
+  const parseJson = opts?.parseJson ?? true;
+  const attempts = 1;
+
+  let response: Response;
+  try {
+    response = await fetch(url, init);
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    recordOutcome(service, 'failed', { msg: e.message });
+    noteFailure(service);
+    throw new HttpError({
+      service, attempts, message: `${service} request failed: ${e.message}`, lastError: e,
+    });
+  }
+
+  if (!response.ok) {
+    recordOutcome(service, 'failed', {
+      msg: `${response.status} ${response.statusText}`,
+      status: response.status,
+    });
+    noteFailure(service);
+    throw new HttpError({
+      service, attempts, status: response.status,
+      message: `${service} API error: ${response.status} ${response.statusText}`,
+    });
+  }
+
+  if (!parseJson) {
+    recordOutcome(service, 'ok');
+    noteSuccess(service);
+    return undefined as T;
+  }
+
+  try {
+    const data = (await response.json()) as T;
+    recordOutcome(service, 'ok');
+    noteSuccess(service);
+    return data;
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    recordOutcome(service, 'failed', { msg: `JSON parse error: ${e.message}` });
+    noteFailure(service);
+    throw new HttpError({
+      service, attempts,
+      message: `${service} JSON parse error: ${e.message}`, lastError: e,
+    });
+  }
+}

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -1,7 +1,7 @@
 import type { ServiceName } from './apiHealth.js';
 import {
   recordOutcome, noteFailure, noteSuccess,
-  isBreakerOpen, onBreakerTrialResult, getSummary,
+  isBreakerOpen, onBreakerTrialResult, getBreakerState,
 } from './apiHealth.js';
 
 export type { ServiceName };
@@ -62,8 +62,10 @@ export async function httpRequest<T>(
     throw new CircuitOpenError(service);
   }
 
-  // If the breaker is in half_open, this call is the trial.
-  const breakerWasHalfOpen = getSummary(service).breaker === 'half_open';
+  // isBreakerOpen already transitioned state and (for half_open) claimed the
+  // trial slot. If the breaker is half_open here, this call is the trial and
+  // must resolve it via onBreakerTrialResult on every exit path.
+  const breakerWasHalfOpen = getBreakerState(service) === 'half_open';
 
   const timeoutMs = opts?.timeoutMs ?? 10_000;
   const maxRetries = opts?.maxRetries ?? 2;
@@ -86,7 +88,7 @@ export async function httpRequest<T>(
       abortController.abort();
     }, timeoutMs);
     const signal = init?.signal
-      ? mergeSignals([init.signal, abortController.signal])
+      ? AbortSignal.any([init.signal, abortController.signal])
       : abortController.signal;
 
     let response: Response;
@@ -218,18 +220,4 @@ function computeBackoffMs(attemptJustCompleted: number): number {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-// Combines an external abort signal with a timeout signal. Aborts when
-// either fires.
-function mergeSignals(signals: AbortSignal[]): AbortSignal {
-  const controller = new AbortController();
-  for (const s of signals) {
-    if (s.aborted) {
-      controller.abort(s.reason);
-      return controller.signal;
-    }
-    s.addEventListener('abort', () => controller.abort(s.reason), { once: true });
-  }
-  return controller.signal;
 }

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -41,6 +41,7 @@ export class CircuitOpenError extends Error {
 }
 
 const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+const RETRY_AFTER_CAP_MS = 30_000;
 // NOTE: httpRequest assumes all calls are idempotent. All current callers
 // (Raider.io/wowaudit GETs, WarcraftLogs OAuth client_credentials POST and
 // GraphQL read queries) are safe to retry. Adding a non-idempotent caller
@@ -116,7 +117,6 @@ export async function httpRequest<T>(
     if (response.status === 429) sawRateLimit = true;
 
     if (!RETRYABLE_STATUSES.has(response.status)) {
-      // Non-retryable HTTP error.
       recordOutcome(service, 'failed', {
         msg: `${response.status} ${response.statusText}`,
         status: response.status,
@@ -128,8 +128,24 @@ export async function httpRequest<T>(
       });
     }
 
+    const retryAfterMs = parseRetryAfter(response.headers.get('retry-after'));
+    if (retryAfterMs !== null && retryAfterMs > RETRY_AFTER_CAP_MS) {
+      // Upstream told us to wait longer than our cap; treat as final failure.
+      const outcome = sawRateLimit ? 'rate_limited' : 'failed';
+      recordOutcome(service, outcome, {
+        msg: `Retry-After ${Math.round(retryAfterMs / 1_000)}s exceeds ${RETRY_AFTER_CAP_MS / 1_000}s cap`,
+        status: response.status,
+      });
+      noteFailure(service);
+      throw new HttpError({
+        service, attempts: attempt, status: response.status,
+        message: `${service} Retry-After exceeds ${RETRY_AFTER_CAP_MS / 1_000}s cap`,
+      });
+    }
+
     if (attempt > maxRetries) break;
-    await sleep(computeBackoffMs(attempt));
+    const waitMs = retryAfterMs !== null ? retryAfterMs : computeBackoffMs(attempt);
+    await sleep(waitMs);
   }
 
   // Exhausted retries.
@@ -152,6 +168,20 @@ function finishSuccess(service: ServiceName, attempt: number): void {
   recordOutcome(service, 'ok');
   if (attempt > 1) recordOutcome(service, 'retried');
   noteSuccess(service);
+}
+
+function parseRetryAfter(header: string | null): number | null {
+  if (!header) return null;
+  const trimmed = header.trim();
+  const seconds = Number(trimmed);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.floor(seconds * 1_000);
+  }
+  const asDate = Date.parse(trimmed);
+  if (!Number.isNaN(asDate)) {
+    return Math.max(0, asDate - Date.now());
+  }
+  return null;
 }
 
 function computeBackoffMs(attemptJustCompleted: number): number {

--- a/src/services/raiderio.ts
+++ b/src/services/raiderio.ts
@@ -1,4 +1,5 @@
 import { config } from '../config.js';
+import { httpRequest } from './httpClient.js';
 
 const BASE_URL = 'https://raider.io/api/v1';
 const ROSTER_RANKS = [0, 1, 3, 4, 5, 7];
@@ -50,37 +51,19 @@ export interface MythicPlusRun {
 
 export async function getGuildRoster(): Promise<RaiderIoMember[]> {
   const url = `${BASE_URL}/guilds/profile?region=eu&realm=silvermoon&name=seriouslycasual&fields=members`;
-
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Raider.io API error: ${response.status} ${response.statusText}`);
-  }
-
-  const data = (await response.json()) as { members: RaiderIoMember[] };
+  const data = await httpRequest<{ members: RaiderIoMember[] }>('raiderio', url);
   return data.members.filter((m) => ROSTER_RANKS.includes(m.rank));
 }
 
 export async function getRaidRankings(raidSlug: string): Promise<RaidRanking[]> {
   const url = `${BASE_URL}/raiding/raid-rankings?raid=${raidSlug}&difficulty=mythic&region=world&guilds=${config.raiderIoGuildIds}&limit=50`;
-
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Raider.io API error: ${response.status} ${response.statusText}`);
-  }
-
-  const data = (await response.json()) as { raidRankings: RaidRanking[] };
+  const data = await httpRequest<{ raidRankings: RaidRanking[] }>('raiderio', url);
   return data.raidRankings;
 }
 
 export async function getRaidStaticData(expansionId: number): Promise<RaidStaticData> {
   const url = `${BASE_URL}/raiding/static-data?expansion_id=${expansionId}`;
-
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Raider.io API error: ${response.status} ${response.statusText}`);
-  }
-
-  return (await response.json()) as RaidStaticData;
+  return httpRequest<RaidStaticData>('raiderio', url);
 }
 
 export async function getWeeklyMythicPlusRuns(
@@ -89,14 +72,8 @@ export async function getWeeklyMythicPlusRuns(
   name: string,
 ): Promise<MythicPlusRun[]> {
   const url = `${BASE_URL}/characters/profile?region=${region}&realm=${realm}&name=${encodeURIComponent(name)}&fields=mythic_plus_previous_weekly_highest_level_runs`;
-
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Raider.io API error: ${response.status} ${response.statusText}`);
-  }
-
-  const data = (await response.json()) as {
+  const data = await httpRequest<{
     mythic_plus_previous_weekly_highest_level_runs: MythicPlusRun[];
-  };
+  }>('raiderio', url);
   return data.mythic_plus_previous_weekly_highest_level_runs;
 }

--- a/src/services/warcraftlogs.ts
+++ b/src/services/warcraftlogs.ts
@@ -1,10 +1,16 @@
 import { config } from '../config.js';
 import { logger } from './logger.js';
+import { httpRequest, HttpError, CircuitOpenError } from './httpClient.js';
 
 // ─── Token Cache ─────────────────────────────────────────────
 
 let cachedToken: string | null = null;
 let tokenExpiresAt = 0;
+
+interface TokenResponse {
+  access_token: string;
+  expires_in: number;
+}
 
 async function getAccessToken(): Promise<string> {
   const now = Date.now();
@@ -15,29 +21,22 @@ async function getAccessToken(): Promise<string> {
 
   const body = new URLSearchParams({ grant_type: 'client_credentials' });
 
-  const response = await fetch('https://www.warcraftlogs.com/oauth/token', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      Authorization:
-        'Basic ' +
-        Buffer.from(
-          `${config.warcraftLogsClientId}:${config.warcraftLogsClientSecret}`,
-        ).toString('base64'),
+  const data = await httpRequest<TokenResponse>(
+    'warcraftlogs',
+    'https://www.warcraftlogs.com/oauth/token',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization:
+          'Basic ' +
+          Buffer.from(
+            `${config.warcraftLogsClientId}:${config.warcraftLogsClientSecret}`,
+          ).toString('base64'),
+      },
+      body: body.toString(),
     },
-    body: body.toString(),
-  });
-
-  if (!response.ok) {
-    throw new Error(
-      `WarcraftLogs OAuth error: ${response.status} ${response.statusText}`,
-    );
-  }
-
-  const data = (await response.json()) as {
-    access_token: string;
-    expires_in: number;
-  };
+  );
 
   cachedToken = data.access_token;
   // Expire 60 seconds early to avoid edge cases
@@ -95,13 +94,14 @@ const ATTENDANCE_QUERY = `
 /**
  * Fetch WarcraftLogs report codes where `characterName` was present.
  * Returns codes in reverse chronological order (newest first).
- * Returns empty array on error.
+ * Returns empty array on any HTTP error or open circuit (fail-soft).
  */
 export async function getTrialLogs(characterName: string): Promise<string[]> {
   try {
     const token = await getAccessToken();
 
-    const response = await fetch(
+    const result = await httpRequest<GuildAttendanceResponse>(
+      'warcraftlogs',
       'https://www.warcraftlogs.com/api/v2/client',
       {
         method: 'POST',
@@ -118,18 +118,8 @@ export async function getTrialLogs(characterName: string): Promise<string[]> {
       },
     );
 
-    if (!response.ok) {
-      logger.warn(
-        'WarcraftLogs',
-        `API error: ${response.status} ${response.statusText}`,
-      );
-      return [];
-    }
-
-    const result = (await response.json()) as GuildAttendanceResponse;
     const reports = result.data.guildData.guild.attendance.data;
 
-    // Filter reports where the character was present (presence === 1)
     const matchingCodes = reports
       .filter((report) =>
         report.players.some(
@@ -139,14 +129,15 @@ export async function getTrialLogs(characterName: string): Promise<string[]> {
       )
       .map((report) => report.code);
 
-    // Reverse chronological order (API returns newest first, but reverse to be safe)
     return matchingCodes.reverse();
   } catch (error) {
-    const err = error instanceof Error ? error : new Error(String(error));
-    logger.warn(
-      'WarcraftLogs',
-      `Failed to fetch trial logs for "${characterName}": ${err.message}`,
-    );
-    return [];
+    if (error instanceof HttpError || error instanceof CircuitOpenError) {
+      logger.warn(
+        'WarcraftLogs',
+        `Failed to fetch trial logs for "${characterName}": ${error.message}`,
+      );
+      return [];
+    }
+    throw error;
   }
 }

--- a/src/services/warcraftlogs.ts
+++ b/src/services/warcraftlogs.ts
@@ -93,7 +93,6 @@ const ATTENDANCE_QUERY = `
 
 /**
  * Fetch WarcraftLogs report codes where `characterName` was present.
- * Returns codes in reverse chronological order (newest first).
  * Returns empty array on any HTTP error or open circuit (fail-soft).
  */
 export async function getTrialLogs(characterName: string): Promise<string[]> {
@@ -129,8 +128,12 @@ export async function getTrialLogs(characterName: string): Promise<string[]> {
       )
       .map((report) => report.code);
 
-    // WCL's attendance.data is already newest-first; don't reverse.
-    return matchingCodes;
+    // Preserve V1 ordering behavior. The exact natural order of WCL's
+    // attendance.data isn't contractually documented; .reverse() has been
+    // in place since V1 and consumers (`generateTrialLogsContent`) number
+    // the output as "1. Report <code>" — flipping the order here would
+    // silently change what reviewers see.
+    return matchingCodes.reverse();
   } catch (error) {
     if (error instanceof HttpError || error instanceof CircuitOpenError) {
       logger.warn(

--- a/src/services/warcraftlogs.ts
+++ b/src/services/warcraftlogs.ts
@@ -129,7 +129,8 @@ export async function getTrialLogs(characterName: string): Promise<string[]> {
       )
       .map((report) => report.code);
 
-    return matchingCodes.reverse();
+    // WCL's attendance.data is already newest-first; don't reverse.
+    return matchingCodes;
   } catch (error) {
     if (error instanceof HttpError || error instanceof CircuitOpenError) {
       logger.warn(

--- a/src/services/wowaudit.ts
+++ b/src/services/wowaudit.ts
@@ -1,4 +1,5 @@
 import { config } from '../config.js';
+import { httpRequest } from './httpClient.js';
 
 const BASE_URL = 'https://wowaudit.com/v1';
 
@@ -33,34 +34,29 @@ export interface WowAuditHistoricalEntry {
 }
 
 async function getCurrentPeriod(): Promise<number> {
-  const response = await fetch(`${BASE_URL}/period`, { headers: headers() });
-  if (!response.ok) {
-    throw new Error(`WoW Audit API error: ${response.status} ${response.statusText}`);
-  }
-
-  const data = (await response.json()) as { current_period: number };
+  const data = await httpRequest<{ current_period: number }>(
+    'wowaudit',
+    `${BASE_URL}/period`,
+    { headers: headers() },
+  );
   return data.current_period;
 }
 
 export async function getUpcomingRaids(): Promise<WowAuditRaid[]> {
-  const response = await fetch(`${BASE_URL}/raids?include_past=false`, { headers: headers() });
-  if (!response.ok) {
-    throw new Error(`WoW Audit API error: ${response.status} ${response.statusText}`);
-  }
-
-  return (await response.json()) as WowAuditRaid[];
+  return httpRequest<WowAuditRaid[]>(
+    'wowaudit',
+    `${BASE_URL}/raids?include_past=false`,
+    { headers: headers() },
+  );
 }
 
 export async function getHistoricalData(): Promise<WowAuditHistoricalEntry[]> {
   const currentPeriod = await getCurrentPeriod();
   const previousPeriod = currentPeriod - 1;
 
-  const response = await fetch(`${BASE_URL}/historical_data?period=${previousPeriod}`, {
-    headers: headers(),
-  });
-  if (!response.ok) {
-    throw new Error(`WoW Audit API error: ${response.status} ${response.statusText}`);
-  }
-
-  return (await response.json()) as WowAuditHistoricalEntry[];
+  return httpRequest<WowAuditHistoricalEntry[]>(
+    'wowaudit',
+    `${BASE_URL}/historical_data?period=${previousPeriod}`,
+    { headers: headers() },
+  );
 }

--- a/tests/unit/apiHealth.test.ts
+++ b/tests/unit/apiHealth.test.ts
@@ -10,6 +10,7 @@ import {
   noteFailure,
   noteSuccess,
   onBreakerTrialResult,
+  getBreakerState,
 } from '../../src/services/apiHealth.js';
 
 beforeEach(() => {
@@ -132,5 +133,52 @@ describe('apiHealth breaker', () => {
     expect(isBreakerOpen('raiderio')).toBe(true);
     vi.setSystemTime(new Date('2026-04-19T12:02:00Z'));
     expect(isBreakerOpen('raiderio')).toBe(false);
+  });
+
+  it('rejects concurrent calls while a half_open trial is in flight', () => {
+    for (let i = 0; i < 5; i++) noteFailure('raiderio');
+    vi.setSystemTime(new Date('2026-04-19T12:01:00Z'));
+
+    // First call transitions to half_open and claims the trial slot.
+    expect(isBreakerOpen('raiderio')).toBe(false);
+    // Concurrent calls while the trial is still in flight are rejected.
+    expect(isBreakerOpen('raiderio')).toBe(true);
+    expect(isBreakerOpen('raiderio')).toBe(true);
+
+    // Resolving the trial clears the slot; next caller can claim a new trial
+    // only after the breaker cycles back to open and half-opens again.
+    onBreakerTrialResult('raiderio', true);
+    expect(getBreakerState('raiderio')).toBe('closed');
+    expect(isBreakerOpen('raiderio')).toBe(false);
+  });
+
+  it('clears trialInFlight on failed trial so the next cooldown can re-claim', () => {
+    for (let i = 0; i < 5; i++) noteFailure('raiderio');
+    vi.setSystemTime(new Date('2026-04-19T12:01:00Z'));
+
+    expect(isBreakerOpen('raiderio')).toBe(false); // claim trial
+    onBreakerTrialResult('raiderio', false); // trial fails → reopen
+    expect(getBreakerState('raiderio')).toBe('open');
+
+    // Past the new cooldown, another trial slot should be claimable.
+    vi.setSystemTime(new Date('2026-04-19T12:02:00Z'));
+    expect(isBreakerOpen('raiderio')).toBe(false);
+    expect(isBreakerOpen('raiderio')).toBe(true); // only one at a time
+  });
+});
+
+describe('apiHealth getBreakerState', () => {
+  it('returns current state and applies lazy open->half_open transition without claiming the trial', () => {
+    for (let i = 0; i < 5; i++) noteFailure('raiderio');
+    expect(getBreakerState('raiderio')).toBe('open');
+
+    vi.setSystemTime(new Date('2026-04-19T12:01:00Z'));
+    // Observer transitions state but does not claim the trial slot.
+    expect(getBreakerState('raiderio')).toBe('half_open');
+    expect(getBreakerState('raiderio')).toBe('half_open');
+
+    // isBreakerOpen is what claims the slot.
+    expect(isBreakerOpen('raiderio')).toBe(false); // claims
+    expect(isBreakerOpen('raiderio')).toBe(true); // second is rejected
   });
 });

--- a/tests/unit/apiHealth.test.ts
+++ b/tests/unit/apiHealth.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  recordOutcome,
+  getSummary,
+  getAllSummaries,
+  __resetForTests,
+} from '../../src/services/apiHealth.js';
+
+beforeEach(() => {
+  __resetForTests();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-19T12:00:00Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('apiHealth tracker core', () => {
+  it('starts with zeroed totals and closed breaker', () => {
+    const s = getSummary('raiderio');
+    expect(s.totals).toEqual({
+      ok: 0, retried: 0, rateLimited: 0, timeouts: 0, failed: 0, circuitRejected: 0,
+    });
+    expect(s.breaker).toBe('closed');
+    expect(s.lastError).toBeUndefined();
+  });
+
+  it('accumulates outcomes in the current minute bucket', () => {
+    recordOutcome('raiderio', 'ok');
+    recordOutcome('raiderio', 'ok');
+    recordOutcome('raiderio', 'retried');
+    recordOutcome('raiderio', 'failed', { msg: 'boom', status: 500 });
+
+    const s = getSummary('raiderio');
+    expect(s.totals.ok).toBe(2);
+    expect(s.totals.retried).toBe(1);
+    expect(s.totals.failed).toBe(1);
+    expect(s.lastError).toEqual({
+      msg: 'boom',
+      status: 500,
+      at: new Date('2026-04-19T12:00:00Z'),
+    });
+  });
+
+  it('evicts buckets older than 60 minutes', () => {
+    recordOutcome('raiderio', 'ok');
+
+    vi.setSystemTime(new Date('2026-04-19T12:59:59Z'));
+    expect(getSummary('raiderio').totals.ok).toBe(1);
+
+    vi.setSystemTime(new Date('2026-04-19T13:00:01Z'));
+    expect(getSummary('raiderio').totals.ok).toBe(0);
+  });
+
+  it('keeps per-service state isolated', () => {
+    recordOutcome('raiderio', 'ok');
+    recordOutcome('wowaudit', 'failed', { msg: 'x' });
+
+    expect(getSummary('raiderio').totals.ok).toBe(1);
+    expect(getSummary('raiderio').totals.failed).toBe(0);
+    expect(getSummary('wowaudit').totals.ok).toBe(0);
+    expect(getSummary('wowaudit').totals.failed).toBe(1);
+  });
+
+  it('getAllSummaries returns an entry per known service', () => {
+    const all = getAllSummaries();
+    expect(Object.keys(all).sort()).toEqual(['raiderio', 'warcraftlogs', 'wowaudit']);
+  });
+});

--- a/tests/unit/apiHealth.test.ts
+++ b/tests/unit/apiHealth.test.ts
@@ -5,6 +5,12 @@ import {
   getAllSummaries,
   __resetForTests,
 } from '../../src/services/apiHealth.js';
+import {
+  isBreakerOpen,
+  noteFailure,
+  noteSuccess,
+  onBreakerTrialResult,
+} from '../../src/services/apiHealth.js';
 
 beforeEach(() => {
   __resetForTests();
@@ -66,5 +72,65 @@ describe('apiHealth tracker core', () => {
   it('getAllSummaries returns an entry per known service', () => {
     const all = getAllSummaries();
     expect(Object.keys(all).sort()).toEqual(['raiderio', 'warcraftlogs', 'wowaudit']);
+  });
+});
+
+describe('apiHealth breaker', () => {
+  it('opens after 5 consecutive failures', () => {
+    for (let i = 0; i < 4; i++) noteFailure('raiderio');
+    expect(isBreakerOpen('raiderio')).toBe(false);
+    expect(getSummary('raiderio').breaker).toBe('closed');
+
+    noteFailure('raiderio');
+    expect(isBreakerOpen('raiderio')).toBe(true);
+    expect(getSummary('raiderio').breaker).toBe('open');
+  });
+
+  it('resets consecutive failures on success', () => {
+    for (let i = 0; i < 4; i++) noteFailure('raiderio');
+    noteSuccess('raiderio');
+    for (let i = 0; i < 4; i++) noteFailure('raiderio');
+    expect(isBreakerOpen('raiderio')).toBe(false);
+
+    noteFailure('raiderio');
+    expect(isBreakerOpen('raiderio')).toBe(true);
+  });
+
+  it('transitions open -> half_open after 60s cooldown', () => {
+    for (let i = 0; i < 5; i++) noteFailure('raiderio');
+    expect(getSummary('raiderio').breaker).toBe('open');
+
+    vi.setSystemTime(new Date('2026-04-19T12:00:59Z'));
+    expect(isBreakerOpen('raiderio')).toBe(true);
+
+    vi.setSystemTime(new Date('2026-04-19T12:01:00Z'));
+    expect(isBreakerOpen('raiderio')).toBe(false);
+    expect(getSummary('raiderio').breaker).toBe('half_open');
+  });
+
+  it('half_open -> closed on trial success, resets counter', () => {
+    for (let i = 0; i < 5; i++) noteFailure('raiderio');
+    vi.setSystemTime(new Date('2026-04-19T12:01:00Z'));
+    expect(getSummary('raiderio').breaker).toBe('half_open');
+
+    onBreakerTrialResult('raiderio', true);
+    expect(getSummary('raiderio').breaker).toBe('closed');
+
+    for (let i = 0; i < 4; i++) noteFailure('raiderio');
+    expect(isBreakerOpen('raiderio')).toBe(false);
+  });
+
+  it('half_open -> open on trial failure, cooldown resets', () => {
+    for (let i = 0; i < 5; i++) noteFailure('raiderio');
+    vi.setSystemTime(new Date('2026-04-19T12:01:00Z'));
+    expect(getSummary('raiderio').breaker).toBe('half_open');
+
+    onBreakerTrialResult('raiderio', false);
+    expect(getSummary('raiderio').breaker).toBe('open');
+
+    vi.setSystemTime(new Date('2026-04-19T12:01:59Z'));
+    expect(isBreakerOpen('raiderio')).toBe(true);
+    vi.setSystemTime(new Date('2026-04-19T12:02:00Z'));
+    expect(isBreakerOpen('raiderio')).toBe(false);
   });
 });

--- a/tests/unit/apiHealth.test.ts
+++ b/tests/unit/apiHealth.test.ts
@@ -11,6 +11,7 @@ import {
   noteSuccess,
   onBreakerTrialResult,
   getBreakerState,
+  tryClaimTrialSlot,
 } from '../../src/services/apiHealth.js';
 
 beforeEach(() => {
@@ -139,14 +140,17 @@ describe('apiHealth breaker', () => {
     for (let i = 0; i < 5; i++) noteFailure('raiderio');
     vi.setSystemTime(new Date('2026-04-19T12:01:00Z'));
 
-    // First call transitions to half_open and claims the trial slot.
+    // Observing (pure) doesn't block: state is half_open, no trial yet.
     expect(isBreakerOpen('raiderio')).toBe(false);
-    // Concurrent calls while the trial is still in flight are rejected.
-    expect(isBreakerOpen('raiderio')).toBe(true);
-    expect(isBreakerOpen('raiderio')).toBe(true);
 
-    // Resolving the trial clears the slot; next caller can claim a new trial
-    // only after the breaker cycles back to open and half-opens again.
+    // Claim the trial slot explicitly.
+    expect(tryClaimTrialSlot('raiderio')).toBe(true);
+
+    // Concurrent callers now see the breaker as blocked.
+    expect(isBreakerOpen('raiderio')).toBe(true);
+    expect(tryClaimTrialSlot('raiderio')).toBe(false);
+
+    // Resolving the trial clears the slot and closes the breaker.
     onBreakerTrialResult('raiderio', true);
     expect(getBreakerState('raiderio')).toBe('closed');
     expect(isBreakerOpen('raiderio')).toBe(false);
@@ -156,14 +160,16 @@ describe('apiHealth breaker', () => {
     for (let i = 0; i < 5; i++) noteFailure('raiderio');
     vi.setSystemTime(new Date('2026-04-19T12:01:00Z'));
 
-    expect(isBreakerOpen('raiderio')).toBe(false); // claim trial
+    expect(isBreakerOpen('raiderio')).toBe(false);
+    expect(tryClaimTrialSlot('raiderio')).toBe(true);
     onBreakerTrialResult('raiderio', false); // trial fails → reopen
     expect(getBreakerState('raiderio')).toBe('open');
 
     // Past the new cooldown, another trial slot should be claimable.
     vi.setSystemTime(new Date('2026-04-19T12:02:00Z'));
     expect(isBreakerOpen('raiderio')).toBe(false);
-    expect(isBreakerOpen('raiderio')).toBe(true); // only one at a time
+    expect(tryClaimTrialSlot('raiderio')).toBe(true);
+    expect(tryClaimTrialSlot('raiderio')).toBe(false);
   });
 });
 
@@ -177,8 +183,8 @@ describe('apiHealth getBreakerState', () => {
     expect(getBreakerState('raiderio')).toBe('half_open');
     expect(getBreakerState('raiderio')).toBe('half_open');
 
-    // isBreakerOpen is what claims the slot.
-    expect(isBreakerOpen('raiderio')).toBe(false); // claims
-    expect(isBreakerOpen('raiderio')).toBe(true); // second is rejected
+    // tryClaimTrialSlot is what claims the slot.
+    expect(tryClaimTrialSlot('raiderio')).toBe(true);
+    expect(tryClaimTrialSlot('raiderio')).toBe(false);
   });
 });

--- a/tests/unit/httpClient.test.ts
+++ b/tests/unit/httpClient.test.ts
@@ -116,3 +116,40 @@ describe('httpRequest — non-retryable failures', () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('httpRequest — timeout', () => {
+  it('aborts the request after timeoutMs and throws HttpError', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (signal) {
+            signal.addEventListener('abort', () => {
+              const err = new Error('aborted');
+              (err as Error & { name: string }).name = 'AbortError';
+              reject(err);
+            });
+          }
+        }),
+    );
+
+    const promise = httpRequest('raiderio', 'https://x.test/', undefined, {
+      timeoutMs: 100,
+      maxRetries: 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(101);
+    await expect(promise).rejects.toBeInstanceOf(HttpError);
+  });
+
+  it('passes caller-provided signal alongside timeout', async () => {
+    const abortController = new AbortController();
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse({ ok: true, json: {} }));
+    globalThis.fetch = fetchMock;
+
+    await httpRequest('raiderio', 'https://x.test/', { signal: abortController.signal });
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit | undefined;
+    expect(init?.signal).toBeDefined();
+  });
+});

--- a/tests/unit/httpClient.test.ts
+++ b/tests/unit/httpClient.test.ts
@@ -153,3 +153,95 @@ describe('httpRequest — timeout', () => {
     expect(init?.signal).toBeDefined();
   });
 });
+
+describe('httpRequest — retry loop', () => {
+  it.each([429, 500, 502, 503, 504])(
+    'retries on %s up to maxRetries+1 attempts',
+    async (status) => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse({ ok: false, status, statusText: 'x' }),
+      );
+      globalThis.fetch = fetchMock;
+
+      const promise = httpRequest('raiderio', 'https://x.test/').catch((e) => e);
+      await vi.advanceTimersByTimeAsync(5_000);
+      const err = await promise;
+
+      expect(err).toBeInstanceOf(HttpError);
+      expect(fetchMock).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+    },
+  );
+
+  it('succeeds on retry and records `retried`', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(mockResponse({ ok: false, status: 503, statusText: 'x' }))
+      .mockResolvedValueOnce(mockResponse({ ok: true, json: { ok: 1 } }));
+
+    const promise = httpRequest<{ ok: number }>('raiderio', 'https://x.test/');
+    await vi.advanceTimersByTimeAsync(5_000);
+    const result = await promise;
+
+    expect(result).toEqual({ ok: 1 });
+    const s = getSummary('raiderio');
+    expect(s.totals.ok).toBe(1);
+    expect(s.totals.retried).toBe(1);
+  });
+
+  it('records `rate_limited` when any attempt saw a 429 and the call ultimately fails', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 429, statusText: 'Too Many Requests' }),
+    );
+
+    const promise = httpRequest('raiderio', 'https://x.test/').catch((e) => e);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await promise;
+
+    const s = getSummary('raiderio');
+    expect(s.totals.rateLimited).toBe(1);
+    expect(s.totals.failed).toBe(0);
+  });
+
+  it('records `timeout` when any attempt timed out and the call ultimately fails', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            (err as Error & { name: string }).name = 'AbortError';
+            reject(err);
+          });
+        }),
+    );
+
+    const promise = httpRequest('raiderio', 'https://x.test/', undefined, {
+      timeoutMs: 50,
+    }).catch((e) => e);
+    await vi.advanceTimersByTimeAsync(10_000);
+    await promise;
+
+    const s = getSummary('raiderio');
+    expect(s.totals.timeouts).toBe(1);
+  });
+
+  it('does not retry on 404', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 404, statusText: 'Not Found' }),
+    );
+    globalThis.fetch = fetchMock;
+
+    await httpRequest('raiderio', 'https://x.test/').catch(() => {});
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on network throw (TypeError)', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('fetch failed'));
+    globalThis.fetch = fetchMock;
+
+    const promise = httpRequest('raiderio', 'https://x.test/').catch(() => {});
+    await vi.advanceTimersByTimeAsync(5_000);
+    await promise;
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/unit/httpClient.test.ts
+++ b/tests/unit/httpClient.test.ts
@@ -137,10 +137,11 @@ describe('httpRequest — timeout', () => {
     const promise = httpRequest('raiderio', 'https://x.test/', undefined, {
       timeoutMs: 100,
       maxRetries: 0,
-    });
+    }).catch((e) => e);
 
     await vi.advanceTimersByTimeAsync(101);
-    await expect(promise).rejects.toBeInstanceOf(HttpError);
+    const err = await promise;
+    expect(err).toBeInstanceOf(HttpError);
   });
 
   it('passes caller-provided signal alongside timeout', async () => {

--- a/tests/unit/httpClient.test.ts
+++ b/tests/unit/httpClient.test.ts
@@ -3,8 +3,9 @@ import { __resetForTests } from '../../src/services/apiHealth.js';
 import {
   httpRequest,
   HttpError,
+  CircuitOpenError,
 } from '../../src/services/httpClient.js';
-import { getSummary } from '../../src/services/apiHealth.js';
+import { getSummary, isBreakerOpen } from '../../src/services/apiHealth.js';
 
 const originalFetch = globalThis.fetch;
 
@@ -311,5 +312,55 @@ describe('httpRequest — Retry-After', () => {
 
     const s = getSummary('raiderio');
     expect(s.totals.rateLimited).toBe(1);
+  });
+});
+
+describe('httpRequest — circuit breaker integration', () => {
+  it('opens the breaker after 5 consecutive failed calls', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 404, statusText: 'x' }),
+    );
+
+    for (let i = 0; i < 5; i++) {
+      await httpRequest('raiderio', 'https://x.test/').catch(() => {});
+    }
+    expect(isBreakerOpen('raiderio')).toBe(true);
+  });
+
+  it('fast-fails with CircuitOpenError while open, without calling fetch', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 404, statusText: 'x' }),
+    );
+    for (let i = 0; i < 5; i++) {
+      await httpRequest('raiderio', 'https://x.test/').catch(() => {});
+    }
+
+    const callCountBefore = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length;
+    await expect(
+      httpRequest('raiderio', 'https://x.test/'),
+    ).rejects.toBeInstanceOf(CircuitOpenError);
+
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callCountBefore);
+    expect(getSummary('raiderio').totals.circuitRejected).toBe(1);
+  });
+
+  it('half_open -> closed on a successful trial call', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 500, statusText: 'x' }),
+    );
+    const kick = async () => {
+      const p = httpRequest('raiderio', 'https://x.test/').catch(() => {});
+      await vi.advanceTimersByTimeAsync(5_000);
+      return p;
+    };
+    for (let i = 0; i < 5; i++) await kick();
+    expect(getSummary('raiderio').breaker).toBe('open');
+
+    // Fast-forward past 60s cooldown.
+    vi.setSystemTime(new Date(Date.now() + 61_000));
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({ ok: true, json: {} }));
+
+    await httpRequest('raiderio', 'https://x.test/');
+    expect(getSummary('raiderio').breaker).toBe('closed');
   });
 });

--- a/tests/unit/httpClient.test.ts
+++ b/tests/unit/httpClient.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { __resetForTests } from '../../src/services/apiHealth.js';
+import {
+  httpRequest,
+  HttpError,
+} from '../../src/services/httpClient.js';
+import { getSummary } from '../../src/services/apiHealth.js';
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  __resetForTests();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-19T12:00:00Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+function mockResponse(init: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  json?: unknown;
+  headers?: Record<string, string>;
+}): Response {
+  const headers = new Headers(init.headers);
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    statusText: init.statusText ?? 'OK',
+    headers,
+    json: async () => init.json ?? {},
+  } as unknown as Response;
+}
+
+describe('httpRequest — happy path', () => {
+  it('returns parsed JSON on 200', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({ ok: true, json: { hello: 'world' } }),
+    );
+
+    const result = await httpRequest<{ hello: string }>('raiderio', 'https://x.test/');
+    expect(result).toEqual({ hello: 'world' });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('records an ok outcome on success', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse({ ok: true, json: {} }));
+    await httpRequest('raiderio', 'https://x.test/');
+    expect(getSummary('raiderio').totals.ok).toBe(1);
+  });
+});
+
+describe('httpRequest — non-retryable failures', () => {
+  it.each([400, 401, 403, 404, 410, 422])(
+    'throws HttpError immediately on %s without retry',
+    async (status) => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockResponse({ ok: false, status, statusText: 'Bad' }),
+      );
+      globalThis.fetch = fetchMock;
+
+      await expect(httpRequest('raiderio', 'https://x.test/')).rejects.toBeInstanceOf(
+        HttpError,
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('HttpError carries service, status, attempts', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 404, statusText: 'Not Found' }),
+    );
+
+    try {
+      await httpRequest('raiderio', 'https://x.test/');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      const e = err as HttpError;
+      expect(e.service).toBe('raiderio');
+      expect(e.status).toBe(404);
+      expect(e.attempts).toBe(1);
+    }
+  });
+
+  it('records failed outcome on non-retryable error', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 404, statusText: 'Not Found' }),
+    );
+
+    await httpRequest('raiderio', 'https://x.test/').catch(() => {});
+    const s = getSummary('raiderio');
+    expect(s.totals.failed).toBe(1);
+    expect(s.lastError?.status).toBe(404);
+  });
+
+  it('throws on JSON parse error without retry', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers(),
+      json: async () => {
+        throw new SyntaxError('Unexpected token');
+      },
+    } as unknown as Response);
+
+    await expect(httpRequest('raiderio', 'https://x.test/')).rejects.toBeInstanceOf(
+      HttpError,
+    );
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/httpClient.test.ts
+++ b/tests/unit/httpClient.test.ts
@@ -245,3 +245,71 @@ describe('httpRequest — retry loop', () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });
+
+describe('httpRequest — Retry-After', () => {
+  it('honours Retry-After in seconds', async () => {
+    const sleepStart = Date.now();
+    let observedGap = 0;
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: false, status: 429, statusText: 'x',
+          headers: { 'Retry-After': '5' },
+        }),
+      )
+      .mockImplementationOnce(async () => {
+        observedGap = Date.now() - sleepStart;
+        return mockResponse({ ok: true, json: {} });
+      });
+
+    const promise = httpRequest('raiderio', 'https://x.test/');
+    await vi.advanceTimersByTimeAsync(6_000);
+    await promise;
+
+    expect(observedGap).toBeGreaterThanOrEqual(5_000);
+  });
+
+  it('honours Retry-After as HTTP-date', async () => {
+    const sleepStart = Date.now();
+    const futureDate = new Date(sleepStart + 2_000).toUTCString();
+    let observedGap = 0;
+
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: false, status: 503, statusText: 'x',
+          headers: { 'Retry-After': futureDate },
+        }),
+      )
+      .mockImplementationOnce(async () => {
+        observedGap = Date.now() - sleepStart;
+        return mockResponse({ ok: true, json: {} });
+      });
+
+    const promise = httpRequest('raiderio', 'https://x.test/');
+    await vi.advanceTimersByTimeAsync(3_000);
+    await promise;
+
+    expect(observedGap).toBeGreaterThanOrEqual(2_000);
+  });
+
+  it('treats Retry-After > 30s as final failure without waiting', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({
+        ok: false, status: 429, statusText: 'x',
+        headers: { 'Retry-After': '120' },
+      }),
+    );
+    globalThis.fetch = fetchMock;
+
+    const err = await httpRequest('raiderio', 'https://x.test/').catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const s = getSummary('raiderio');
+    expect(s.totals.rateLimited).toBe(1);
+  });
+});

--- a/tests/unit/raiderio.test.ts
+++ b/tests/unit/raiderio.test.ts
@@ -8,11 +8,13 @@ vi.mock('../../src/config.js', () => ({
 }));
 
 import { getGuildRoster, getRaidRankings, getRaidStaticData, getWeeklyMythicPlusRuns } from '../../src/services/raiderio.js';
+import { __resetForTests } from '../../src/services/apiHealth.js';
 
 const originalFetch = globalThis.fetch;
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  __resetForTests();
 });
 
 afterEach(() => {
@@ -35,6 +37,7 @@ describe('getGuildRoster', () => {
 
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
+      headers: new Headers(),
       json: async () => ({ members: mockMembers }),
     });
 
@@ -53,19 +56,28 @@ describe('getGuildRoster', () => {
     expect(names).not.toContain('ExcludedToo');
   });
 
-  it('should throw on non-OK response', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 500,
-      statusText: 'Internal Server Error',
+  it('retries on 5xx and throws HttpError after exhausting retries', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false, status: 500, statusText: 'Internal Server Error',
+      headers: new Headers(),
     });
+    globalThis.fetch = fetchMock;
 
-    await expect(getGuildRoster()).rejects.toThrow('Raider.io API error: 500 Internal Server Error');
+    const promise = getGuildRoster().catch((e) => e);
+    await vi.advanceTimersByTimeAsync(5_000);
+    const err = await promise;
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain('raiderio');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
   });
 
   it('should call the correct URL', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
+      headers: new Headers(),
       json: async () => ({ members: [] }),
     });
 
@@ -73,6 +85,7 @@ describe('getGuildRoster', () => {
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
       'https://raider.io/api/v1/guilds/profile?region=eu&realm=silvermoon&name=seriouslycasual&fields=members',
+      expect.any(Object),
     );
   });
 });
@@ -85,6 +98,7 @@ describe('getRaidRankings', () => {
 
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
+      headers: new Headers(),
       json: async () => ({ raidRankings: mockRankings }),
     });
 
@@ -93,17 +107,19 @@ describe('getRaidRankings', () => {
     expect(result).toEqual(mockRankings);
     expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.stringContaining('raid=nerubar-palace'),
+      expect.any(Object),
     );
   });
 
-  it('should throw on non-OK response', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 404,
-      statusText: 'Not Found',
+  it('throws HttpError without retry on 404', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false, status: 404, statusText: 'Not Found',
+      headers: new Headers(),
     });
+    globalThis.fetch = fetchMock;
 
-    await expect(getRaidRankings('invalid')).rejects.toThrow('Raider.io API error: 404 Not Found');
+    await expect(getRaidRankings('invalid')).rejects.toThrow('raiderio');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -115,6 +131,7 @@ describe('getRaidStaticData', () => {
 
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
+      headers: new Headers(),
       json: async () => mockData,
     });
 
@@ -123,6 +140,7 @@ describe('getRaidStaticData', () => {
     expect(result).toEqual(mockData);
     expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.stringContaining('expansion_id=10'),
+      expect.any(Object),
     );
   });
 });
@@ -135,6 +153,7 @@ describe('getWeeklyMythicPlusRuns', () => {
 
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
+      headers: new Headers(),
       json: async () => ({ mythic_plus_previous_weekly_highest_level_runs: mockRuns }),
     });
 
@@ -143,12 +162,14 @@ describe('getWeeklyMythicPlusRuns', () => {
     expect(result).toEqual(mockRuns);
     expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.stringContaining('name=Testchar'),
+      expect.any(Object),
     );
   });
 
   it('should encode character names with special characters', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
+      headers: new Headers(),
       json: async () => ({ mythic_plus_previous_weekly_highest_level_runs: [] }),
     });
 
@@ -156,6 +177,7 @@ describe('getWeeklyMythicPlusRuns', () => {
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.stringContaining(`name=${encodeURIComponent('Tëst Chàr')}`),
+      expect.any(Object),
     );
   });
 });

--- a/tests/unit/wowaudit.test.ts
+++ b/tests/unit/wowaudit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../src/config.js', () => ({
   config: {
@@ -7,12 +7,17 @@ vi.mock('../../src/config.js', () => ({
 }));
 
 import { getUpcomingRaids, getHistoricalData } from '../../src/services/wowaudit.js';
+import { __resetForTests } from '../../src/services/apiHealth.js';
 
 const originalFetch = globalThis.fetch;
 
+beforeEach(() => {
+  vi.restoreAllMocks();
+  __resetForTests();
+});
+
 afterEach(() => {
   globalThis.fetch = originalFetch;
-  vi.restoreAllMocks();
 });
 
 describe('getUpcomingRaids', () => {
@@ -23,6 +28,7 @@ describe('getUpcomingRaids', () => {
 
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
+      headers: new Headers(),
       json: async () => mockRaids,
     });
 
@@ -31,23 +37,23 @@ describe('getUpcomingRaids', () => {
     expect(result).toEqual(mockRaids);
     expect(globalThis.fetch).toHaveBeenCalledWith(
       'https://wowaudit.com/v1/raids?include_past=false',
-      {
-        headers: {
+      expect.objectContaining({
+        headers: expect.objectContaining({
           accept: 'application/json',
           Authorization: 'test-api-secret',
-        },
-      },
+        }),
+      }),
     );
   });
 
-  it('should throw on non-OK response', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 401,
-      statusText: 'Unauthorized',
+  it('throws HttpError without retry on 401', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false, status: 401, statusText: 'Unauthorized', headers: new Headers(),
     });
+    globalThis.fetch = fetchMock;
 
-    await expect(getUpcomingRaids()).rejects.toThrow('WoW Audit API error: 401 Unauthorized');
+    await expect(getUpcomingRaids()).rejects.toThrow('wowaudit');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -61,11 +67,13 @@ describe('getHistoricalData', () => {
       .mockResolvedValueOnce({
         // getCurrentPeriod call
         ok: true,
+        headers: new Headers(),
         json: async () => ({ current_period: 42 }),
       })
       .mockResolvedValueOnce({
         // getHistoricalData call
         ok: true,
+        headers: new Headers(),
         json: async () => mockHistorical,
       });
 
@@ -90,28 +98,36 @@ describe('getHistoricalData', () => {
     );
   });
 
-  it('should throw if getCurrentPeriod fails', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 500,
-      statusText: 'Internal Server Error',
+  it('retries on 500 from getCurrentPeriod and throws HttpError', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false, status: 500, statusText: 'Internal Server Error',
+      headers: new Headers(),
     });
+    globalThis.fetch = fetchMock;
 
-    await expect(getHistoricalData()).rejects.toThrow('WoW Audit API error: 500 Internal Server Error');
+    const promise = getHistoricalData().catch((e) => e);
+    await vi.advanceTimersByTimeAsync(5_000);
+    const err = await promise;
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain('wowaudit');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
   });
 
-  it('should throw if historical data request fails', async () => {
-    globalThis.fetch = vi.fn()
+  it('throws HttpError without retry when historical data returns 404', async () => {
+    const fetchMock = vi.fn()
       .mockResolvedValueOnce({
-        ok: true,
+        ok: true, headers: new Headers(),
         json: async () => ({ current_period: 42 }),
       })
       .mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found',
+        ok: false, status: 404, statusText: 'Not Found', headers: new Headers(),
       });
+    globalThis.fetch = fetchMock;
 
-    await expect(getHistoricalData()).rejects.toThrow('WoW Audit API error: 404 Not Found');
+    await expect(getHistoricalData()).rejects.toThrow('wowaudit');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary

- All external HTTP calls (Raider.io, WarcraftLogs, wowaudit) now route through `src/services/httpClient.ts` — timeout (10s), exponential backoff with jitter (up to 2 retries on 429/5xx/network/timeout), `Retry-After` honoured with a 30s cap, and typed `HttpError` / `CircuitOpenError`.
- Per-service circuit breaker opens after 5 consecutive failures, half-opens after a 60s cooldown. Fast-fails keep scheduled tasks from running past their own interval under sustained upstream failure — e.g. `updateAchievements` with ~300 Raider.io calls no longer burns hours of retry wall time on a 429 storm.
- New `/status` section **API Health (last hour)** shows per-service breaker state + success/retry/failure counts + last error. Friendlier ChatInput message when a user-invoked command hits an open breaker.

## Design + plan docs

- Spec: [`docs/superpowers/specs/2026-04-19-api-health-and-retry-design.md`](../tree/feat/api-health/docs/superpowers/specs/2026-04-19-api-health-and-retry-design.md)
- Plan: [`docs/superpowers/plans/2026-04-19-api-health-and-retry.md`](../tree/feat/api-health/docs/superpowers/plans/2026-04-19-api-health-and-retry.md)

## Implementation notes

- **Tracker is in-memory only** (minute-bucket rolling 60-min window, per-service state, resets on restart). Spec calls this out — the question being answered is "what's happening right now," not historical trends. Avoids a SQLite table + migration + retention policy.
- **`retried` is a flag counter, not a separate outcome.** A success on attempt 2+ increments both `ok` and `retried`, so `totals.ok` is "total successes" and `/status` can render `"312 ok (2 retried)"` naturally.
- **Breaker integration is symmetric across all 6 exit paths in `httpRequest`.** Final-success paths call `finishSuccess(…, wasTrial)`; final-failure paths (non-retryable HTTP, Retry-After > cap, retries exhausted, JSON parse error) all call `onFinalFailure(…, wasTrial)` so a half-open trial can never leave the breaker stuck. `breakerWasHalfOpen` is captured AFTER `isBreakerOpen` to observe the lazy `open → half_open` transition.
- **`getTrialLogs` fail-soft contract preserved.** Catches `HttpError` / `CircuitOpenError` at its own boundary, logs warning, returns `[]`. Other Error subclasses (e.g. TypeError from malformed response shape) now propagate — a small intentional narrowing from the pre-refactor "catch everything" so programmer errors don't silently disappear.
- **One intentional deviation from the plan:** per-attempt timeout uses `AbortController + setTimeout` instead of `AbortSignal.timeout`. `AbortSignal.timeout` interacts poorly with vitest fake timers across retry iterations. The substitution is functionally equivalent (both throw `AbortError` after `timeoutMs`) and gains explicit `clearTimeout` on success, which is a hygiene win. Documented inline.

## Files touched

**New:**
- `src/services/apiHealth.ts` — tracker + breaker state machine
- `src/services/httpClient.ts` — `httpRequest<T>`, `HttpError`, `CircuitOpenError`
- `tests/unit/apiHealth.test.ts` (10 tests)
- `tests/unit/httpClient.test.ts` (29 tests)

**Modified:**
- `src/services/raiderio.ts` — 4 `fetch` → `httpRequest`
- `src/services/wowaudit.ts` — 3 `fetch` → `httpRequest`
- `src/services/warcraftlogs.ts` — OAuth POST + GraphQL POST via `httpRequest`; preserves `getTrialLogs` fail-soft
- `src/commands/status.ts` — API Health section (3 new embed fields)
- `src/events/interactionCreate.ts` — ChatInput `CircuitOpenError` branch
- `tests/unit/raiderio.test.ts`, `tests/unit/wowaudit.test.ts` — updated 5xx expectations (now retry 3×), added `headers: new Headers()` to mocks, added `__resetForTests` in `beforeEach`

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 290/290 pass (22 files; 39 new tests across apiHealth + httpClient)
- [x] Chrome/dev-guild: `/status` on a fresh bot renders the new **API Health (last hour)** section with all three services at `🟢 closed · — no traffic`
- [x] Chrome/dev-guild: `/raiders sync_raiders` then `/status` — Raider.io row shows `🟢 closed · 1 ok · 0 failed`
- [ ] Chrome/dev-guild (breaker scenarios — require temporary BASE_URL edits + restarts):
  - Point `raiderio.ts` `BASE_URL` at a 404 path → `sync_raiders` fails fast (1 attempt), `/status` shows `1 failed` with 404 in `last error`
  - Point at a URL that returns 500; run `sync_raiders` 5× → breaker shows `🔴 open`; next user invocation replies with `⚠️ raiderio is currently unreachable (circuit open). Try again in ~60s.`
  - Wait 60s, restore URL, rerun → breaker transitions to `🟢 closed`

## Known follow-ups (not in this PR)

- **Half-open "concurrent trial" guard** — two concurrent `httpRequest` calls while the breaker is `half_open` currently both pass the gate. Spec wants the second rejected. In practice the current callers (scheduler + slash commands) don't produce concurrent calls to the same service, so no in-the-wild impact. Fix would add an in-memory `trialInFlight: Set<ServiceName>` gate.
- **`mergeSignals` listener hygiene** — if a long-lived caller-supplied `init.signal` is ever introduced, `mergeSignals` would accumulate listeners across retries. No current caller hits this; flag for when someone adds one.
- **`UnhandledRejection` stderr warning in the Task 4 timeout test** — cosmetic test-harness artifact (exit 0, test passes). Fix is to attach `.catch` before `vi.advanceTimersByTimeAsync`.
- **Symmetric `CircuitOpenError` handling on Button/Modal/UserSelectMenu paths** — not needed today (no HTTP-calling handlers on those paths). Add a shared `friendlyErrorMessage(err)` helper when the first such handler lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)