### PR TITLE
Promote to prod: detailed bot-audit logs (+ earlier develop fixes)

### DIFF
--- a/.claude/skills/bot-architecture.md
+++ b/.claude/skills/bot-architecture.md
@@ -1,48 +1,63 @@
 # Bot Architecture
 
 ## Startup sequence (src/index.ts)
-1. `setupGracefulShutdown()` - registers SIGTERM/SIGINT handlers
-2. `initDatabase()` - creates/opens SQLite DB, runs migrations
-3. `loadCommands()` - dynamically imports all `src/commands/*.ts`
-4. `loadEvents()` - dynamically imports all `src/events/*.ts`
-5. `client.login()` - connects to Discord
+1. `initLogger(config.logLevel)` - creates the console logger
+2. `registerProcessErrorHandlers()` - last-resort `unhandledRejection` /
+   `uncaughtException` logging
+3. `initDatabase()` - creates/opens SQLite DB, runs migrations
+4. Create the Discord `Client` (with intents + `Partials.Channel`)
+5. `loadCommands()` - dynamically imports all `src/commands/*.ts`
+6. Load events - inline loop importing each `src/events/*.ts`
+7. Register `SIGTERM`/`SIGINT` shutdown handlers
+8. `client.login()` (wrapped in try/catch; a login failure logs and exits 1)
 
 ## Ready event (src/events/ready.ts)
-After Discord connection:
-1. `logger.init()` - creates/finds Logs category + channels in Discord
-2. Auto-registers slash commands via REST API
-3. Sets bot status based on `isSetupComplete()` check
-4. Initializes audit log channel if configured
-5. `initScheduler()` + `registerAllJobs()` - starts BullMQ
+Handler for `clientReady` (`once: true`). After Discord connection:
+1. `deployCommands()` - registers slash commands via the REST API
+2. Channel bootstrap: find/create `bot-logs` (→ `logger.setDiscordChannel`) and
+   `bot-audit` (→ `setAuditChannel`) under the "SeriouslyCasual Bot" category
+3. Register scheduled tasks on the shared `scheduler` (see the scheduler skill)
+4. `scheduler.start()`
+5. `rescheduleAllAlerts(client)` - re-arms trial alerts from the DB
+6. `resumeSessions(client)` - resumes in-progress DM application sessions
 
-## Shutdown sequence
+## Shutdown sequence (src/index.ts `shutdown()`)
 1. Log shutdown message
-2. `closeScheduler()` - closes BullMQ worker + queue
-3. `closeDatabase()` - closes SQLite connection
-4. `client.destroy()` - disconnects from Discord
+2. `scheduler.shutdown()` - clears interval timers + stops cron jobs
+3. `client.destroy()` - disconnects from Discord
+4. `closeDatabase()` - closes SQLite connection
+5. `process.exit(0)`
 
 ## Event handlers (src/events/)
 - `ready.ts` - one-time setup on connect
 - `interactionCreate.ts` - routes slash commands, buttons, modals, select menus
+- `messageCreate.ts` - message-based handling (e.g. DM questionnaire replies)
+- `threadUpdate.ts` - thread state changes (e.g. keep-alive / un-archive)
 
 ## File organization
 ```
 src/
   commands/       # Slash command handlers (auto-loaded)
-  events/         # Discord event handlers (auto-loaded)
-  database/       # SQLite setup, schemas, migrations
-  scheduler/      # BullMQ queue, worker, job definitions
-  services/       # External API wrappers (logger, auditLog, raiderio, etc.)
-  functions/      # Business logic by domain (settings/, setup/, etc.)
+  events/         # Discord event handlers (loaded in index.ts)
+  interactions/   # Button/modal/select-menu dispatch, registry, middleware
+  database/       # SQLite setup, schema, migrations
+  scheduler/      # node-cron based Scheduler class
+  services/       # External API wrappers + logger, auditLog, statusTracker, httpClient
+  functions/      # Business logic by domain (applications/, raids/, trial-review/, loot/, …)
   types/          # TypeScript interfaces and types
-  utils/          # Shared utilities (pagination, permissions)
-  utils.ts        # Core helpers (asSendable, loadJson)
   config.ts       # Environment variable config
+  utils.ts        # Core helpers (asSendable, requireOfficer, createEmbed, paginationRow)
+  loadCommands.ts # Command loader
+  processErrorHandlers.ts # Process-level error handlers
 ```
 
 ## Key conventions
-- ESM: all imports use `.js` extension
-- Commands/events use `export default` pattern
-- Business logic in `src/functions/`, not in commands directly
-- Config stored in DB via `/setup` (channel_config table) and `/settings` (settings table)
+- ESM: all imports use the `.js` extension (even for `.ts` source)
+- Commands/events use the `export default` pattern
+- Business logic lives in `src/functions/`, not in command files
+- Interaction components (buttons/modals/selects) are routed through
+  `src/interactions/` — register handlers there; use the `officerOnly` flag or
+  `requireOfficer` for gated actions
+- Config stored in DB via `/setup` (channel_config) and `/settings` (settings)
 - Use `getChannel(key)` to resolve configured channels at runtime - always handle null
+- Use `MessageFlags.Ephemeral` (not `ephemeral: true`) for ephemeral replies

--- a/.claude/skills/scheduler.md
+++ b/.claude/skills/scheduler.md
@@ -1,53 +1,71 @@
-# BullMQ Scheduler
+# Scheduler (node-cron)
+
+Lightweight in-process scheduler. **No Redis, no BullMQ** — just `node-cron`
+plus self-correcting `setTimeout` for interval jobs. There is a single
+`Scheduler` instance for the whole bot.
 
 ## Files
-- `src/scheduler/scheduler.ts` - Queue/Worker lifecycle, job registration, scheduling
-- `src/scheduler/jobs.ts` - All job handler registrations and schedules
 
-## Usage
+- `src/scheduler/scheduler.ts` — the `Scheduler` class (interval + cron task
+  lifecycle, per-task running-guard, error handling).
+- `src/events/ready.ts` — the shared `scheduler` instance is created here and
+  all jobs are registered inside the `clientReady` handler after startup.
 
-### Registering a new job
-In `jobs.ts`, add inside `registerAllJobs()`:
+## Registering a new job
+
+Jobs are registered in `ready.ts` (not a separate `jobs.ts`). Add a
+`scheduler.registerInterval(...)` or `scheduler.registerCron(...)` call before
+`scheduler.start()`.
+
 ```ts
-// 1. Register the handler
-registerJob('myJobName', async (client) => {
-    // client is the BotClient instance
+// Interval job — intervalMs is a wall-clock cadence (fires at :00, :10, :20 …):
+scheduler.registerInterval({
+  name: 'myJob',
+  intervalMs: 5 * 60 * 1000,
+  handler: async () => {
     await doSomething(client);
+  },
 });
 
-// 2. Schedule it
-// Interval (every N ms):
-await scheduleRepeating('myJobName', '', { every: 5 * 60 * 1000 });
-
-// Cron pattern:
-await scheduleRepeating('myJobName', '0 12 * * 3'); // noon Wednesday
+// Cron job — standard 5-field cron expression:
+scheduler.registerCron({
+  name: 'myCronJob',
+  expression: '0 12 * * 3', // noon on Wednesday
+  handler: () => doSomethingElse(client),
+});
 ```
 
-### Implementing a stub job
-Many jobs in `jobs.ts` are stubs with `// TODO: Implement in Task X`. To implement:
-1. Create the business logic function in `src/functions/`
-2. Import it in `jobs.ts`
-3. Replace the stub with the actual call
+Wrap the handler body in try/catch and call `recordTaskRun(name, ok, err?)`
+(from `src/services/statusTracker.ts`) if the job should surface in `/status` —
+see the existing interval jobs for the pattern.
 
-### Key details
-- BullMQ uses Redis - configured via `REDIS_URL` env var
-- Connection uses host/port/password config object (NOT ioredis instance - version mismatch)
-- Worker concurrency is 1 (sequential job processing)
-- Jobs have `removeOnComplete: { count: 5 }` and `removeOnFail: { count: 10 }`
-- Scheduler initializes in `ready.ts` after Discord client is ready
-- Graceful shutdown in `index.ts` calls `closeScheduler()`
+## Key details
 
-## Current jobs (11)
-| Job | Schedule | Task |
-|-----|----------|------|
-| checkApplications | every 5m | Task 5 |
-| keepAppThreadsAlive | every 3m | Task 5 |
-| updateAchievements | every 30m | Task 3 |
-| updateTrialLogs | every 60m | Task 7 |
-| keepTrialThreadsAlive | every 6m | Task 7 |
-| checkReviewAlerts | every 3m | Task 7 |
-| checkPromotionAlerts | every 5m | Task 7 |
-| syncRaiders | every 10m | Task 4 |
-| alertSignups | 7pm Mon/Tue/Fri/Sat | Task 8 |
-| weeklyReports | noon Wed | Task 4 |
-| updatePriorityPost | */10 cron | Task 10 |
+- **Interval alignment:** `registerInterval` uses a self-correcting
+  `setTimeout` pinned to wall-clock boundaries (not `setInterval`), so a
+  10-minute job fires at :00/:10/:20 regardless of bot start time or timer drift.
+- **Running-guard:** if a task's previous run is still in flight when the next
+  tick fires, that tick is skipped and logged at DEBUG — no overlapping runs.
+- **Error isolation:** handler errors are caught and logged via
+  `logger.error('scheduler', …)`; a failing job never crashes the loop or other
+  jobs.
+- **Lifecycle:** `scheduler.start()` is called once in `ready.ts`;
+  `scheduler.shutdown()` is called from the `shutdown()` handler in
+  `src/index.ts` (on SIGTERM/SIGINT), which clears all timers and stops all
+  cron jobs.
+
+## Current jobs (registered in `ready.ts`)
+
+| Job | Type | Schedule | Handler |
+|-----|------|----------|---------|
+| syncRaiders | interval | every 10m | `syncRaiders` + `alertForNewUnlinkedRaiders` |
+| refreshLinkingMessages | interval | every 10m | `refreshLinkingMessages` |
+| updateAchievements | interval | every 30m | `updateAchievements` |
+| updateTrialLogs | interval | every 60m | `updateTrialLogs` |
+| alertSignups | cron | `0 19 * * 1,2,5,6` (7pm Mon/Tue/Fri/Sat) | `alertSignups` |
+| weeklyReports | cron | `0 12 * * 3` (noon Wed) | `alertHighestMythicPlusDone` |
+| dailyBackup | cron | `0 4 * * *` (4am daily) | `dailyBackup` |
+
+Trial review/promotion alerts are **not** fixed jobs — they are scheduled
+dynamically from the DB by `rescheduleAllAlerts` (called after
+`scheduler.start()`), which computes per-trial timings.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -47,7 +47,7 @@ Each worktree shares the same git history but has an independent working directo
 4. CI must pass (typecheck + tests + build).
 5. Claude Code Review runs automatically and posts inline comments.
 6. Address review feedback, then merge to `develop` (auto-deploys to test).
-7. Once validated on test, promote by opening a PR from `develop` → `main` (squash-merge).
+7. Once validated on test, promote by opening a PR from `develop` → `main` (merge commit — the only merge method the repo enables).
 
 ## Testing Strategy
 

--- a/docs/superpowers/plans/2026-07-19-detailed-audit-logs.md
+++ b/docs/superpowers/plans/2026-07-19-detailed-audit-logs.md
@@ -1,0 +1,600 @@
+# Detailed Bot-Audit Log Messages — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make entity-related bot-audit log messages say *who* the action was about and link (without pinging) to the relevant Discord user and post/thread.
+
+**Architecture:** A new pure formatter module (`src/services/auditRefs.ts`) produces the enriched detail strings; `audit()` gains `allowedMentions: { parse: [] }` so `<@id>` renders as a non-pinging chip; each entity call site is rewired to use the formatters.
+
+**Tech Stack:** TypeScript (ESM, Node16 module resolution — imports use `.js` extension), discord.js v14, better-sqlite3, Vitest.
+
+## Global Constraints
+
+- ESM with Node16 resolution: **all relative imports end in `.js`** even for `.ts` sources.
+- Discord timestamps use the long-date style `<t:UNIX:D>` (static full date, localised per viewer) — never the relative `:R` style.
+- Mentions in audit messages must never notify anyone.
+- Tests are Vitest; run with `npm test` (the `default` project). Typecheck with `npm run typecheck`. Lint with `npm run lint`.
+- Config is eagerly validated on import, so unit tests that import modules pulling in `../config.js` must `vi.mock('../../src/config.js', ...)`.
+
+---
+
+### Task 1: `auditRefs` formatter module
+
+**Files:**
+- Create: `src/services/auditRefs.ts`
+- Test: `tests/unit/auditRefs.test.ts`
+
+**Interfaces:**
+- Consumes: `TrialRow`, `ApplicationRow` from `src/types/index.ts`.
+- Produces:
+  - `trialRef(trial: Pick<TrialRow, 'character_name' | 'id' | 'thread_id'>): string`
+  - `applicationRef(app: Pick<ApplicationRow, 'character_name' | 'applicant_user_id' | 'thread_id' | 'forum_post_id'>): string`
+  - `dateRef(date: string): string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/auditRefs.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { trialRef, applicationRef, dateRef } from '../../src/services/auditRefs.js';
+
+describe('trialRef', () => {
+  it('includes name, id, and a thread link when thread_id is set', () => {
+    expect(trialRef({ character_name: 'Sploboss', id: 3, thread_id: '123' })).toBe(
+      '**Sploboss** (#3) — <#123>',
+    );
+  });
+
+  it('omits the thread link when thread_id is null', () => {
+    expect(trialRef({ character_name: 'Sploboss', id: 3, thread_id: null })).toBe(
+      '**Sploboss** (#3)',
+    );
+  });
+});
+
+describe('applicationRef', () => {
+  it('links the applicant and prefers forum_post_id for the post link', () => {
+    expect(
+      applicationRef({
+        character_name: 'Sploboss',
+        applicant_user_id: '456',
+        thread_id: '999',
+        forum_post_id: '789',
+      }),
+    ).toBe('**Sploboss** (<@456>) — <#789>');
+  });
+
+  it('falls back to thread_id when forum_post_id is null', () => {
+    expect(
+      applicationRef({
+        character_name: 'Sploboss',
+        applicant_user_id: '456',
+        thread_id: '999',
+        forum_post_id: null,
+      }),
+    ).toBe('**Sploboss** (<@456>) — <#999>');
+  });
+
+  it('omits the post link when both post ids are null', () => {
+    expect(
+      applicationRef({
+        character_name: 'Sploboss',
+        applicant_user_id: '456',
+        thread_id: null,
+        forum_post_id: null,
+      }),
+    ).toBe('**Sploboss** (<@456>)');
+  });
+
+  it('shows Unknown when character_name is null', () => {
+    expect(
+      applicationRef({
+        character_name: null,
+        applicant_user_id: '456',
+        thread_id: null,
+        forum_post_id: null,
+      }),
+    ).toBe('**Unknown** (<@456>)');
+  });
+});
+
+describe('dateRef', () => {
+  it('renders a YYYY-MM-DD date as a long-date Discord timestamp', () => {
+    // 2026-04-20 UTC midnight = 1776643200 seconds
+    expect(dateRef('2026-04-20')).toBe('<t:1776643200:D>');
+  });
+
+  it('returns the raw string when the date is unparseable', () => {
+    expect(dateRef('not-a-date')).toBe('not-a-date');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/auditRefs.test.ts`
+Expected: FAIL — cannot resolve `../../src/services/auditRefs.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/services/auditRefs.ts`:
+
+```ts
+import type { TrialRow, ApplicationRow } from '../types/index.js';
+
+/** `**Name** (#id)`, plus ` — <#thread_id>` when the review thread exists. */
+export function trialRef(trial: Pick<TrialRow, 'character_name' | 'id' | 'thread_id'>): string {
+  const base = `**${trial.character_name}** (#${trial.id})`;
+  return trial.thread_id ? `${base} — <#${trial.thread_id}>` : base;
+}
+
+/**
+ * `**Name** (<@applicant>)`, plus ` — <#post>` when a forum post/thread exists.
+ * Prefers `forum_post_id`, falling back to `thread_id`.
+ */
+export function applicationRef(
+  app: Pick<ApplicationRow, 'character_name' | 'applicant_user_id' | 'thread_id' | 'forum_post_id'>,
+): string {
+  const name = app.character_name ?? 'Unknown';
+  const base = `**${name}** (<@${app.applicant_user_id}>)`;
+  const postId = app.forum_post_id ?? app.thread_id;
+  return postId ? `${base} — <#${postId}>` : base;
+}
+
+/**
+ * Render a `YYYY-MM-DD` string as a Discord long-date timestamp (static full
+ * date, localised to each viewer). Falls back to the raw string if unparseable.
+ */
+export function dateRef(date: string): string {
+  const ms = Date.parse(date);
+  if (Number.isNaN(ms)) return date;
+  return `<t:${Math.floor(ms / 1000)}:D>`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/auditRefs.test.ts`
+Expected: PASS (all 8 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/auditRefs.ts tests/unit/auditRefs.test.ts
+git commit -m "feat(audit): add auditRefs formatters for trials, applications, dates"
+```
+
+---
+
+### Task 2: Suppress pings in `audit()`
+
+**Files:**
+- Modify: `src/services/auditLog.ts:18`
+- Test: `tests/unit/auditLog.test.ts` (create)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `audit()` behaviour unchanged except the `send` call now passes `allowedMentions: { parse: [] }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/auditLog.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/config.js', () => ({ config: { officerRoleId: 'role-1' } }));
+vi.mock('../../src/services/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { audit, setAuditChannel } from '../../src/services/auditLog.js';
+
+describe('audit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends with mentions suppressed so linked users are not pinged', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    // Cast through unknown — the test channel only needs `send`.
+    setAuditChannel({ send } as unknown as Parameters<typeof setAuditChannel>[0]);
+
+    const officer = { displayName: 'Splo' } as Parameters<typeof audit>[0];
+    await audit(officer, 'rejected application', '**Sploboss** (<@456>)');
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const arg = send.mock.calls[0][0];
+    expect(arg.content).toBe('**Splo** rejected application: **Sploboss** (<@456>)');
+    expect(arg.allowedMentions).toEqual({ parse: [] });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/auditLog.test.ts`
+Expected: FAIL — `arg.allowedMentions` is `undefined`, not `{ parse: [] }`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/services/auditLog.ts`, change the `audit()` send call (line 18):
+
+```ts
+    await auditChannel.send({ content: message, allowedMentions: { parse: [] } });
+```
+
+Leave `alertOfficers()` untouched — it keeps its own `allowedMentions: { roles: [roleId] }`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/auditLog.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/auditLog.ts tests/unit/auditLog.test.ts
+git commit -m "fix(audit): suppress mention pings in audit channel posts"
+```
+
+---
+
+### Task 3: Enrich trial audit call sites
+
+**Files:**
+- Modify: `src/interactions/trial.ts` (handlers `extend`, `markPromote`, `close`, `modalCreate`, `modalUpdate`)
+- Modify: `src/commands/trials.ts` (cases `remove_trial`, `change_trial_info`)
+
+**Interfaces:**
+- Consumes: `trialRef`, `dateRef` from `src/services/auditRefs.js`.
+- Produces: no new exports.
+
+- [ ] **Step 1: Add the import to `src/interactions/trial.ts`**
+
+After the existing `import { audit } from '../services/auditLog.js';` line, add:
+
+```ts
+import { trialRef } from '../services/auditRefs.js';
+```
+
+(`getDatabase` and the `TrialRow` type are already imported in this file.)
+
+- [ ] **Step 2: Rewrite the three button handlers to fetch the row and use `trialRef`**
+
+Replace the bodies of `extend`, `markPromote`, and `close` so each captures the trial row before acting. New `extend`:
+
+```ts
+async function extend(interaction: ButtonInteraction, params: string[]): Promise<void> {
+  const trialId = parseInt(params[0], 10);
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+  const trial = getDatabase().prepare('SELECT * FROM trials WHERE id = ?').get(trialId) as
+    | TrialRow
+    | undefined;
+
+  try {
+    await extendTrial(interaction.client, trialId);
+    await audit(interaction.user, 'extended trial', trial ? trialRef(trial) : `#${trialId}`);
+    await interaction.editReply({ content: 'Trial extended by 1 week.' });
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    await interaction.editReply({ content: `Failed to extend trial: ${error.message}` });
+  }
+}
+```
+
+New `markPromote`:
+
+```ts
+async function markPromote(interaction: ButtonInteraction, params: string[]): Promise<void> {
+  const trialId = parseInt(params[0], 10);
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+  const trial = getDatabase().prepare('SELECT * FROM trials WHERE id = ?').get(trialId) as
+    | TrialRow
+    | undefined;
+
+  try {
+    await markForPromotion(interaction.client, trialId);
+    await audit(
+      interaction.user,
+      'marked trial for promotion',
+      trial ? trialRef(trial) : `#${trialId}`,
+    );
+    await interaction.editReply({ content: 'Trial marked for promotion.' });
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    await interaction.editReply({ content: `Failed: ${error.message}` });
+  }
+}
+```
+
+New `close`:
+
+```ts
+async function close(interaction: ButtonInteraction, params: string[]): Promise<void> {
+  const trialId = parseInt(params[0], 10);
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+  const trial = getDatabase().prepare('SELECT * FROM trials WHERE id = ?').get(trialId) as
+    | TrialRow
+    | undefined;
+
+  try {
+    await closeTrial(interaction.client, trialId);
+    await audit(interaction.user, 'closed trial', trial ? trialRef(trial) : `#${trialId}`);
+    await interaction.editReply({ content: 'Trial closed.' });
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    await interaction.editReply({ content: `Failed to close trial: ${error.message}` });
+  }
+}
+```
+
+- [ ] **Step 3: Update `modalCreate` and `modalUpdate` in `src/interactions/trial.ts`**
+
+In `modalCreate`, replace the audit line:
+
+```ts
+    await audit(interaction.user, 'created trial', `${characterName} as ${role} (#${trial.id})`);
+```
+
+with (name bold, role backticked, thread link when present):
+
+```ts
+    const createdDetail = `**${characterName}** (#${trial.id}) as \`${role}\`${
+      trial.thread_id ? ` — <#${trial.thread_id}>` : ''
+    }`;
+    await audit(interaction.user, 'created trial', createdDetail);
+```
+
+In `modalUpdate`, replace the audit call:
+
+```ts
+    await audit(
+      interaction.user,
+      'updated trial info via modal',
+      `${trial.character_name} (#${trialId})`,
+    );
+```
+
+with:
+
+```ts
+    await audit(interaction.user, 'updated trial info via modal', trialRef(trial));
+```
+
+- [ ] **Step 4: Update `src/commands/trials.ts`**
+
+Add the import after the existing `audit` import:
+
+```ts
+import { trialRef, dateRef } from '../services/auditRefs.js';
+```
+
+In the `remove_trial` case, replace:
+
+```ts
+          await audit(interaction.user, 'closed trial', `${trial.character_name} (#${trial.id})`);
+```
+
+with:
+
+```ts
+          await audit(interaction.user, 'closed trial', trialRef(trial));
+```
+
+In the `change_trial_info` case, replace the changes-list build and audit call:
+
+```ts
+          const changes = [];
+          if (characterName) changes.push(`name=${characterName}`);
+          if (role) changes.push(`role=${role}`);
+          if (startDate) changes.push(`start_date=${startDate}`);
+
+          await audit(
+            interaction.user,
+            'updated trial info',
+            `${trial.character_name} (#${trial.id}): ${changes.join(', ')}`,
+          );
+```
+
+with (role backticked, date as timestamp, prefix via `trialRef`):
+
+```ts
+          const changes = [];
+          if (characterName) changes.push(`name=${characterName}`);
+          if (role) changes.push(`role=\`${role}\``);
+          if (startDate) changes.push(`start_date=${dateRef(startDate)}`);
+
+          await audit(
+            interaction.user,
+            'updated trial info',
+            `${trialRef(trial)}: ${changes.join(', ')}`,
+          );
+```
+
+- [ ] **Step 5: Typecheck, lint, and run the suite**
+
+Run: `npm run typecheck && npm run lint && npm test`
+Expected: typecheck clean, lint clean, all existing tests PASS (no regressions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/interactions/trial.ts src/commands/trials.ts
+git commit -m "feat(audit): enrich trial audit logs with name, thread link, and dates"
+```
+
+---
+
+### Task 4: Enrich application audit call sites
+
+**Files:**
+- Modify: `src/functions/applications/rejectApplication.ts:201`
+- Modify: `src/functions/applications/acceptApplication.ts:244-248`
+
+**Interfaces:**
+- Consumes: `applicationRef`, `dateRef` from `src/services/auditRefs.js`.
+- Produces: no new exports.
+
+- [ ] **Step 1: Update `rejectApplication.ts`**
+
+Add the import after the existing `audit` import:
+
+```ts
+import { applicationRef } from '../../services/auditRefs.js';
+```
+
+Replace the audit call:
+
+```ts
+  // Audit log
+  await audit(interaction.user, 'rejected application', characterName);
+```
+
+with:
+
+```ts
+  // Audit log
+  await audit(interaction.user, 'rejected application', applicationRef(application));
+```
+
+(`application` is the DB row fetched at the top of `processRejectModal`; its `character_name` may be null, in which case `applicationRef` shows `Unknown` — matching the existing `characterName` fallback.)
+
+- [ ] **Step 2: Update `acceptApplication.ts`**
+
+Add the import after the existing `audit` import:
+
+```ts
+import { applicationRef, dateRef } from '../../services/auditRefs.js';
+```
+
+Replace the audit call:
+
+```ts
+  // Audit log
+  await audit(
+    interaction.user,
+    'accepted application',
+    `${characterName} as ${role} starting ${startDate}`,
+  );
+```
+
+with (using the modal-entered `characterName`, applicant/post from the row, backticked role, timestamped date):
+
+```ts
+  // Audit log
+  const acceptRef = applicationRef({
+    character_name: characterName,
+    applicant_user_id: application.applicant_user_id,
+    thread_id: application.thread_id,
+    forum_post_id: application.forum_post_id,
+  });
+  await audit(
+    interaction.user,
+    'accepted application',
+    `${acceptRef} as \`${role}\` starting ${dateRef(startDate)}`,
+  );
+```
+
+- [ ] **Step 3: Typecheck, lint, and run the suite**
+
+Run: `npm run typecheck && npm run lint && npm test`
+Expected: typecheck clean, lint clean, all existing tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/functions/applications/rejectApplication.ts src/functions/applications/acceptApplication.ts
+git commit -m "feat(audit): link applicant and post in application audit logs"
+```
+
+---
+
+### Task 5: Enrich raider/overlord audit call sites
+
+**Files:**
+- Modify: `src/commands/raiders.ts` (cases `update_raider_user`, `add_overlord`, `remove_overlord`)
+
+**Interfaces:**
+- Consumes: `getOverlords` (already imported in `raiders.ts`).
+- Produces: no new exports.
+
+- [ ] **Step 1: Update `update_raider_user` (linked raider)**
+
+Replace:
+
+```ts
+          await audit(interaction.user, 'linked raider', `${characterName} -> ${user.tag}`);
+```
+
+with (clickable, non-pinging user link):
+
+```ts
+          await audit(interaction.user, 'linked raider', `${characterName} → <@${user.id}>`);
+```
+
+- [ ] **Step 2: Update `add_overlord`**
+
+Replace:
+
+```ts
+          await audit(interaction.user, 'added overlord', `${name} (${user.tag})`);
+```
+
+with:
+
+```ts
+          await audit(interaction.user, 'added overlord', `${name} (<@${user.id}>)`);
+```
+
+- [ ] **Step 3: Update `remove_overlord` to look up the user id before removal**
+
+Replace:
+
+```ts
+        try {
+          removeOverlord(name);
+          await audit(interaction.user, 'removed overlord', name);
+```
+
+with (capture the overlord's user id before it is deleted so the log can link it):
+
+```ts
+        try {
+          const overlord = getOverlords().find((o) => o.name === name);
+          removeOverlord(name);
+          await audit(
+            interaction.user,
+            'removed overlord',
+            overlord ? `${name} (<@${overlord.user_id}>)` : name,
+          );
+```
+
+- [ ] **Step 4: Typecheck, lint, and run the suite**
+
+Run: `npm run typecheck && npm run lint && npm test`
+Expected: typecheck clean, lint clean, all existing tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/raiders.ts
+git commit -m "feat(audit): link users in raider-link and overlord audit logs"
+```
+
+---
+
+## Final verification
+
+- [ ] **Full suite green:** `npm run typecheck && npm run lint && npm test` — all clean.
+- [ ] **Behavioural check:** Use the `verify` skill (or the test bot on `develop`) to exercise a trial close via the review-thread button and an application rejection, confirming the audit channel now shows the character name, a clickable user/post link, and that **no ping notification** fires. (Note from project memory: pushing to `develop` restarts the test bot and kills in-flight commands — don't push mid-run.)
+
+## Notes on scope (left unchanged, per spec)
+
+- Ignored-character logs (`raiders.ts` ignore/remove-ignore, `raider.ts` ignore) — name only; nothing to link.
+- `raider.ts` `confirmLink` / `selectUser` already emit `<@userId>`; they gain non-pinging behaviour for free via Task 2.
+- Config-type actions (log level, settings, setup, guildinfo, migrate) — already self-explanatory.

--- a/docs/superpowers/specs/2026-07-19-detailed-audit-logs-design.md
+++ b/docs/superpowers/specs/2026-07-19-detailed-audit-logs-design.md
@@ -1,0 +1,107 @@
+# Detailed bot-audit log messages — Design
+
+**Date:** 2026-07-19
+**Status:** Approved
+
+## Problem
+
+`audit(officer, action, detail)` (`src/services/auditLog.ts`) renders
+`**{officer}** {action}: {detail}` and sends it to the audit channel with no
+`allowedMentions`. Several entity-related call sites pass a thin `detail`, so the
+log fails to say *who* the action was about or link to the relevant user/post:
+
+- Closing a trial via the review-thread button logs only `#3` — no character name.
+  (The command path already logs the character name, so button vs. command is
+  inconsistent.)
+- Rejecting an application logs only the bare character name — no link to the
+  applicant or the forum post.
+
+## Goals
+
+- Entity actions (trials, applications, raider links, overlords) log a
+  human-readable identifier plus clickable links to the Discord user and the
+  related post/thread where the data exists.
+- Links must **not** ping anyone — `<@id>` should render as a clickable name chip
+  without sending a notification.
+
+## Non-goals
+
+- Config-type actions (log level, settings toggles, channel/role setup, guild
+  info refresh, V1 migration) stay as-is — already self-explanatory.
+- Ignored-character logs stay name-only — there is no Discord user or post to
+  link to.
+
+## Design
+
+### 1. Suppress pings in `audit()`
+
+Add `allowedMentions: { parse: [] }` to the `auditChannel.send(...)` call in
+`audit()`. `<@id>` still renders as a clickable name chip but never notifies, so
+overlords and applicants are linked, not pinged. `alertOfficers()` is untouched —
+it keeps its intentional officer-role ping via its own `allowedMentions`.
+
+### 2. New pure formatter module `src/services/auditRefs.ts`
+
+Pure functions, no Discord/DB dependencies, unit-testable in isolation:
+
+- `trialRef(trial)` → `**{character_name}** (#{id})`, appending
+  ` — <#{thread_id}>` when `thread_id` is set.
+- `applicationRef(app)` → `**{character_name}** (<@{applicant_user_id}>)`,
+  appending ` — <#{forum_post_id ?? thread_id}>` when present. Falls back to
+  `Unknown` when `character_name` is null.
+- `dateRef(date)` → renders a `YYYY-MM-DD` string as a Discord long-date
+  timestamp `<t:{unix}:D>` (static full date, localised to each viewer — e.g.
+  "20 April 2026"; **not** the dynamic relative `:R` style). Falls back to the
+  raw string if `Date.parse` yields `NaN`.
+
+Types are accepted as `Pick<...>` of the relevant row so callers can pass either a
+DB row or an ad-hoc object (accept flow constructs the character name locally).
+
+### 3. Enriched call sites (entity actions only)
+
+| Site | Before | After |
+|---|---|---|
+| `interactions/trial.ts` extend / markPromote / close | `#{id}` | fetch row → `trialRef(trial)` |
+| `interactions/trial.ts` modalUpdate | `Name (#id)` | `trialRef(trial)` |
+| `interactions/trial.ts` modalCreate | `Name as Role (#id)` | `` **Name** (#id) as `Role` — <#thread> `` |
+| `commands/trials.ts` remove_trial | `Name (#id)` | `trialRef(trial)` |
+| `commands/trials.ts` change_trial_info | `Name (#id): name=…, role=…, start_date=…` | `` trialRef(trial): name=…, role=`…`, start_date=<t:…:D> `` |
+| `functions/applications/rejectApplication.ts` | `characterName` | `applicationRef(application)` |
+| `functions/applications/acceptApplication.ts` | `Name as Role starting Date` | `` applicationRef(app) as `Role` starting <t:…:D> `` |
+| `commands/raiders.ts` linked raider | `Name -> user.tag` | `Name → <@userId>` |
+| `commands/raiders.ts` add_overlord | `Name (user.tag)` | `Name (<@userId>)` |
+| `commands/raiders.ts` remove_overlord | `Name` | `Name (<@userId>)` — look up `user_id` before removal |
+
+The three `trial.ts` button handlers (extend / markPromote / close) currently hold
+only `trialId`, so each gains a small `SELECT * FROM trials WHERE id = ?` fetch of
+the row (mirroring the existing `updateInfo` handler) to obtain `character_name`
+and `thread_id`.
+
+### Left unchanged
+
+- Ignored-character logs (`raiders.ts` ignore/remove_ignore, `raider.ts` ignore)
+  — name only; nothing to link.
+- `raider.ts` confirmLink / selectUser — already use `<@userId>`; they now benefit
+  from the ping suppression in (1) for free.
+- All config-type actions.
+
+### Example results
+
+```
+Splo closed trial: **Sploboss** (#3) — <#123456789>
+Splo rejected application: **Sploboss** (<@456…>) — <#789…>
+Splo accepted application: **Sploboss** (<@456…>) as `Healer` starting <t:1776…:D>
+```
+
+## Testing
+
+TDD:
+
+- New `tests/unit/auditRefs.test.ts`:
+  - `trialRef` with and without `thread_id`.
+  - `applicationRef` with `forum_post_id`, with only `thread_id`, with neither,
+    and with null `character_name`.
+  - `dateRef` for a valid `YYYY-MM-DD` (asserts `<t:UNIX:D>` with correct unix
+    seconds) and an unparseable string (returns input unchanged).
+- Extend an audit-send test to assert `audit()` calls `send` with
+  `allowedMentions: { parse: [] }`.

--- a/src/commands/raiders.ts
+++ b/src/commands/raiders.ts
@@ -274,7 +274,7 @@ export default {
         const success = await updateRaiderDiscordUser(interaction.client, characterName, user.id);
 
         if (success) {
-          await audit(interaction.user, 'linked raider', `${characterName} -> ${user.tag}`);
+          await audit(interaction.user, 'linked raider', `${characterName} → <@${user.id}>`);
           await interaction.reply({
             content: `Linked **${characterName}** to ${user}.`,
             flags: MessageFlags.Ephemeral,
@@ -349,7 +349,7 @@ export default {
 
         try {
           addOverlord(name, user.id);
-          await audit(interaction.user, 'added overlord', `${name} (${user.tag})`);
+          await audit(interaction.user, 'added overlord', `${name} (<@${user.id}>)`);
           await interaction.reply({
             content: `Added overlord **${name}** (${user}).`,
             flags: MessageFlags.Ephemeral,
@@ -381,8 +381,13 @@ export default {
         const name = interaction.options.getString('name', true);
 
         try {
+          const overlord = getOverlords().find((o) => o.name === name);
           removeOverlord(name);
-          await audit(interaction.user, 'removed overlord', name);
+          await audit(
+            interaction.user,
+            'removed overlord',
+            overlord ? `${name} (<@${overlord.user_id}>)` : name,
+          );
           await interaction.reply({
             content: `Removed overlord **${name}**.`,
             flags: MessageFlags.Ephemeral,

--- a/src/commands/trials.ts
+++ b/src/commands/trials.ts
@@ -11,6 +11,7 @@ import {
 import { getDatabase } from '../database/db.js';
 import { requireOfficer } from '../utils.js';
 import { audit } from '../services/auditLog.js';
+import { trialRef, dateRef } from '../services/auditRefs.js';
 import { logger } from '../services/logger.js';
 import {
   paginateLines,
@@ -179,7 +180,7 @@ export default {
 
         try {
           await closeTrial(interaction.client, trial.id);
-          await audit(interaction.user, 'closed trial', `${trial.character_name} (#${trial.id})`);
+          await audit(interaction.user, 'closed trial', trialRef(trial));
           await interaction.editReply({
             content: `Closed trial for **${trial.character_name}**.`,
           });
@@ -237,13 +238,13 @@ export default {
 
           const changes = [];
           if (characterName) changes.push(`name=${characterName}`);
-          if (role) changes.push(`role=${role}`);
-          if (startDate) changes.push(`start_date=${startDate}`);
+          if (role) changes.push(`role=\`${role}\``);
+          if (startDate) changes.push(`start_date=${dateRef(startDate)}`);
 
           await audit(
             interaction.user,
             'updated trial info',
-            `${trial.character_name} (#${trial.id}): ${changes.join(', ')}`,
+            `${trialRef(trial)}: ${changes.join(', ')}`,
           );
 
           await interaction.editReply({ content: 'Trial info updated.' });

--- a/src/functions/applications/acceptApplication.ts
+++ b/src/functions/applications/acceptApplication.ts
@@ -16,6 +16,7 @@ import { getDatabase } from '../../database/db.js';
 import { config } from '../../config.js';
 import { logger } from '../../services/logger.js';
 import { audit } from '../../services/auditLog.js';
+import { applicationRef, dateRef } from '../../services/auditRefs.js';
 import { generateTranscript } from './generateTranscript.js';
 import { closeThread } from '../threads.js';
 import { createTrialReviewThread } from '../trial-review/createTrialReviewThread.js';
@@ -241,10 +242,16 @@ export async function processAcceptModal(interaction: ModalSubmitInteraction): P
   ).run(characterName, applicationId);
 
   // Audit log
+  const acceptRef = applicationRef({
+    character_name: characterName,
+    applicant_user_id: application.applicant_user_id,
+    thread_id: application.thread_id,
+    forum_post_id: application.forum_post_id,
+  });
   await audit(
     interaction.user,
     'accepted application',
-    `${characterName} as ${role} starting ${startDate}`,
+    `${acceptRef} as \`${role}\` starting ${dateRef(startDate)}`,
   );
 
   // Give the accepted applicant the Raider role (best-effort; never fails accept)

--- a/src/functions/applications/overlordNotification.ts
+++ b/src/functions/applications/overlordNotification.ts
@@ -1,0 +1,20 @@
+import type { MessageCreateOptions } from 'discord.js';
+
+/**
+ * Build the "new application" notification sent to overlords.
+ *
+ * The character name is applicant-supplied, so `allowedMentions` is locked to
+ * the explicit overlord user ids: a crafted name like `@everyone` renders as
+ * literal text and cannot trigger a real ping.
+ */
+export function buildOverlordNotification(
+  overlordIds: string[],
+  characterName: string,
+  applicantTag: string,
+): MessageCreateOptions {
+  const mentions = overlordIds.map((id) => `<@${id}>`).join(' ');
+  return {
+    content: `${mentions}\nNew application from **${characterName}** (${applicantTag}). Please review!`,
+    allowedMentions: { users: overlordIds },
+  };
+}

--- a/src/functions/applications/rejectApplication.ts
+++ b/src/functions/applications/rejectApplication.ts
@@ -16,6 +16,7 @@ import { getDatabase } from '../../database/db.js';
 import { config } from '../../config.js';
 import { logger } from '../../services/logger.js';
 import { audit } from '../../services/auditLog.js';
+import { applicationRef } from '../../services/auditRefs.js';
 import { generateTranscript } from './generateTranscript.js';
 import { closeThread } from '../threads.js';
 import type { ApplicationRow, DefaultMessageRow } from '../../types/index.js';
@@ -198,7 +199,7 @@ export async function processRejectModal(interaction: ModalSubmitInteraction): P
   ).run(applicationId);
 
   // Audit log
-  await audit(interaction.user, 'rejected application', characterName);
+  await audit(interaction.user, 'rejected application', applicationRef(application));
 
   logger.info('Applications', `Application #${applicationId} rejected: ${characterName}`);
 

--- a/src/functions/applications/submitApplication.ts
+++ b/src/functions/applications/submitApplication.ts
@@ -17,6 +17,7 @@ import { buildQAText } from './buildQAText.js';
 import { deriveCharacterNameFromAnswers } from './raiderIoName.js';
 import { linkCharacterIdentity } from '../raids/linkCharacterIdentity.js';
 import { getOverlords } from '../raids/overlords.js';
+import { buildOverlordNotification } from './overlordNotification.js';
 import type { ApplicationRow } from '../../types/index.js';
 
 interface AnswerWithQuestion {
@@ -295,6 +296,9 @@ async function notifyOverlords(
   const overlords = getOverlords();
   if (overlords.length === 0) return;
 
+  const overlordIds = overlords.map((o) => o.user_id);
+  const notification = buildOverlordNotification(overlordIds, characterName, applicant.tag);
+
   const thread = guild.channels.cache.get(threadId);
   if (!thread || !thread.isThread()) {
     // Try to fetch it
@@ -302,18 +306,12 @@ async function notifyOverlords(
       const fetchedThread = await guild.channels.fetch(threadId);
       if (!fetchedThread || !fetchedThread.isThread()) return;
 
-      const mentions = overlords.map((o) => `<@${o.user_id}>`).join(' ');
-      await fetchedThread.send(
-        `${mentions}\nNew application from **${characterName}** (${applicant.tag}). Please review!`,
-      );
+      await fetchedThread.send(notification);
     } catch {
       logger.warn('Applications', `Failed to notify overlords in thread ${threadId}`);
     }
     return;
   }
 
-  const mentions = overlords.map((o) => `<@${o.user_id}>`).join(' ');
-  await (thread as unknown as TextChannel).send(
-    `${mentions}\nNew application from **${characterName}** (${applicant.tag}). Please review!`,
-  );
+  await (thread as unknown as TextChannel).send(notification);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { initDatabase, closeDatabase } from './database/db.js';
 import { initLogger, logger } from './services/logger.js';
 import { scheduler } from './events/ready.js';
 import { loadCommands } from './loadCommands.js';
+import { registerProcessErrorHandlers } from './processErrorHandlers.js';
 import { readdirSync } from 'fs';
 import { pathToFileURL } from 'url';
 import { join, dirname } from 'path';
@@ -15,6 +16,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // ─── Initialize ──────────────────────────────────────────────
 
 initLogger(config.logLevel);
+registerProcessErrorHandlers();
 logger.info('bot', 'Starting SeriouslyCasualBot...');
 
 initDatabase();
@@ -76,4 +78,10 @@ process.on('SIGINT', shutdown);
 
 // ─── Login ───────────────────────────────────────────────────
 
-await client.login(config.discordToken);
+try {
+  await client.login(config.discordToken);
+} catch (error) {
+  const err = error instanceof Error ? error : new Error(String(error));
+  logger.error('bot', `Failed to log in to Discord: ${err.message}`, err);
+  process.exit(1);
+}

--- a/src/interactions/raider.ts
+++ b/src/interactions/raider.ts
@@ -16,7 +16,7 @@ async function confirmLink(interaction: ButtonInteraction, params: string[]): Pr
   const success = await updateRaiderDiscordUser(interaction.client, characterName, userId);
 
   if (success) {
-    await audit(interaction.user, 'confirmed raider link', `${characterName} -> <@${userId}>`);
+    await audit(interaction.user, 'confirmed raider link', `${characterName} → <@${userId}>`);
 
     // updateRaiderDiscordUser already deletes the linking message; delete here
     // too as a no-op safety net. The confirmation itself is ephemeral so the
@@ -97,7 +97,7 @@ async function selectUser(interaction: UserSelectMenuInteraction, params: string
     await audit(
       interaction.user,
       'linked raider via select',
-      `${characterName} -> <@${selectedUserId}>`,
+      `${characterName} → <@${selectedUserId}>`,
     );
 
     try {

--- a/src/interactions/trial.ts
+++ b/src/interactions/trial.ts
@@ -9,6 +9,7 @@ import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
 import type { ButtonHandler, ModalHandler } from './registry.js';
 import { getDatabase } from '../database/db.js';
 import { audit } from '../services/auditLog.js';
+import { trialRef } from '../services/auditRefs.js';
 import { logger } from '../services/logger.js';
 import { extendTrial } from '../functions/trial-review/extendTrial.js';
 import { markForPromotion } from '../functions/trial-review/markForPromotion.js';
@@ -67,9 +68,13 @@ async function extend(interaction: ButtonInteraction, params: string[]): Promise
   const trialId = parseInt(params[0], 10);
   await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
+  const trial = getDatabase().prepare('SELECT * FROM trials WHERE id = ?').get(trialId) as
+    | TrialRow
+    | undefined;
+
   try {
     await extendTrial(interaction.client, trialId);
-    await audit(interaction.user, 'extended trial', `#${trialId}`);
+    await audit(interaction.user, 'extended trial', trial ? trialRef(trial) : `#${trialId}`);
     await interaction.editReply({ content: 'Trial extended by 1 week.' });
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
@@ -81,9 +86,17 @@ async function markPromote(interaction: ButtonInteraction, params: string[]): Pr
   const trialId = parseInt(params[0], 10);
   await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
+  const trial = getDatabase().prepare('SELECT * FROM trials WHERE id = ?').get(trialId) as
+    | TrialRow
+    | undefined;
+
   try {
     await markForPromotion(interaction.client, trialId);
-    await audit(interaction.user, 'marked trial for promotion', `#${trialId}`);
+    await audit(
+      interaction.user,
+      'marked trial for promotion',
+      trial ? trialRef(trial) : `#${trialId}`,
+    );
     await interaction.editReply({ content: 'Trial marked for promotion.' });
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
@@ -95,9 +108,13 @@ async function close(interaction: ButtonInteraction, params: string[]): Promise<
   const trialId = parseInt(params[0], 10);
   await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
+  const trial = getDatabase().prepare('SELECT * FROM trials WHERE id = ?').get(trialId) as
+    | TrialRow
+    | undefined;
+
   try {
     await closeTrial(interaction.client, trialId);
-    await audit(interaction.user, 'closed trial', `#${trialId}`);
+    await audit(interaction.user, 'closed trial', trial ? trialRef(trial) : `#${trialId}`);
     await interaction.editReply({ content: 'Trial closed.' });
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
@@ -126,7 +143,10 @@ async function modalCreate(interaction: ModalSubmitInteraction, _params: string[
       role,
       startDate,
     });
-    await audit(interaction.user, 'created trial', `${characterName} as ${role} (#${trial.id})`);
+    const createdDetail = `**${characterName}** (#${trial.id}) as \`${role}\`${
+      trial.thread_id ? ` — <#${trial.thread_id}>` : ''
+    }`;
+    await audit(interaction.user, 'created trial', createdDetail);
     await interaction.editReply({
       content: `Trial created for **${characterName}**. Thread: <#${trial.thread_id}>`,
     });
@@ -175,11 +195,7 @@ async function modalUpdate(interaction: ModalSubmitInteraction, params: string[]
     }
 
     await changeTrialInfo(interaction.client, trialId, updates);
-    await audit(
-      interaction.user,
-      'updated trial info via modal',
-      `${trial.character_name} (#${trialId})`,
-    );
+    await audit(interaction.user, 'updated trial info via modal', trialRef(trial));
     await interaction.editReply({ content: 'Trial info updated.' });
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));

--- a/src/processErrorHandlers.ts
+++ b/src/processErrorHandlers.ts
@@ -1,0 +1,27 @@
+import { logger } from './services/logger.js';
+
+/** Minimal surface of `process` used for registering error handlers (injectable for tests). */
+export interface ProcessLike {
+  on(event: string, listener: (...args: unknown[]) => void): unknown;
+}
+
+/**
+ * Register last-resort handlers for otherwise-fatal errors.
+ *
+ * The bot leans heavily on fire-and-forget promises; without these handlers an
+ * escaped rejection or throw terminates the process silently with no log line.
+ * We log (rather than exit) to match the codebase's resilient, best-effort
+ * philosophy and to avoid restart loops — the diagnostic reaches the logs and,
+ * via the logger's Discord relay, the bot-logs channel.
+ */
+export function registerProcessErrorHandlers(proc: ProcessLike = process): void {
+  proc.on('unhandledRejection', (reason: unknown) => {
+    const err = reason instanceof Error ? reason : new Error(String(reason));
+    logger.error('process', `Unhandled promise rejection: ${err.message}`, err);
+  });
+
+  proc.on('uncaughtException', (error: unknown) => {
+    const err = error instanceof Error ? error : new Error(String(error));
+    logger.error('process', `Uncaught exception: ${err.message}`, err);
+  });
+}

--- a/src/services/auditLog.ts
+++ b/src/services/auditLog.ts
@@ -15,7 +15,7 @@ export async function audit(officer: User, action: string, detail: string): Prom
   if (!auditChannel) return;
 
   try {
-    await auditChannel.send({ content: message });
+    await auditChannel.send({ content: message, allowedMentions: { parse: [] } });
   } catch {
     logger.error('audit', 'Failed to send audit log to Discord');
   }

--- a/src/services/auditRefs.ts
+++ b/src/services/auditRefs.ts
@@ -1,0 +1,30 @@
+import type { TrialRow, ApplicationRow } from '../types/index.js';
+
+/** `**Name** (#id)`, plus ` — <#thread_id>` when the review thread exists. */
+export function trialRef(trial: Pick<TrialRow, 'character_name' | 'id' | 'thread_id'>): string {
+  const base = `**${trial.character_name}** (#${trial.id})`;
+  return trial.thread_id ? `${base} — <#${trial.thread_id}>` : base;
+}
+
+/**
+ * `**Name** (<@applicant>)`, plus ` — <#post>` when a forum post/thread exists.
+ * Prefers `forum_post_id`, falling back to `thread_id`.
+ */
+export function applicationRef(
+  app: Pick<ApplicationRow, 'character_name' | 'applicant_user_id' | 'thread_id' | 'forum_post_id'>,
+): string {
+  const name = app.character_name ?? 'Unknown';
+  const base = `**${name}** (<@${app.applicant_user_id}>)`;
+  const postId = app.forum_post_id ?? app.thread_id;
+  return postId ? `${base} — <#${postId}>` : base;
+}
+
+/**
+ * Render a `YYYY-MM-DD` string as a Discord long-date timestamp (static full
+ * date, localised to each viewer). Falls back to the raw string if unparseable.
+ */
+export function dateRef(date: string): string {
+  const ms = Date.parse(date);
+  if (Number.isNaN(ms)) return date;
+  return `<t:${Math.floor(ms / 1000)}:D>`;
+}

--- a/tests/unit/auditLog.test.ts
+++ b/tests/unit/auditLog.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/config.js', () => ({ config: { officerRoleId: 'role-1' } }));
+vi.mock('../../src/services/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { audit, setAuditChannel } from '../../src/services/auditLog.js';
+
+describe('audit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends with mentions suppressed so linked users are not pinged', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    // Cast through unknown — the test channel only needs `send`.
+    setAuditChannel({ send } as unknown as Parameters<typeof setAuditChannel>[0]);
+
+    const officer = { displayName: 'Splo' } as Parameters<typeof audit>[0];
+    await audit(officer, 'rejected application', '**Sploboss** (<@456>)');
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const arg = send.mock.calls[0][0];
+    expect(arg.content).toBe('**Splo** rejected application: **Sploboss** (<@456>)');
+    expect(arg.allowedMentions).toEqual({ parse: [] });
+  });
+});

--- a/tests/unit/auditRefs.test.ts
+++ b/tests/unit/auditRefs.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { trialRef, applicationRef, dateRef } from '../../src/services/auditRefs.js';
+
+describe('trialRef', () => {
+  it('includes name, id, and a thread link when thread_id is set', () => {
+    expect(trialRef({ character_name: 'Sploboss', id: 3, thread_id: '123' })).toBe(
+      '**Sploboss** (#3) — <#123>',
+    );
+  });
+
+  it('omits the thread link when thread_id is null', () => {
+    expect(trialRef({ character_name: 'Sploboss', id: 3, thread_id: null })).toBe(
+      '**Sploboss** (#3)',
+    );
+  });
+});
+
+describe('applicationRef', () => {
+  it('links the applicant and prefers forum_post_id for the post link', () => {
+    expect(
+      applicationRef({
+        character_name: 'Sploboss',
+        applicant_user_id: '456',
+        thread_id: '999',
+        forum_post_id: '789',
+      }),
+    ).toBe('**Sploboss** (<@456>) — <#789>');
+  });
+
+  it('falls back to thread_id when forum_post_id is null', () => {
+    expect(
+      applicationRef({
+        character_name: 'Sploboss',
+        applicant_user_id: '456',
+        thread_id: '999',
+        forum_post_id: null,
+      }),
+    ).toBe('**Sploboss** (<@456>) — <#999>');
+  });
+
+  it('omits the post link when both post ids are null', () => {
+    expect(
+      applicationRef({
+        character_name: 'Sploboss',
+        applicant_user_id: '456',
+        thread_id: null,
+        forum_post_id: null,
+      }),
+    ).toBe('**Sploboss** (<@456>)');
+  });
+
+  it('shows Unknown when character_name is null', () => {
+    expect(
+      applicationRef({
+        character_name: null,
+        applicant_user_id: '456',
+        thread_id: null,
+        forum_post_id: null,
+      }),
+    ).toBe('**Unknown** (<@456>)');
+  });
+});
+
+describe('dateRef', () => {
+  it('renders a YYYY-MM-DD date as a long-date Discord timestamp', () => {
+    // 2026-04-20 UTC midnight = 1776643200 seconds
+    expect(dateRef('2026-04-20')).toBe('<t:1776643200:D>');
+  });
+
+  it('returns the raw string when the date is unparseable', () => {
+    expect(dateRef('not-a-date')).toBe('not-a-date');
+  });
+});

--- a/tests/unit/overlordNotification.test.ts
+++ b/tests/unit/overlordNotification.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { buildOverlordNotification } from '../../src/functions/applications/overlordNotification.js';
+
+describe('buildOverlordNotification', () => {
+  it('restricts allowed mentions to the overlord user ids only', () => {
+    const msg = buildOverlordNotification(['111', '222'], 'Thrall', 'thrall#0001');
+    expect(msg.allowedMentions).toEqual({ users: ['111', '222'] });
+  });
+
+  it('does not let an @everyone injected via the character name ping anyone', () => {
+    const msg = buildOverlordNotification(['111'], '@everyone', 'sneaky#0001');
+    // The literal text may appear in the content, but it must never resolve to a
+    // real mention: only the explicit overlord user ids are allowed.
+    expect(msg.allowedMentions).toEqual({ users: ['111'] });
+    expect(msg.allowedMentions).not.toHaveProperty('parse');
+    expect(msg.allowedMentions).not.toHaveProperty('roles');
+  });
+
+  it('mentions each overlord and names the applicant in the content', () => {
+    const msg = buildOverlordNotification(['111', '222'], 'Thrall', 'thrall#0001');
+    expect(msg.content).toContain('<@111>');
+    expect(msg.content).toContain('<@222>');
+    expect(msg.content).toContain('**Thrall**');
+    expect(msg.content).toContain('thrall#0001');
+  });
+});

--- a/tests/unit/processErrorHandlers.test.ts
+++ b/tests/unit/processErrorHandlers.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { registerProcessErrorHandlers } from '../../src/processErrorHandlers.js';
+import { logger } from '../../src/services/logger.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('registerProcessErrorHandlers', () => {
+  it('logs unhandled promise rejections via logger.error', () => {
+    const proc = new EventEmitter();
+    const spy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+    registerProcessErrorHandlers(proc);
+    proc.emit('unhandledRejection', new Error('boom'));
+
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0][0]).toBe('process');
+    expect(spy.mock.calls[0][1]).toContain('boom');
+  });
+
+  it('logs uncaught exceptions via logger.error', () => {
+    const proc = new EventEmitter();
+    const spy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+    registerProcessErrorHandlers(proc);
+    proc.emit('uncaughtException', new Error('kaboom'));
+
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0][0]).toBe('process');
+    expect(spy.mock.calls[0][1]).toContain('kaboom');
+  });
+
+  it('coerces a non-Error rejection reason into a logged message', () => {
+    const proc = new EventEmitter();
+    const spy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+    registerProcessErrorHandlers(proc);
+    proc.emit('unhandledRejection', 'just a string');
+
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0][1]).toContain('just a string');
+    // An Error object is passed through as the third argument for the stack trace.
+    expect(spy.mock.calls[0][2]).toBeInstanceOf(Error);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,13 @@ export default defineConfig({
       },
       {
         test: {
+          name: 'integration',
+          include: ['tests/integration/**/*.test.ts'],
+          environment: 'node',
+        },
+      },
+      {
+        test: {
           name: 'e2e',
           include: ['tests/e2e/**/*.e2e.ts'],
           environment: 'node',


### PR DESCRIPTION
Promotes the current `develop` (test) to `main` (prod).

## Primary feature — detailed bot-audit log messages
Entity-related audit-channel messages now carry a human-readable identifier plus clickable, **non-pinging** links to the Discord user and related post/thread.

- New pure formatters `src/services/auditRefs.ts` (`trialRef`, `applicationRef`, `dateRef`) with unit tests.
- `audit()` now sends with `allowedMentions: { parse: [] }` — `<@id>`/`<#id>` render as clickable chips but never notify. `alertOfficers()` keeps its intentional officer-role ping.
- Trial, application, and raider/overlord audit call sites enriched: character/name identity, user + post links, backticked roles, Discord long-date timestamps (`<t:…:D>`).

Spec: `docs/superpowers/specs/2026-07-19-detailed-audit-logs-design.md`
Plan: `docs/superpowers/plans/2026-07-19-detailed-audit-logs.md`

## Also included (pre-existing on develop, not yet on main)
- `ccbf3b8` fix(applications): prevent mention injection in overlord notification
- `fd39a34` fix: log otherwise-fatal process errors and guard login
- `0aab924` test: add integration vitest project
- `ec745da` docs: correct stale scheduler and architecture skill docs

## Verification
416/416 tests pass; typecheck + lint clean. Audit feature reviewed per-task and in a final whole-branch review (no Critical/Important findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)